### PR TITLE
Make chiselc transform find{Many,One} calls

### DIFF
--- a/chiselc/src/query.rs
+++ b/chiselc/src/query.rs
@@ -77,6 +77,8 @@ pub struct Scan {
 /// Filter operator.
 #[derive(Debug)]
 pub struct Filter {
+    /// The ChiselStrike internal function to call.
+    pub function: String,
     /// The parameters to this filter.
     pub parameters: Vec<String>,
     /// The predicate expression to filter by.

--- a/chiselc/src/rewrite.rs
+++ b/chiselc/src/rewrite.rs
@@ -10,6 +10,7 @@ use crate::query::Operator;
 use crate::query::PropertyAccessExpr;
 use crate::symbols::Symbols;
 use crate::transforms::filter::infer_filter;
+use crate::transforms::find::infer_find;
 use std::str::FromStr;
 use swc_ecmascript::ast::ExportDefaultDecl;
 use swc_ecmascript::ast::FnExpr;
@@ -256,6 +257,13 @@ impl Rewriter {
 
     fn rewrite_call_expr(&mut self, call_expr: &CallExpr) -> CallExpr {
         let (filter, index) = infer_filter(call_expr, &self.symbols);
+        if let Some(index) = index {
+            self.indexes.push(index);
+        }
+        if let Some(filter) = filter {
+            return self.to_ts_expr(call_expr, &filter);
+        }
+        let (filter, index) = infer_find(call_expr, &self.symbols);
         if let Some(index) = index {
             self.indexes.push(index);
         }

--- a/chiselc/src/rewrite.rs
+++ b/chiselc/src/rewrite.rs
@@ -278,7 +278,7 @@ impl Rewriter {
     fn to_ts_expr(&self, call_expr: &CallExpr, filter: &Operator) -> CallExpr {
         match filter {
             Operator::Filter(filter) => {
-                let callee = self.rewrite_filter_callee(&call_expr.callee);
+                let callee = self.rewrite_filter_callee(&call_expr.callee, &filter.function);
                 let expr = self.filter_to_ts(filter, call_expr.span);
                 let expr = ExprOrSpread {
                     spread: None,
@@ -300,14 +300,14 @@ impl Rewriter {
     }
 
     /// Rewrites the filter() call with __filterWithExpression().
-    fn rewrite_filter_callee(&self, callee: &Callee) -> Callee {
+    fn rewrite_filter_callee(&self, callee: &Callee, function: &str) -> Callee {
         match callee {
             Callee::Expr(expr) => match &**expr {
                 Expr::Member(member_expr) => {
                     let mut member_expr = member_expr.clone();
                     let prop = MemberProp::Ident(Ident {
                         span: member_expr.span,
-                        sym: JsWord::from("__filterWithExpression"),
+                        sym: JsWord::from(function),
                         optional: false,
                     });
                     member_expr.prop = prop;

--- a/chiselc/src/transforms/filter.rs
+++ b/chiselc/src/transforms/filter.rs
@@ -1,20 +1,14 @@
 use crate::filtering::FilterProperties;
-use crate::query::BinaryExpr as QBinaryExpr;
-use crate::query::BinaryOp as QBinaryOp;
 use crate::query::Expr as QExpr;
 use crate::query::Filter as QFilter;
 use crate::query::Literal as QLiteral;
 use crate::query::Operator as QOperator;
-use crate::query::PropertyAccessExpr as QPropertyAccessExpr;
 use crate::query::Scan as QScan;
 use crate::symbols::Symbols;
+use crate::transforms::utils::{convert_bin_expr, lookup_callee_entity_type};
 use crate::utils::{is_call_to_entity_method, is_ident_member_prop, pat_to_string};
-use anyhow::{anyhow, Result};
 
-use swc_ecmascript::ast::{
-    BinExpr, BinaryOp, BlockStmtOrExpr, CallExpr, Callee, Expr, Ident, Lit, MemberExpr, MemberProp,
-    Stmt,
-};
+use swc_ecmascript::ast::{BlockStmtOrExpr, CallExpr, Callee, Expr, Lit, Stmt};
 
 /// Infer filter operator from the lambda predicate of to filter()
 pub fn infer_filter(
@@ -109,71 +103,4 @@ fn is_rewritable_filter(callee: &Callee, symbols: &Symbols) -> bool {
         },
         _ => false,
     }
-}
-
-fn lookup_callee_entity_type(callee: &Callee) -> Result<String> {
-    match callee {
-        Callee::Expr(expr) => lookup_entity_type(expr),
-        _ => {
-            todo!();
-        }
-    }
-}
-
-fn lookup_entity_type(expr: &Expr) -> Result<String> {
-    match expr {
-        Expr::Member(MemberExpr { obj, .. }) => lookup_entity_type(obj),
-        Expr::Call(CallExpr { callee, .. }) => lookup_callee_entity_type(callee),
-        Expr::Ident(Ident { sym, .. }) => Ok(sym.to_string()),
-        _ => {
-            anyhow::bail!("Failed to look up entity type from call chain")
-        }
-    }
-}
-
-fn convert_bin_expr(expr: &BinExpr) -> Result<QExpr> {
-    let left = Box::new(convert_expr(&expr.left)?);
-    let op = convert_binary_op(&expr.op)?;
-    let right = Box::new(convert_expr(&expr.right)?);
-    Ok(QExpr::BinaryExpr(QBinaryExpr { left, op, right }))
-}
-
-fn convert_expr(expr: &Expr) -> Result<QExpr> {
-    match expr {
-        Expr::Bin(bin_expr) => convert_bin_expr(bin_expr),
-        Expr::Paren(paren_expr) => Ok(convert_expr(&*paren_expr.expr)?),
-        Expr::Lit(Lit::Num(number)) => Ok(QExpr::Literal(QLiteral::Num(number.value))),
-        Expr::Lit(Lit::Str(s)) => Ok(QExpr::Literal(QLiteral::Str(format!("{}", s.value)))),
-        Expr::Member(member_expr) => {
-            let obj = convert_expr(&member_expr.obj)?;
-            let prop = match &member_expr.prop {
-                MemberProp::Ident(ident) => ident.sym.to_string(),
-                _ => {
-                    todo!();
-                }
-            };
-            Ok(QExpr::PropertyAccess(QPropertyAccessExpr {
-                object: Box::new(obj),
-                property: prop,
-            }))
-        }
-        Expr::Ident(ident) => Ok(QExpr::Identifier(ident.sym.to_string())),
-        _ => Err(anyhow!("Unsupported expression: {:#?}", expr)),
-    }
-}
-
-fn convert_binary_op(op: &BinaryOp) -> Result<QBinaryOp> {
-    Ok(match op {
-        BinaryOp::EqEq => QBinaryOp::Eq,
-        BinaryOp::Gt => QBinaryOp::Gt,
-        BinaryOp::GtEq => QBinaryOp::GtEq,
-        BinaryOp::Lt => QBinaryOp::Lt,
-        BinaryOp::LtEq => QBinaryOp::LtEq,
-        BinaryOp::NotEq => QBinaryOp::NotEq,
-        BinaryOp::LogicalAnd => QBinaryOp::And,
-        BinaryOp::LogicalOr => QBinaryOp::Or,
-        _ => {
-            anyhow::bail!("Cannot convert binary operator {}", op);
-        }
-    })
 }

--- a/chiselc/src/transforms/filter.rs
+++ b/chiselc/src/transforms/filter.rs
@@ -8,7 +8,7 @@ use crate::query::Operator as QOperator;
 use crate::query::PropertyAccessExpr as QPropertyAccessExpr;
 use crate::query::Scan as QScan;
 use crate::symbols::Symbols;
-use crate::utils::{is_call_to_entity_cursor, is_ident_member_prop, pat_to_string};
+use crate::utils::{is_call_to_entity_method, is_ident_member_prop, pat_to_string};
 use anyhow::{anyhow, Result};
 
 use swc_ecmascript::ast::{
@@ -98,7 +98,7 @@ fn is_rewritable_filter(callee: &Callee, symbols: &Symbols) -> bool {
         Callee::Expr(expr) => match &**expr {
             Expr::Member(member_expr) => {
                 is_ident_member_prop(&member_expr.prop, "filter")
-                    && is_call_to_entity_cursor(&member_expr.obj, symbols)
+                    && is_call_to_entity_method(&member_expr.obj, "cursor", symbols)
             }
             _ => false,
         },

--- a/chiselc/src/transforms/filter.rs
+++ b/chiselc/src/transforms/filter.rs
@@ -22,12 +22,13 @@ pub fn infer_filter(
         Ok(entity_type) => entity_type,
         _ => return (None, None),
     };
-    extract_filter(call_expr, entity_type)
+    extract_filter(call_expr, entity_type, "__filterWithExpression".to_string())
 }
 
 fn extract_filter(
     call_expr: &CallExpr,
     entity_type: String,
+    function: String,
 ) -> (Option<Box<QOperator>>, Option<FilterProperties>) {
     let args = &call_expr.args;
     assert_eq!(args.len(), 1);
@@ -83,7 +84,7 @@ fn extract_filter(
         Err(_) => return (None, None),
     };
     let filter = QFilter {
-        function: "__filterWithExpression".to_string(),
+        function,
         parameters: vec![param.clone()],
         input: Box::new(QOperator::Scan(QScan {
             entity_type: entity_type.clone(),

--- a/chiselc/src/transforms/filter.rs
+++ b/chiselc/src/transforms/filter.rs
@@ -97,7 +97,13 @@ fn is_rewritable_filter(callee: &Callee, symbols: &Symbols) -> bool {
     match callee {
         Callee::Expr(expr) => match &**expr {
             Expr::Member(member_expr) if is_ident_member_prop(&member_expr.prop, "filter") => {
-                is_call_to_entity_method(&member_expr.obj, "cursor", symbols)
+                match &*member_expr.obj {
+                    Expr::Call(call_expr) => match &call_expr.callee {
+                        Callee::Expr(expr) => is_call_to_entity_method(expr, "cursor", symbols),
+                        _ => false,
+                    },
+                    _ => false,
+                }
             }
             _ => false,
         },

--- a/chiselc/src/transforms/filter.rs
+++ b/chiselc/src/transforms/filter.rs
@@ -1,14 +1,10 @@
 use crate::filtering::FilterProperties;
-use crate::query::Expr as QExpr;
-use crate::query::Filter as QFilter;
-use crate::query::Literal as QLiteral;
 use crate::query::Operator as QOperator;
-use crate::query::Scan as QScan;
 use crate::symbols::Symbols;
-use crate::transforms::utils::{convert_bin_expr, lookup_callee_entity_type};
-use crate::utils::{is_call_to_entity_method, is_ident_member_prop, pat_to_string};
+use crate::transforms::utils::{extract_filter, lookup_callee_entity_type};
+use crate::utils::{is_call_to_entity_method, is_ident_member_prop};
 
-use swc_ecmascript::ast::{BlockStmtOrExpr, CallExpr, Callee, Expr, Lit, Stmt};
+use swc_ecmascript::ast::{CallExpr, Callee, Expr};
 
 /// Infer filter operator from the lambda predicate of to filter()
 pub fn infer_filter(
@@ -23,77 +19,6 @@ pub fn infer_filter(
         _ => return (None, None),
     };
     extract_filter(call_expr, entity_type, "__filterWithExpression".to_string())
-}
-
-fn extract_filter(
-    call_expr: &CallExpr,
-    entity_type: String,
-    function: String,
-) -> (Option<Box<QOperator>>, Option<FilterProperties>) {
-    let args = &call_expr.args;
-    assert_eq!(args.len(), 1);
-    let arg = &args[0];
-    let arrow = match &*arg.expr {
-        Expr::Arrow(arrow_expr) => arrow_expr,
-        Expr::Object(object_lit) => {
-            /*
-             * Filter by restriction object, nothing to transform, but let's
-             * grab predicate indexes.
-             */
-            let props = FilterProperties::from_object_lit(entity_type, object_lit);
-            return (None, props);
-        }
-        _ => {
-            /* filter() call that has a parameter type we don't recognize, nothing to transform.  */
-            return (None, None);
-        }
-    };
-    let params = &arrow.params;
-    assert_eq!(params.len(), 1);
-    let param = &params[0];
-    let param = pat_to_string(param).unwrap();
-    let expr = match &arrow.body {
-        BlockStmtOrExpr::BlockStmt(block_stmt) => {
-            assert_eq!(block_stmt.stmts.len(), 1);
-            let return_stmt = match &block_stmt.stmts[0] {
-                Stmt::Return(return_stmt) => return_stmt,
-                _ => {
-                    return (None, None);
-                }
-            };
-            match &return_stmt.arg {
-                Some(expr) => match &**expr {
-                    Expr::Bin(bin_expr) => convert_bin_expr(bin_expr),
-                    Expr::Lit(Lit::Bool(value)) => Ok(QExpr::Literal(QLiteral::Bool(value.value))),
-                    _ => {
-                        todo!();
-                    }
-                },
-                None => {
-                    todo!();
-                }
-            }
-        }
-        BlockStmtOrExpr::Expr(expr) => match &**expr {
-            Expr::Bin(bin_expr) => convert_bin_expr(bin_expr),
-            _ => todo!("Unsupported filter predicate expression: {:?}", expr),
-        },
-    };
-    let expr = match expr {
-        Ok(expr) => expr,
-        Err(_) => return (None, None),
-    };
-    let filter = QFilter {
-        function,
-        parameters: vec![param.clone()],
-        input: Box::new(QOperator::Scan(QScan {
-            entity_type: entity_type.clone(),
-            alias: param,
-        })),
-        predicate: expr,
-    };
-    let props = FilterProperties::from_filter(entity_type, &filter);
-    (Some(Box::new(QOperator::Filter(filter))), props)
 }
 
 fn is_rewritable_filter(callee: &Callee, symbols: &Symbols) -> bool {

--- a/chiselc/src/transforms/filter.rs
+++ b/chiselc/src/transforms/filter.rs
@@ -96,9 +96,8 @@ pub fn infer_filter(
 fn is_rewritable_filter(callee: &Callee, symbols: &Symbols) -> bool {
     match callee {
         Callee::Expr(expr) => match &**expr {
-            Expr::Member(member_expr) => {
-                is_ident_member_prop(&member_expr.prop, "filter")
-                    && is_call_to_entity_method(&member_expr.obj, "cursor", symbols)
+            Expr::Member(member_expr) if is_ident_member_prop(&member_expr.prop, "filter") => {
+                is_call_to_entity_method(&member_expr.obj, "cursor", symbols)
             }
             _ => false,
         },

--- a/chiselc/src/transforms/filter.rs
+++ b/chiselc/src/transforms/filter.rs
@@ -83,6 +83,7 @@ fn extract_filter(
         Err(_) => return (None, None),
     };
     let filter = QFilter {
+        function: "__filterWithExpression".to_string(),
         parameters: vec![param.clone()],
         input: Box::new(QOperator::Scan(QScan {
             entity_type: entity_type.clone(),

--- a/chiselc/src/transforms/filter.rs
+++ b/chiselc/src/transforms/filter.rs
@@ -22,6 +22,13 @@ pub fn infer_filter(
         Ok(entity_type) => entity_type,
         _ => return (None, None),
     };
+    extract_filter(call_expr, entity_type)
+}
+
+fn extract_filter(
+    call_expr: &CallExpr,
+    entity_type: String,
+) -> (Option<Box<QOperator>>, Option<FilterProperties>) {
     let args = &call_expr.args;
     assert_eq!(args.len(), 1);
     let arg = &args[0];

--- a/chiselc/src/transforms/find.rs
+++ b/chiselc/src/transforms/find.rs
@@ -1,0 +1,29 @@
+use crate::filtering::FilterProperties;
+use crate::query::Operator as QOperator;
+use crate::symbols::Symbols;
+use crate::transforms::utils::{extract_filter, lookup_callee_entity_type};
+use crate::utils::is_call_to_entity_method;
+
+use swc_ecmascript::ast::{CallExpr, Callee};
+
+/// Infer filter operator from the lambda predicate of `findMany`.
+pub fn infer_find(
+    call_expr: &CallExpr,
+    symbols: &Symbols,
+) -> (Option<Box<QOperator>>, Option<FilterProperties>) {
+    if !is_rewritable_find("findMany", &call_expr.callee, symbols) {
+        return (None, None);
+    }
+    let entity_type = match lookup_callee_entity_type(&call_expr.callee) {
+        Ok(entity_type) => entity_type,
+        _ => return (None, None),
+    };
+    extract_filter(call_expr, entity_type, "__findMany".to_string())
+}
+
+fn is_rewritable_find(function: &str, callee: &Callee, symbols: &Symbols) -> bool {
+    match callee {
+        Callee::Expr(expr) => is_call_to_entity_method(expr, function, symbols),
+        _ => false,
+    }
+}

--- a/chiselc/src/transforms/find.rs
+++ b/chiselc/src/transforms/find.rs
@@ -6,7 +6,7 @@ use crate::utils::is_call_to_entity_method;
 
 use swc_ecmascript::ast::{CallExpr, Callee};
 
-/// Infer filter operator from the lambda predicate of `findMany`.
+/// Infer filter operator from the lambda predicate of `find{Many,One}`.
 pub fn infer_find(
     call_expr: &CallExpr,
     symbols: &Symbols,
@@ -25,6 +25,9 @@ pub fn infer_find(
 fn infer_rewritable_find(call_expr: &CallExpr, symbols: &Symbols) -> Option<String> {
     if is_rewritable_find("findMany", &call_expr.callee, symbols) {
         return Some("__findMany".to_string());
+    }
+    if is_rewritable_find("findOne", &call_expr.callee, symbols) {
+        return Some("__findOne".to_string());
     }
     None
 }

--- a/chiselc/src/transforms/find.rs
+++ b/chiselc/src/transforms/find.rs
@@ -11,14 +11,22 @@ pub fn infer_find(
     call_expr: &CallExpr,
     symbols: &Symbols,
 ) -> (Option<Box<QOperator>>, Option<FilterProperties>) {
-    if !is_rewritable_find("findMany", &call_expr.callee, symbols) {
-        return (None, None);
-    }
+    let function = match infer_rewritable_find(call_expr, symbols) {
+        Some(function) => function,
+        None => return (None, None),
+    };
     let entity_type = match lookup_callee_entity_type(&call_expr.callee) {
         Ok(entity_type) => entity_type,
         _ => return (None, None),
     };
-    extract_filter(call_expr, entity_type, "__findMany".to_string())
+    extract_filter(call_expr, entity_type, function)
+}
+
+fn infer_rewritable_find(call_expr: &CallExpr, symbols: &Symbols) -> Option<String> {
+    if is_rewritable_find("findMany", &call_expr.callee, symbols) {
+        return Some("__findMany".to_string());
+    }
+    None
 }
 
 fn is_rewritable_find(function: &str, callee: &Callee, symbols: &Symbols) -> bool {

--- a/chiselc/src/transforms/mod.rs
+++ b/chiselc/src/transforms/mod.rs
@@ -1,2 +1,3 @@
 pub mod filter;
+pub mod find;
 pub mod utils;

--- a/chiselc/src/transforms/mod.rs
+++ b/chiselc/src/transforms/mod.rs
@@ -1,1 +1,2 @@
 pub mod filter;
+pub mod utils;

--- a/chiselc/src/transforms/utils.rs
+++ b/chiselc/src/transforms/utils.rs
@@ -1,0 +1,77 @@
+use crate::query::BinaryExpr as QBinaryExpr;
+use crate::query::BinaryOp as QBinaryOp;
+use crate::query::Expr as QExpr;
+use crate::query::Literal as QLiteral;
+use crate::query::PropertyAccessExpr as QPropertyAccessExpr;
+use anyhow::{anyhow, Result};
+
+use swc_ecmascript::ast::{
+    BinExpr, BinaryOp, CallExpr, Callee, Expr, Ident, Lit, MemberExpr, MemberProp,
+};
+
+pub fn lookup_callee_entity_type(callee: &Callee) -> Result<String> {
+    match callee {
+        Callee::Expr(expr) => lookup_entity_type(expr),
+        _ => {
+            todo!();
+        }
+    }
+}
+
+fn lookup_entity_type(expr: &Expr) -> Result<String> {
+    match expr {
+        Expr::Member(MemberExpr { obj, .. }) => lookup_entity_type(obj),
+        Expr::Call(CallExpr { callee, .. }) => lookup_callee_entity_type(callee),
+        Expr::Ident(Ident { sym, .. }) => Ok(sym.to_string()),
+        _ => {
+            anyhow::bail!("Failed to look up entity type from call chain")
+        }
+    }
+}
+
+pub fn convert_bin_expr(expr: &BinExpr) -> Result<QExpr> {
+    let left = Box::new(convert_expr(&expr.left)?);
+    let op = convert_binary_op(&expr.op)?;
+    let right = Box::new(convert_expr(&expr.right)?);
+    Ok(QExpr::BinaryExpr(QBinaryExpr { left, op, right }))
+}
+
+fn convert_expr(expr: &Expr) -> Result<QExpr> {
+    match expr {
+        Expr::Bin(bin_expr) => convert_bin_expr(bin_expr),
+        Expr::Paren(paren_expr) => Ok(convert_expr(&*paren_expr.expr)?),
+        Expr::Lit(Lit::Num(number)) => Ok(QExpr::Literal(QLiteral::Num(number.value))),
+        Expr::Lit(Lit::Str(s)) => Ok(QExpr::Literal(QLiteral::Str(format!("{}", s.value)))),
+        Expr::Member(member_expr) => {
+            let obj = convert_expr(&member_expr.obj)?;
+            let prop = match &member_expr.prop {
+                MemberProp::Ident(ident) => ident.sym.to_string(),
+                _ => {
+                    todo!();
+                }
+            };
+            Ok(QExpr::PropertyAccess(QPropertyAccessExpr {
+                object: Box::new(obj),
+                property: prop,
+            }))
+        }
+        Expr::Ident(ident) => Ok(QExpr::Identifier(ident.sym.to_string())),
+        _ => Err(anyhow!("Unsupported expression: {:#?}", expr)),
+    }
+}
+
+pub fn convert_binary_op(op: &BinaryOp) -> Result<QBinaryOp> {
+    Ok(match op {
+        BinaryOp::EqEq => QBinaryOp::Eq,
+        BinaryOp::Gt => QBinaryOp::Gt,
+        BinaryOp::GtEq => QBinaryOp::GtEq,
+        BinaryOp::Lt => QBinaryOp::Lt,
+        BinaryOp::LtEq => QBinaryOp::LtEq,
+        BinaryOp::NotEq => QBinaryOp::NotEq,
+        BinaryOp::LogicalAnd => QBinaryOp::And,
+        BinaryOp::LogicalOr => QBinaryOp::Or,
+        _ => {
+            anyhow::bail!("Cannot convert binary operator {}", op);
+        }
+    })
+}

--- a/chiselc/src/transforms/utils.rs
+++ b/chiselc/src/transforms/utils.rs
@@ -1,12 +1,18 @@
+use crate::filtering::FilterProperties;
 use crate::query::BinaryExpr as QBinaryExpr;
 use crate::query::BinaryOp as QBinaryOp;
 use crate::query::Expr as QExpr;
+use crate::query::Filter as QFilter;
 use crate::query::Literal as QLiteral;
+use crate::query::Operator as QOperator;
 use crate::query::PropertyAccessExpr as QPropertyAccessExpr;
+use crate::query::Scan as QScan;
+use crate::utils::pat_to_string;
 use anyhow::{anyhow, Result};
 
 use swc_ecmascript::ast::{
-    BinExpr, BinaryOp, CallExpr, Callee, Expr, Ident, Lit, MemberExpr, MemberProp,
+    BinExpr, BinaryOp, BlockStmtOrExpr, CallExpr, Callee, Expr, Ident, Lit, MemberExpr, MemberProp,
+    Stmt,
 };
 
 pub fn lookup_callee_entity_type(callee: &Callee) -> Result<String> {
@@ -27,6 +33,77 @@ fn lookup_entity_type(expr: &Expr) -> Result<String> {
             anyhow::bail!("Failed to look up entity type from call chain")
         }
     }
+}
+
+pub fn extract_filter(
+    call_expr: &CallExpr,
+    entity_type: String,
+    function: String,
+) -> (Option<Box<QOperator>>, Option<FilterProperties>) {
+    let args = &call_expr.args;
+    assert_eq!(args.len(), 1);
+    let arg = &args[0];
+    let arrow = match &*arg.expr {
+        Expr::Arrow(arrow_expr) => arrow_expr,
+        Expr::Object(object_lit) => {
+            /*
+             * Filter by restriction object, nothing to transform, but let's
+             * grab predicate indexes.
+             */
+            let props = FilterProperties::from_object_lit(entity_type, object_lit);
+            return (None, props);
+        }
+        _ => {
+            /* filter() call that has a parameter type we don't recognize, nothing to transform.  */
+            return (None, None);
+        }
+    };
+    let params = &arrow.params;
+    assert_eq!(params.len(), 1);
+    let param = &params[0];
+    let param = pat_to_string(param).unwrap();
+    let expr = match &arrow.body {
+        BlockStmtOrExpr::BlockStmt(block_stmt) => {
+            assert_eq!(block_stmt.stmts.len(), 1);
+            let return_stmt = match &block_stmt.stmts[0] {
+                Stmt::Return(return_stmt) => return_stmt,
+                _ => {
+                    return (None, None);
+                }
+            };
+            match &return_stmt.arg {
+                Some(expr) => match &**expr {
+                    Expr::Bin(bin_expr) => convert_bin_expr(bin_expr),
+                    Expr::Lit(Lit::Bool(value)) => Ok(QExpr::Literal(QLiteral::Bool(value.value))),
+                    _ => {
+                        todo!();
+                    }
+                },
+                None => {
+                    todo!();
+                }
+            }
+        }
+        BlockStmtOrExpr::Expr(expr) => match &**expr {
+            Expr::Bin(bin_expr) => convert_bin_expr(bin_expr),
+            _ => todo!("Unsupported filter predicate expression: {:?}", expr),
+        },
+    };
+    let expr = match expr {
+        Ok(expr) => expr,
+        Err(_) => return (None, None),
+    };
+    let filter = QFilter {
+        function,
+        parameters: vec![param.clone()],
+        input: Box::new(QOperator::Scan(QScan {
+            entity_type: entity_type.clone(),
+            alias: param,
+        })),
+        predicate: expr,
+    };
+    let props = FilterProperties::from_filter(entity_type, &filter);
+    (Some(Box::new(QOperator::Filter(filter))), props)
 }
 
 pub fn convert_bin_expr(expr: &BinExpr) -> Result<QExpr> {

--- a/chiselc/src/utils.rs
+++ b/chiselc/src/utils.rs
@@ -15,7 +15,7 @@ pub fn ident_to_string(expr: &Expr) -> Option<String> {
     }
 }
 
-pub fn is_call_to_entity_cursor(expr: &Expr, symbols: &Symbols) -> bool {
+pub fn is_call_to_entity_method(expr: &Expr, method: &str, symbols: &Symbols) -> bool {
     match expr {
         Expr::Call(call_expr) => match &call_expr.callee {
             Callee::Expr(expr) => match &**expr {
@@ -26,7 +26,7 @@ pub fn is_call_to_entity_cursor(expr: &Expr, symbols: &Symbols) -> bool {
                             return false;
                         }
                     }
-                    is_ident_member_prop(&member_expr.prop, "cursor")
+                    is_ident_member_prop(&member_expr.prop, method)
                 }
                 _ => false,
             },

--- a/chiselc/src/utils.rs
+++ b/chiselc/src/utils.rs
@@ -1,5 +1,5 @@
 use crate::symbols::Symbols;
-use swc_ecmascript::ast::{Callee, Expr, MemberProp, Pat};
+use swc_ecmascript::ast::{Expr, MemberProp, Pat};
 
 pub fn is_ident_member_prop(member_prop: &MemberProp, value: &str) -> bool {
     match member_prop {
@@ -17,21 +17,15 @@ pub fn ident_to_string(expr: &Expr) -> Option<String> {
 
 pub fn is_call_to_entity_method(expr: &Expr, method: &str, symbols: &Symbols) -> bool {
     match expr {
-        Expr::Call(call_expr) => match &call_expr.callee {
-            Callee::Expr(expr) => match &**expr {
-                Expr::Member(member_expr) => {
-                    let expr = &member_expr.obj;
-                    if let Some(ty) = ident_to_string(expr) {
-                        if !symbols.is_entity(&ty) {
-                            return false;
-                        }
-                    }
-                    is_ident_member_prop(&member_expr.prop, method)
+        Expr::Member(member_expr) => {
+            let expr = &member_expr.obj;
+            if let Some(ty) = ident_to_string(expr) {
+                if !symbols.is_entity(&ty) {
+                    return false;
                 }
-                _ => false,
-            },
-            _ => false,
-        },
+            }
+            is_ident_member_prop(&member_expr.prop, method)
+        }
         _ => false,
     }
 }

--- a/chiselc/tests/lit/filter-properties-findmany.lit
+++ b/chiselc/tests/lit/filter-properties-findmany.lit
@@ -1,0 +1,18 @@
+// Extract predicate indexes
+// RUN: @chiselc @file -e Person --target filter-properties
+
+await Person.findMany({ name: "Pekka", age: 39 });
+
+await Person.findMany({ });
+
+await Person.findMany((p) => { return p.age > 4 });
+
+await Person.findMany((p) => { return p.age < 4 || (p.age > 10 && p.age != 12) });
+
+await Person.findMany((p) => { return true; });
+
+const property = 'name';
+
+await Person.findMany({ [property]: "Pekka" });
+
+// CHECK: [{"entity_name":"Person","properties":["name","age"]},{"entity_name":"Person","properties":["age"]},{"entity_name":"Person","properties":["age"]}]

--- a/chiselc/tests/lit/filter-properties-findone.lit
+++ b/chiselc/tests/lit/filter-properties-findone.lit
@@ -1,0 +1,18 @@
+// Extract predicate indexes
+// RUN: @chiselc @file -e Person --target filter-properties
+
+await Person.findOne({ name: "Pekka", age: 39 });
+
+await Person.findOne({ });
+
+await Person.findOne((p) => { return p.age > 4 });
+
+await Person.findOne((p) => { return p.age < 4 || (p.age > 10 && p.age != 12) });
+
+await Person.findOne((p) => { return true; });
+
+const property = 'name';
+
+await Person.findOne({ [property]: "Pekka" });
+
+// CHECK: [{"entity_name":"Person","properties":["name","age"]},{"entity_name":"Person","properties":["age"]},{"entity_name":"Person","properties":["age"]}]


### PR DESCRIPTION
This extends `chiselc` to also transform `findMany()` and `findOne()`
with predicate lambdas to internal query calls that are optimized by the
runtime.

Similarly, `chiselc` now also extracts filter properties from `findMany`
and `findOne`, which allows the runtime to auto-index the underlying
table columns if needed.