### PR TITLE
chiselc: Add support for computed property names

### DIFF
--- a/chiselc/src/filtering.rs
+++ b/chiselc/src/filtering.rs
@@ -32,7 +32,9 @@ impl FilterProperties {
             match prop {
                 PropOrSpread::Prop(prop) => match &**prop {
                     Prop::KeyValue(key_value_prop) => {
-                        properties.insert(prop_name_to_string(&key_value_prop.key));
+                        if let Some(prop_name) = prop_name_to_string(&key_value_prop.key) {
+                            properties.insert(prop_name);
+                        }
                     }
                     Prop::Shorthand(ident) => {
                         properties.insert(ident.sym.to_string());
@@ -57,12 +59,10 @@ impl FilterProperties {
     }
 }
 
-fn prop_name_to_string(prop_name: &PropName) -> String {
+fn prop_name_to_string(prop_name: &PropName) -> Option<String> {
     match prop_name {
-        PropName::Ident(ident) => ident.sym.to_string(),
-        PropName::Str(s) => s.value.to_string(),
-        _ => {
-            todo!();
-        }
+        PropName::Ident(ident) => Some(ident.sym.to_string()),
+        PropName::Str(s) => Some(s.value.to_string()),
+        _ => None,
     }
 }

--- a/chiselc/tests/lit/predicate-indexes.lit
+++ b/chiselc/tests/lit/predicate-indexes.lit
@@ -5,6 +5,10 @@ await Person.cursor().filter({ name: "Pekka", age: 39 }).toArray();
 
 await Person.cursor().filter({ }).toArray();
 
+const property = "name";
+
+await Person.cursor().filter({ [property]: "Pekka" });
+
 await Person.cursor().filter((p) => { return p.age > 4 }).toArray();
 
 await Person.cursor().filter((p) => { return p.age < 4 || (p.age > 10 && p.age != 12) });


### PR DESCRIPTION
Make sure `chiselc` accepts computed property names, although we cannot
infer filter properties, and therefore no index can be created.