### PR TITLE
Make without_extension more specific

### DIFF
--- a/tsc_compile/src/lib.rs
+++ b/tsc_compile/src/lib.rs
@@ -234,7 +234,12 @@ fn abs(path: &str) -> String {
 }
 
 fn without_extension(path: &str) -> &str {
-    path.rsplit_once('.').map_or(path, |p| p.0)
+    for suffix in [".d.ts", ".ts", ".js"] {
+        if let Some(s) = path.strip_suffix(suffix) {
+            return s;
+        }
+    }
+    path
 }
 
 static SNAPSHOT: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/SNAPSHOT.bin"));


### PR DESCRIPTION
We really just want to remove the JS/TS extensions. In the current
code base both implementations work, but this change makes
without_extension more reliable. For example, given
https://cdn.skypack.dev/handlebars, it used to return
https://cdn.skypack, now it returns the original url.