### PR TITLE
Allow unary expression for default values

### DIFF
--- a/cli/src/ts.rs
+++ b/cli/src/ts.rs
@@ -97,6 +97,12 @@ fn get_field_value(handler: &Handler, x: &Option<Box<Expr>>) -> Result<Option<(S
                 let val_type = lit_name(k).into();
                 Ok(Some((val, val_type)))
             }
+            Expr::Unary(k) => {
+                let op = k.op;
+                let value = get_field_value(handler, &Some(k.arg.clone()))?
+                    .ok_or_else(|| swc_err(handler, k, "unexpected empty expression"))?;
+                Ok(Some((format!("{}{}", op, value.0), value.1)))
+            }
             x => Err(swc_err(handler, x, "expression not supported")),
         },
     }

--- a/cli/tests/lit/defaults.deno
+++ b/cli/tests/lit/defaults.deno
@@ -2,6 +2,24 @@
 
 # RUN: sh -e @file
 
+cd "$TEMPDIR"
+## check that unary expressions as defaults are valid
+cat << EOF > "$TEMPDIR/models/types.ts"
+export class Unary extends ChiselEntity { a: number = +1; b: number = 0; c: number = -1 ;}
+EOF
+$CHISEL apply
+
+# CHECK: Model defined: Unary
+
+$CHISEL restart
+$CHISEL describe
+
+# CHECK: class Unary {
+# CHECK: a: number = +1;
+# CHECK: b: number = 0;
+# CHECK: c: number = -1;
+# CHECK: }
+
 cat << EOF > "$TEMPDIR/models/types.ts"
 export class Foo extends Chisel.ChiselEntity {
 	a: string = "dfl1";
@@ -37,8 +55,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cd "$TEMPDIR"
-$CHISEL apply
+$CHISEL apply --allow-type-deletion
 
 $CURL -X POST $CHISELD_HOST/dev/default
 # CHECK: HTTP/1.1 200 OK


### PR DESCRIPTION
We forbid expressions for default values, but we should allow unary
expressions. The reason for that, is that things like "-1", that are
obviously very reasonable defaults, are unary expressions.

Fixes #1171