### PR TITLE
Use $CURL --no-include instead of curl -s

### DIFF
--- a/cli/tests/lit/introspect.node
+++ b/cli/tests/lit/introspect.node
@@ -66,7 +66,7 @@ $CURL $CHISELD_HOST/dev
 # CHECK: "title": "glauber",
 
 # jq doesn't like the standard output including headers because it is not json
-TITLE=$(curl -s $CHISELD_HOST/dev | jq '.info.version')
+TITLE=$($CURL --no-include $CHISELD_HOST/dev | jq '.info.version')
 EXPECTED="\"1.0.0-$(git rev-parse --short HEAD)\""
 
 if [ "$TITLE" = "$EXPECTED" ]; then echo "match"; fi


### PR DESCRIPTION
If one sees a use of plain curl, it is not clear which difference from
CURL is desired. Using $CURL --no-include makes that explicit.