### PR TITLE
Change CURL to not add single quotes

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -114,7 +114,7 @@ fn run_tests(opt: Opt, optimize: bool) -> bool {
 
     env::set_var("CHISELD", chiseld);
     env::set_var("RMCOLOR", "sed s/\x1B\\[[0-9;]*[A-Za-z]//g");
-    env::set_var("CURL", "curl -N -S -s -i -w '\\n'");
+    env::set_var("CURL", "curl -N -S -s -i -w \\n");
     env::set_var("CREATE_APP", create_app);
     env::set_var("TEST_DATABASE", opt.database.to_string());
 


### PR DESCRIPTION
The original intent was to add just a newline at the end of the
output. Unfortunately the quoting was wrong and we were writing 3
characters: "'", "\n" and "'".