### PR TITLE
Compile .js files

### DIFF
--- a/cli/tests/lit/parse-error.deno
+++ b/cli/tests/lit/parse-error.deno
@@ -108,3 +108,13 @@ EOF
 $CHISEL apply 2>&1 | $RMCOLOR|| true
 # CHECK: endpoints/error.ts:4:25 - error TS2322: Type 'string' is not assignable to type 'number'.
 # CHECK:  The expected type comes from property 'height' which is declared here on type 'Partial<Person>'
+
+rm "$TEMPDIR/endpoints/error.ts"
+cat << EOF > "$TEMPDIR/endpoints/not-js.js"
+export default async function chisel(req: Request) {
+    return new Response("");
+}
+EOF
+
+$CHISEL apply 2>&1 | $RMCOLOR|| true
+# CHECK: The module's source code could not be parsed: Expected ',', got ':' at file:///[[.*]]/endpoints/not-js.js:1:41


### PR DESCRIPTION
This causes us to reject typescript constructs in .js files.