### PR TITLE
Fix unnecessary rebuilds

### DIFF
--- a/tsc_compile_build/src/lib.rs
+++ b/tsc_compile_build/src/lib.rs
@@ -7,7 +7,6 @@ pub fn read(path: &str) -> &'static str {
     if let Some(suffix) = path.strip_prefix("/default/lib/location/") {
         macro_rules! inc_and_rerun {
             ( $e:expr ) => {{
-                println!("cargo:rerun-if-changed={}", $e);
                 include_str!($e)
             }};
         }


### PR DESCRIPTION
If a build.rs ever prints a cargo:rerun-if-changed= pointing to a non
existing file, cargo will rerun that build.rs.

This library is used from other directories, so the relative paths are
wrong, causing tsc_compile to always be rebuilt.

Since this code is using include_str!, the rerun-if-changed was at
most redundant anyway, so drop it.