### PR TITLE
Add the endpoint_compile crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,8 +545,8 @@ name = "cli"
 version = "0.10.0-dev.0"
 dependencies = [
  "anyhow",
- "api",
  "compile",
+ "endpoint_tsc",
  "futures",
  "glob",
  "handlebars",
@@ -566,7 +566,6 @@ dependencies = [
  "toml",
  "tonic",
  "tonic-build",
- "tsc_compile",
  "vergen",
  "whoami",
 ]
@@ -1372,6 +1371,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "endpoint_tsc"
+version = "0.10.0-dev.0"
+dependencies = [
+ "anyhow",
+ "api",
+ "tempfile",
+ "tsc_compile",
 ]
 
 [[package]]
@@ -2645,9 +2654,9 @@ name = "my_tsc"
 version = "0.10.0-dev.0"
 dependencies = [
  "deno_runtime",
+ "endpoint_tsc",
  "structopt",
  "tokio",
- "tsc_compile",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-api = { path = "../api" }
 compile = { path = "../compile" }
+endpoint_tsc = { path = "../endpoint_tsc" }
 futures = "0.3.17"
 handlebars = "4.2.2"
 notify = "5.0.0-pre.12"
@@ -21,7 +21,6 @@ tempfile = "3.2.0"
 tokio = { version = "1.11.0", features = ["rt-multi-thread", "net", "fs"] }
 toml = "0.5.8"
 tonic = "0.5.2"
-tsc_compile = { path = "../tsc_compile" }
 
 [build-dependencies]
 anyhow = "1.0"

--- a/endpoint_tsc/Cargo.toml
+++ b/endpoint_tsc/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "endpoint_tsc"
+version = "0.10.0-dev.0"
+authors = ["ChiselStrike"]
+edition = "2021"
+
+[dependencies]
+tsc_compile = { path = "../tsc_compile" }
+anyhow = "1.0"
+api = { path = "../api" }
+tempfile = "3.2.0"
+
+[lib]
+name = "endpoint_tsc"

--- a/endpoint_tsc/src/chisel-global.d.ts
+++ b/endpoint_tsc/src/chisel-global.d.ts
@@ -1,0 +1,4 @@
+import * as ChiselAlias from "@chiselstrike/api";
+declare global {
+    let Chisel: typeof ChiselAlias;
+}

--- a/endpoint_tsc/src/lib.rs
+++ b/endpoint_tsc/src/lib.rs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
+
+use anyhow::Result;
+use std::collections::HashMap;
+use std::io::Write;
+use tempfile::Builder;
+use tempfile::NamedTempFile;
+use tsc_compile::CompileOptions;
+
+pub struct Compiler {
+    pub tsc: tsc_compile::Compiler,
+}
+
+impl Compiler {
+    pub fn new(use_snapshot: bool) -> Compiler {
+        let tsc = tsc_compile::Compiler::new(use_snapshot);
+        Compiler { tsc }
+    }
+
+    pub async fn compile_endpoint(&mut self, file_name: &str) -> Result<HashMap<String, String>> {
+        let mods: HashMap<String, String> = [(
+            "@chiselstrike/api".to_string(),
+            api::chisel_d_ts().to_string(),
+        )]
+        .into_iter()
+        .collect();
+        let chisel_global = include_str!("chisel-global.d.ts");
+        let temp = to_tempfile(chisel_global, ".d.ts")?;
+
+        let opts = CompileOptions {
+            extra_default_lib: Some(temp.path().to_str().unwrap()),
+            extra_libs: mods,
+            ..Default::default()
+        };
+
+        self.tsc.compile_ts_code(file_name, opts).await
+    }
+}
+
+fn to_tempfile(data: &str, suffix: &str) -> Result<NamedTempFile> {
+    let mut f = Builder::new().suffix(suffix).tempfile()?;
+    let inner = f.as_file_mut();
+    inner.write_all(data.as_bytes())?;
+    inner.flush()?;
+    Ok(f)
+}
+
+pub async fn compile_endpoint(file_name: &str) -> Result<HashMap<String, String>> {
+    let mut compiler = Compiler::new(true);
+    compiler.compile_endpoint(file_name).await
+}

--- a/my_tsc/Cargo.toml
+++ b/my_tsc/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 
 [dependencies]
 deno_runtime = { path = "../third_party/deno/runtime" }
+endpoint_tsc = { path = "../endpoint_tsc" }
 structopt = "0.3.23"
 tokio = "1.11.0"
-tsc_compile = { path = "../tsc_compile" }
 
 [[bin]]
 name = "my_tsc"

--- a/my_tsc/src/main.rs
+++ b/my_tsc/src/main.rs
@@ -1,7 +1,7 @@
 use deno_runtime::inspector_server::InspectorServer;
+use endpoint_tsc::Compiler;
 use std::net::SocketAddr;
 use structopt::StructOpt;
-use tsc_compile::Compiler;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
@@ -20,16 +20,14 @@ async fn main() {
     if opt.inspect {
         let addr: SocketAddr = "127.0.0.1:9229".parse().unwrap();
         let inspector = InspectorServer::new(addr, "my_tsc".to_string());
-        inspector.register_inspector("main_module".to_string(), &mut compiler.runtime, true);
+        inspector.register_inspector("main_module".to_string(), &mut compiler.tsc.runtime, true);
         _maybe_inspector = Some(inspector);
         compiler
+            .tsc
             .runtime
             .inspector()
             .wait_for_session_and_break_on_next_statement();
     }
 
-    compiler
-        .compile_ts_code(&opt.file, Default::default())
-        .await
-        .unwrap();
+    compiler.compile_endpoint(&opt.file).await.unwrap();
 }


### PR DESCRIPTION
This small crate refactors the special logic for compiling endpoints,
as opposed to plain ts files, to a new crate. This cannot be part of
tsc_compile sice tsc_compile is used to compile api which is used by
the endpoints.

With this my_tsc complies endpoints the same way that "chisel apply"
does.