### PR TITLE
query.rs: Fix from_ops(...) docstring.

### DIFF
--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -270,7 +270,7 @@ impl QueryPlan {
         Ok(builder)
     }
 
-    /// Constructs QueryPlan from `entity_name` and application of given
+    /// Constructs QueryPlan from type `ty` and application of given
     /// `operators.
     pub(crate) fn from_ops(
         c: &RequestContext,


### PR DESCRIPTION
Just fixing a docstring