### PR TITLE
Don't map null to undefined in getSecret

### DIFF
--- a/api/src/chisel.ts
+++ b/api/src/chisel.ts
@@ -897,8 +897,8 @@ type JSONValue =
     | { [x: string]: JSONValue }
     | Array<JSONValue>;
 
-export function getSecret(key: string): JSONValue | undefined {
-    return Deno.core.opSync("op_chisel_get_secret", key) ?? undefined;
+export function getSecret(key: string): JSONValue {
+    return Deno.core.opSync("op_chisel_get_secret", key);
 }
 
 export function responseFromJson(body: unknown, status = 200) {

--- a/cli/tests/lit/secrets.deno
+++ b/cli/tests/lit/secrets.deno
@@ -17,7 +17,7 @@ $CHISEL apply
 echo '{ "secret" : null }' > ${TEMPDIR}/.env
 sleep 2.5;
 $CURL -o - $CHISELD_HOST/dev/secret
-# CHECK: [undefined]
+# CHECK: [null]
 
 echo '{ "secret" : "string" }' > ${TEMPDIR}/.env
 sleep 2.5;
@@ -32,12 +32,12 @@ $CURL -o - $CHISELD_HOST/dev/secret
 echo '{ malformed }' > ${TEMPDIR}/.env
 sleep 2.5;
 $CURL -o - $CHISELD_HOST/dev/secret
-# CHECK: [undefined]
+# CHECK: [null]
 
 echo '{ "othersecret" : "value" }' > ${TEMPDIR}/.env
 sleep 2.5;
 $CURL -o - $CHISELD_HOST/dev/secret
-# CHECK: [undefined]
+# CHECK: [null]
 #
 echo '{ "secret" : true }' > ${TEMPDIR}/.env
 sleep 2.5;


### PR DESCRIPTION
JSON has null, but not undefined, so it is odd to accept JSON but map
null to undefined.

If we really want to keep using undefined for "no secret was set", I can do it, but since that implementation is more complicated I wanted to check first.
