### PR TITLE
create-chiselstrike-app: Depend on exact versions

### DIFF
--- a/packages/create-chiselstrike-app/package-lock.json
+++ b/packages/create-chiselstrike-app/package-lock.json
@@ -9,20 +9,20 @@
             "version": "0.10.0-dev.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "handlebars": "^4.7.7"
+                "handlebars": "4.7.7"
             },
             "bin": {
                 "create-chiselstrike-app": "dist/index.js"
             },
             "devDependencies": {
-                "@types/chalk": "^2.2.0",
-                "@types/cross-spawn": "^6.0.2",
-                "@types/node": "^17.0.8",
-                "@vercel/ncc": "^0.33.1",
-                "commander": "^8.3.0",
-                "cross-spawn": "^7.0.3",
-                "rimraf": "^3.0.2",
-                "typescript": "^4.5.4"
+                "@types/chalk": "2.2.0",
+                "@types/cross-spawn": "6.0.2",
+                "@types/node": "17.0.8",
+                "@vercel/ncc": "0.33.1",
+                "commander": "8.3.0",
+                "cross-spawn": "7.0.3",
+                "rimraf": "3.0.2",
+                "typescript": "4.5.4"
             },
             "engines": {
                 "node": ">=14.18.0"
@@ -48,15 +48,15 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "17.0.25",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
-            "integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==",
+            "version": "17.0.8",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+            "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
             "dev": true
         },
         "node_modules/@vercel/ncc": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.4.tgz",
-            "integrity": "sha512-ln18hs7dMffelP47tpkaR+V5Tj6coykNyxJrlcmCormPqRQjB/Gv4cu2FfBG+PMzIfdZp2CLDsrrB1NPU22Qhg==",
+            "version": "0.33.1",
+            "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.1.tgz",
+            "integrity": "sha512-Mlsps/P0PLZwsCFtSol23FGqT3FhBGb4B1AuGQ52JTAtXhak+b0Fh/4T55r0/SVQPeRiX9pNItOEHwakGPmZYA==",
             "dev": true,
             "bin": {
                 "ncc": "dist/ncc/cli.js"
@@ -126,15 +126,15 @@
             "dev": true
         },
         "node_modules/glob": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^3.0.4",
+                "minimatch": "^3.1.1",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
             },
@@ -281,9 +281,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -294,9 +294,9 @@
             }
         },
         "node_modules/uglify-js": {
-            "version": "3.15.4",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
-            "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
+            "version": "3.15.5",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
+            "integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
             "optional": true,
             "bin": {
                 "uglifyjs": "bin/uglifyjs"
@@ -352,15 +352,15 @@
             }
         },
         "@types/node": {
-            "version": "17.0.25",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
-            "integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==",
+            "version": "17.0.8",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+            "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
             "dev": true
         },
         "@vercel/ncc": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.4.tgz",
-            "integrity": "sha512-ln18hs7dMffelP47tpkaR+V5Tj6coykNyxJrlcmCormPqRQjB/Gv4cu2FfBG+PMzIfdZp2CLDsrrB1NPU22Qhg==",
+            "version": "0.33.1",
+            "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.1.tgz",
+            "integrity": "sha512-Mlsps/P0PLZwsCFtSol23FGqT3FhBGb4B1AuGQ52JTAtXhak+b0Fh/4T55r0/SVQPeRiX9pNItOEHwakGPmZYA==",
             "dev": true
         },
         "balanced-match": {
@@ -415,15 +415,15 @@
             "dev": true
         },
         "glob": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^3.0.4",
+                "minimatch": "^3.1.1",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
             }
@@ -532,15 +532,15 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "typescript": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
             "dev": true
         },
         "uglify-js": {
-            "version": "3.15.4",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
-            "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
+            "version": "3.15.5",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
+            "integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
             "optional": true
         },
         "which": {

--- a/packages/create-chiselstrike-app/package.json
+++ b/packages/create-chiselstrike-app/package.json
@@ -16,19 +16,19 @@
         "dist"
     ],
     "devDependencies": {
-        "@types/chalk": "^2.2.0",
-        "@types/cross-spawn": "^6.0.2",
-        "@types/node": "^17.0.8",
-        "@vercel/ncc": "^0.33.1",
-        "commander": "^8.3.0",
-        "cross-spawn": "^7.0.3",
-        "rimraf": "^3.0.2",
-        "typescript": "^4.5.4"
+        "@types/chalk": "2.2.0",
+        "@types/cross-spawn": "6.0.2",
+        "@types/node": "17.0.8",
+        "@vercel/ncc": "0.33.1",
+        "commander": "8.3.0",
+        "cross-spawn": "7.0.3",
+        "rimraf": "3.0.2",
+        "typescript": "4.5.4"
     },
     "engines": {
         "node": ">=14.18.0"
     },
     "dependencies": {
-        "handlebars": "^4.7.7"
+        "handlebars": "4.7.7"
     }
 }


### PR DESCRIPTION
Let's depend on exact versions instead of compatible versions to keep
builds reproducible.

The practical reason is that the current `typescript` dependency
installs latest 4.7.2, which fails the build:

ncc: Using typescript@4.7.2 (local user-provided)
Error: Module build failed (from ./node_modules/@vercel/ncc/dist/ncc/loaders/ts-loader.js):
Error: Debug Failure. False expression: Non-string value passed to `ts.resolveTypeReferenceDirective`, likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is probably not a problem in TS itself.
    at Object.resolveTypeReferenceDirective (/Users/penberg/src/chiselstrike/chiselstrike/packages/create-chiselstrike-app/node_modules/typescript/lib/typescript.js:42530:18)
    at /Users/penberg/src/chiselstrike/chiselstrike/packages/create-chiselstrike-app/node_modules/@vercel/ncc/dist/ncc/loaders/ts-loader.js.cache.js:13:316837
    at /Users/penberg/src/chiselstrike/chiselstrike/packages/create-chiselstrike-app/node_modules/@vercel/ncc/dist/ncc/loaders/ts-loader.js.cache.js:13:303785
    at Array.map (<anonymous>)
    at Object.resolveTypeReferenceDirectives (/Users/penberg/src/chiselstrike/chiselstrike/packages/create-chiselstrike-app/node_modules/@vercel/ncc/dist/ncc/loaders/ts-loader.js.cache.js:13:303777)
    at actualResolveTypeReferenceDirectiveNamesWorker (/Users/penberg/src/chiselstrike/chiselstrike/packages/create-chiselstrike-app/node_modules/typescript/lib/typescript.js:116611:163)
    at resolveTypeReferenceDirectiveNamesWorker (/Users/penberg/src/chiselstrike/chiselstrike/packages/create-chiselstrike-app/node_modules/typescript/lib/typescript.js:116911:26)
    at processTypeReferenceDirectives (/Users/penberg/src/chiselstrike/chiselstrike/packages/create-chiselstrike-app/node_modules/typescript/lib/typescript.js:118393:31)
    at findSourceFileWorker (/Users/penberg/src/chiselstrike/chiselstrike/packages/create-chiselstrike-app/node_modules/typescript/lib/typescript.js:118278:21)
    at findSourceFile (/Users/penberg/src/chiselstrike/chiselstrike/packages/create-chiselstrike-app/node_modules/typescript/lib/typescript.js:118133:26)
    at /Users/penberg/src/chiselstrike/chiselstrike/packages/create-chiselstrike-app/node_modules/@vercel/ncc/dist/ncc/index.js.cache.js:37:1770552
    at /Users/penberg/src/chiselstrike/chiselstrike/packages/create-chiselstrike-app/node_modules/@vercel/ncc/dist/ncc/index.js.cache.js:37:374702
    at _done (eval at create (/Users/penberg/src/chiselstrike/chiselstrike/packages/create-chiselstrike-app/node_modules/@vercel/ncc/dist/ncc/index.js.cache.js:20:75523), <anonymous>:9:1)
    at eval (eval at create (/Users/penberg/src/chiselstrike/chiselstrike/packages/create-chiselstrike-app/node_modules/@vercel/ncc/dist/ncc/index.js.cache.js:20:75523), <anonymous>:34:22)

As it's still an open issue, we anyway need to avoid that specific
version:

https://github.com/microsoft/TypeScript/issues/49257

But better to just have explicit version numbers to avoid stuff breaking
when our source stays the same.