### PR TITLE
Use the same TS version as tsc_compile

### DIFF
--- a/packages/create-chiselstrike-app/template/package.json
+++ b/packages/create-chiselstrike-app/template/package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "@chiselstrike/api": "{{chiselVersion}}",
         "esbuild": "^0.14.14",
-        "typescript": "^4.5.4"
+        "typescript": "4.6.2"
     },
     "devDependencies": {
         "@chiselstrike/cli": "{{chiselVersion}}"


### PR DESCRIPTION
The TS we use when compiling is from third_party/deno/cli/tsc/00_typescript.js.