### PR TITLE
Pass multiple files to TSC itself

### DIFF
--- a/tsc_compile/src/lib.rs
+++ b/tsc_compile/src/lib.rs
@@ -375,12 +375,14 @@ impl Compiler {
                 get_member(global_proxy, scope, "compile").unwrap();
             let emit_declarations = v8::Boolean::new(scope, opts.emit_declarations).into();
 
-            for url in &urls {
-                let file = v8::String::new(scope, url.0.as_str()).unwrap().into();
-                compile
-                    .call(scope, global_proxy.into(), &[file, lib, emit_declarations])
-                    .unwrap();
-            }
+            let urls: Vec<_> = urls
+                .iter()
+                .map(|url| v8::String::new(scope, url.0.as_str()).unwrap().into())
+                .collect();
+            let urls = v8::Array::new_with_elements(scope, &urls).into();
+            compile
+                .call(scope, global_proxy.into(), &[urls, lib, emit_declarations])
+                .unwrap();
         }
 
         let op_state = self.runtime.op_state();

--- a/tsc_compile_build/src/tsc.js
+++ b/tsc_compile_build/src/tsc.js
@@ -93,7 +93,7 @@
     };
 
     const readCache = {};
-    function compileAux(file, lib, emitDeclarations) {
+    function compileAux(files, lib, emitDeclarations) {
         // FIXME: This is probably not exactly what we want. Deno uses
         // deno.window. This is the subset of deno.window that is
         // compatible with lib.dom.d.ts + lib.dom.d.ts. It should probably
@@ -128,7 +128,7 @@
             types: [],
         };
 
-        const program = ts.createProgram([file], options, host);
+        const program = ts.createProgram(files, options, host);
         const emitResult = program.emit();
 
         let allDiagnostics = ts
@@ -152,9 +152,9 @@
         }
     }
 
-    function compile(file, lib, emitDeclarations) {
+    function compile(files, lib, emitDeclarations) {
         try {
-            return compileAux(file, lib, emitDeclarations);
+            return compileAux(files, lib, emitDeclarations);
         } catch (e) {
             Deno.core.opSync("diagnostic", e.stack + "\n");
             return false;
@@ -188,7 +188,7 @@
         }
     }
 
-    compile("bootstrap.ts", undefined);
+    compile(["bootstrap.ts"], undefined, false);
 
     globalThis.compile = compile;
 })();


### PR DESCRIPTION
TSC is crazy slow to start, so this is a big win:

This speeds chisel apply in a directory with two endpoints by 1.74X
and with 3 by 2.38X.