### PR TITLE
Use upstream deno URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third_party/deno"]
 	path = third_party/deno
-	url = git@github.com:chiselstrike/deno.git
+	url = https://github.com/denoland/deno.git


### PR DESCRIPTION
We don't need any patches for deno at the moment. We are getting
security warnings from github because the main branch in our fork of
deno is old (which is OK, since we use tags, not the main branch).

With this we should be able to delete the fork. It is easy enough to
create it again if we ever need to.