### PR TITLE
Add missing format string

### DIFF
--- a/cli/tests/lit/crud.node
+++ b/cli/tests/lit/crud.node
@@ -60,11 +60,11 @@ $CURL "$CHISELD_HOST/dev/persons?sort=-age"
 
 count_results () {
     results=$(cat)
-    printf "$results" \
+    printf '%s' "$results" \
         | grep -o "last_name" \
         | wc -l \
         | xargs printf 'Number of names: %d\n';
-    printf "$results";
+    printf '%s' "$results";
 }
 
 $CURL "$CHISELD_HOST/dev/persons?sort=first_name&limit=3" | count_results

--- a/cli/tests/lit/defaults.deno
+++ b/cli/tests/lit/defaults.deno
@@ -110,11 +110,11 @@ $CURL -o - $CHISELD_HOST/dev/crud_foo
 
 count_results () {
     results=$(cat)
-    printf "$results" \
+    printf '%s' "$results" \
         | grep -o "\"a\":" \
         | wc -l \
         | xargs printf 'Number of results: %d\n';
-    printf "$results";
+    printf '%s' "$results";
 }
 
 $CURL "$CHISELD_HOST/dev/crud_foo?.a=xxx" | count_results


### PR DESCRIPTION
The first argument to printf is a format string. Passing a single
string is equivalent only if that string has no formatting directives.