### PR TITLE
Expand tests

### DIFF
--- a/tsc_compile/src/lib.rs
+++ b/tsc_compile/src/lib.rs
@@ -715,15 +715,23 @@ export default foo;
         func(abs(path)).await;
     }
 
-    async fn check_output_imported(path: String) {
+    async fn check_import(path: String, suffix_a: &str, suffix_b: &str) {
         let abs_a = abs(&path);
-        let import = format!("file://{}b.ts", abs_a.strip_suffix("a.ts").unwrap());
+        let import = format!(
+            "file://{}{}",
+            abs_a.strip_suffix(suffix_a).unwrap(),
+            suffix_b
+        );
         let written = compile_ts_code(&path, Default::default()).await.unwrap();
         let mut keys: Vec<_> = written.keys().collect();
         keys.sort_unstable();
         let mut expected = vec![import.as_str(), path.as_str()];
         expected.sort_unstable();
         assert_eq!(keys, expected);
+    }
+
+    async fn check_output_imported(path: String) {
+        check_import(path, "a.ts", "b.ts").await;
     }
 
     #[tokio::test]
@@ -732,14 +740,7 @@ export default foo;
     }
 
     async fn check_import_js(path: String) {
-        let abs_a = abs(&path);
-        let import = format!("file://{}b.js", abs_a.strip_suffix("a.ts").unwrap());
-        let written = compile_ts_code(&path, Default::default()).await.unwrap();
-        let mut keys: Vec<_> = written.keys().collect();
-        keys.sort_unstable();
-        let mut expected = vec![import.as_str(), path.as_ref()];
-        expected.sort_unstable();
-        assert_eq!(keys, expected);
+        check_import(path, "a.ts", "b.js").await;
     }
 
     #[tokio::test]
@@ -748,17 +749,7 @@ export default foo;
     }
 
     async fn check_relative(path: String) {
-        let abs_a = abs(&path);
-        let import = format!(
-            "file://{}_b/bar.ts",
-            abs_a.strip_suffix("_a/foo.ts").unwrap()
-        );
-        let written = compile_ts_code(&path, Default::default()).await.unwrap();
-        let mut keys: Vec<_> = written.keys().collect();
-        keys.sort_unstable();
-        let mut expected = vec![import.as_str(), path.as_str()];
-        expected.sort_unstable();
-        assert_eq!(keys, expected);
+        check_import(path, "_a/foo.ts", "_b/bar.ts").await;
     }
 
     #[tokio::test]

--- a/tsc_compile/src/lib.rs
+++ b/tsc_compile/src/lib.rs
@@ -739,4 +739,25 @@ export default foo;
         check_import_js("./tests/import_js_a.ts").await;
         check_import_js(&abs("tests/import_js_a.ts")).await;
     }
+
+    async fn check_relative(path: &str) {
+        let abs_a = abs(path);
+        let import = format!(
+            "file://{}_b/bar.ts",
+            abs_a.strip_suffix("_a/foo.ts").unwrap()
+        );
+        let written = compile_ts_code(path, Default::default()).await.unwrap();
+        let mut keys: Vec<_> = written.keys().collect();
+        keys.sort_unstable();
+        let mut expected = vec![import.as_str(), path];
+        expected.sort_unstable();
+        assert_eq!(keys, expected);
+    }
+
+    #[tokio::test]
+    async fn relative() {
+        check_relative("tests/relative_a/foo.ts").await;
+        check_relative("./tests/relative_a/foo.ts").await;
+        check_relative(&abs("tests/relative_a/foo.ts")).await;
+    }
 }

--- a/tsc_compile/tests/relative_a/foo.ts
+++ b/tsc_compile/tests/relative_a/foo.ts
@@ -1,0 +1,3 @@
+import { Foo } from "../relative_b/bar.ts";
+export function foo(a: Foo) {
+}

--- a/tsc_compile/tests/relative_b/bar.ts
+++ b/tsc_compile/tests/relative_b/bar.ts
@@ -1,0 +1,2 @@
+export class Foo {
+}


### PR DESCRIPTION
With this we now also test import from sibling directories and test variations on the path of the given source file. The output will change a bit in my next PR, so this serves to make that change more visible.