### PR TITLE
Output relative paths for local imports

### DIFF
--- a/tsc_compile/tests/import_js_a.js
+++ b/tsc_compile/tests/import_js_a.js
@@ -1,0 +1,4 @@
+import { foo } from "./import_js_b.js";
+export function bar() {
+    return foo();
+}


### PR DESCRIPTION
In the common case of endpoints/foo.ts importing models/bar.ts, the
output of compile_ts_code would contain "endpoint/foo.ts", but
"file:///path/to/models/bar.ts". That is inconvenient since the
absolute paths will be different in the server.

With this patch we output "endpoint/foo.ts" and "models/bar.ts", which
is the format we want when sending multiple modules to the server.

This also fixes the output path of a top level JS file. A testcase is
included.