### PR TITLE
Upgrade lit to include always_show_stdout flag.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
  "glob",
  "handlebars",
  "itertools 0.10.3",
- "lit 1.0.4 (git+https://github.com/chiselstrike/lit?rev=b3137dd)",
+ "lit 1.0.4 (git+https://github.com/chiselstrike/lit?rev=607b0b9)",
  "notify",
  "prost",
  "rayon",
@@ -2484,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "lit"
 version = "1.0.4"
-source = "git+https://github.com/chiselstrike/lit?rev=b3137dd#b3137dda5778a5e63c2250825b60407e0530f75f"
+source = "git+https://github.com/chiselstrike/lit?rev=607b0b9#607b0b9af934e55fdf3814e9186468c9b91b7cae"
 dependencies = [
  "clap",
  "error-chain 0.12.4",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -31,7 +31,7 @@ vergen = { version = "6", default-features = false, features = ["git"] }
 futures = "0.3.17"
 glob = "0.3.0"
 itertools = "0.10.3"
-lit = { git = "https://github.com/chiselstrike/lit", rev = "b3137dd" }
+lit = { git = "https://github.com/chiselstrike/lit", rev = "607b0b9" }
 rayon = "1.5.1"
 server = { path = "../server" }
 whoami = "1.2.1"

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -159,6 +159,7 @@ fn run_tests(opt: Opt, optimize: bool) -> bool {
                     let i = rayon::current_thread_index().unwrap_or(0) + 1;
                     config.test_paths = vec![test_path.clone()];
                     config.truncate_output_context_to_number_of_lines = Some(500);
+                    config.always_show_stdout = false;
 
                     let mut path = repo.clone();
                     path.push("cli/tests/test-wrapper.sh");


### PR DESCRIPTION
Showing the whole stdout is very useful for debugging and the current version of lit doesn't show stdout if anything is printed to stderr. :(