### PR TITLE
Compile multiple endpoints at once

### DIFF
--- a/api/src/endpoint.ts
+++ b/api/src/endpoint.ts
@@ -100,16 +100,12 @@ export async function readWorkerChannel() {
     await toWorker({ cmd: "readWorkerChannel" });
 }
 
-export async function importEndpoint(
-    path: string,
-    apiVersion: string,
-    version: number,
-) {
+type Endpoint = { path: string; apiVersion: string; version: number };
+
+export async function importEndpoints(endpoints: [Endpoint]) {
     await toWorker({
-        cmd: "importEndpoint",
-        path,
-        apiVersion,
-        version,
+        cmd: "importEndpoints",
+        endpoints,
     });
 }
 

--- a/cli/tests/lit/endpoint-error.deno
+++ b/cli/tests/lit/endpoint-error.deno
@@ -15,7 +15,7 @@ set +e
 $CHISEL apply 2>&1
 set -e
 
-# CHECK: Error: parsing endpoint /dev/test
+# CHECK: Error: parsing endpoints
 # CHECK: expected type `v8::data::Function`, got `v8::data::Value`
 
 $CURL -o - $CHISELD_HOST/dev/test

--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -10,6 +10,7 @@ use anyhow::Result;
 use deno_core::OpState;
 use sqlx::Row;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -30,7 +31,8 @@ async fn add_crud_endpoint_for_type(
     endpoint_name: &str,
     api: &mut ApiService,
 ) -> Result<()> {
-    crate::server::add_endpoint(
+    let mut sources = HashMap::new();
+    sources.insert(
         format!("/__chiselstrike/auth/{}", endpoint_name),
         format!(
             r#"
@@ -38,9 +40,9 @@ import {{ ChiselEntity }} from "@chiselstrike/api"
 class {type_name} extends ChiselEntity {{}}
 export default {type_name}.crud()"#
         ),
-        api,
-    )
-    .await
+    );
+
+    crate::server::add_endpoints(sources, api).await
 }
 
 pub(crate) async fn init(api: &mut ApiService) -> Result<()> {

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -125,7 +125,7 @@ struct DenoService {
 
     module_loader: Arc<std::sync::Mutex<ModuleLoaderInner>>,
 
-    import_endpoint: v8::Global<v8::Function>,
+    import_endpoints: v8::Global<v8::Function>,
     activate_endpoint: v8::Global<v8::Function>,
     call_handler: v8::Global<v8::Function>,
     read_worker_channel: v8::Global<v8::Function>,
@@ -422,7 +422,7 @@ impl DenoService {
             .unwrap();
 
         let (
-            import_endpoint,
+            import_endpoints,
             activate_endpoint,
             call_handler,
             init_worker,
@@ -436,9 +436,9 @@ impl DenoService {
             let module = runtime.resolve_value(promise).await.unwrap();
             let scope = &mut runtime.handle_scope();
             let module = v8::Local::new(scope, module).try_into().unwrap();
-            let import_endpoint: v8::Local<v8::Function> =
-                get_member(module, scope, "importEndpoint").unwrap();
-            let import_endpoint = v8::Global::new(scope, import_endpoint);
+            let import_endpoints: v8::Local<v8::Function> =
+                get_member(module, scope, "importEndpoints").unwrap();
+            let import_endpoints = v8::Global::new(scope, import_endpoints);
             let activate_endpoint: v8::Local<v8::Function> =
                 get_member(module, scope, "activateEndpoint").unwrap();
             let activate_endpoint = v8::Global::new(scope, activate_endpoint);
@@ -456,7 +456,7 @@ impl DenoService {
             let end_of_request = v8::Global::new(scope, end_of_request);
 
             (
-                import_endpoint,
+                import_endpoints,
                 activate_endpoint,
                 call_handler,
                 init_worker,
@@ -474,7 +474,7 @@ impl DenoService {
                 worker,
                 inspector,
                 module_loader: inner,
-                import_endpoint,
+                import_endpoints,
                 activate_endpoint,
                 call_handler,
                 to_worker: to_worker_sender,
@@ -1509,14 +1509,22 @@ pub(crate) async fn compile_endpoint(path: String, code: String) -> Result<()> {
 
         let runtime = &mut service.worker.js_runtime;
         let scope = &mut runtime.handle_scope();
-        let import_endpoint = service.import_endpoint.open(scope);
+        let import_endpoints = service.import_endpoints.open(scope);
         let path = RequestPath::try_from(path.as_ref()).unwrap();
         let api_version = v8::String::new(scope, path.api_version()).unwrap().into();
         let path = v8::String::new(scope, path.path()).unwrap().into();
         let version = v8::Number::new(scope, entry.version as f64).into();
+        let endpoint = v8::Object::new(scope);
+        let path_key = v8::String::new(scope, "path").unwrap();
+        endpoint.set(scope, path_key.into(), path);
+        let api_version_key = v8::String::new(scope, "apiVersion").unwrap();
+        endpoint.set(scope, api_version_key.into(), api_version);
+        let version_key = v8::String::new(scope, "version").unwrap();
+        endpoint.set(scope, version_key.into(), version);
+        let endpoints = v8::Array::new_with_elements(scope, &[endpoint.into()]).into();
         let undefined = v8::undefined(scope).into();
-        let promise = import_endpoint
-            .call(scope, undefined, &[path, api_version, version])
+        let promise = import_endpoints
+            .call(scope, undefined, &[endpoints])
             .unwrap();
         v8::Global::new(scope, promise)
     };

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -228,20 +228,12 @@ impl RpcService {
         // Do this before any permanent changes to any of the databases. Otherwise
         // we end up with bad code commited to the meta database and will fail to load
         // chiseld next time, as it tries to replenish the endpoints
-        for (path, code) in &endpoint_routes {
-            let cmd_path = path.clone();
-            let code = code.clone();
-            let cmd = send_command!({
-                let mut sources = HashMap::new();
-                sources.insert(cmd_path, code);
-                deno::compile_endpoints(sources).await?;
-                Ok(())
-            });
-            state
-                .send_command(cmd)
-                .await
-                .with_context(|| format!("parsing endpoint {}", path))?;
-        }
+        let endpoints = endpoint_routes.clone().into_iter().collect();
+        let cmd = send_command!({
+            deno::compile_endpoints(endpoints).await?;
+            Ok(())
+        });
+        state.send_command(cmd).await.context("parsing endpoints")?;
 
         anyhow::ensure!(
             "__chiselstrike" != &api_version,

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -232,7 +232,9 @@ impl RpcService {
             let cmd_path = path.clone();
             let code = code.clone();
             let cmd = send_command!({
-                deno::compile_endpoint(cmd_path, code).await?;
+                let mut sources = HashMap::new();
+                sources.insert(cmd_path, code);
+                deno::compile_endpoints(sources).await?;
                 Ok(())
             });
             state

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -9,7 +9,7 @@ use crate::deno::set_policies;
 use crate::deno::set_query_engine;
 use crate::deno::set_type_system;
 use crate::deno::update_secrets;
-use crate::deno::{activate_endpoint, compile_endpoint};
+use crate::deno::{activate_endpoint, compile_endpoints};
 use crate::rpc::{GlobalRpcState, RpcService};
 use crate::runtime;
 use crate::runtime::Runtime;
@@ -21,6 +21,7 @@ use deno_core::futures;
 use futures::future::LocalBoxFuture;
 use futures::FutureExt;
 use futures::StreamExt;
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::panic;
 use std::path::PathBuf;
@@ -119,7 +120,9 @@ pub(crate) async fn add_endpoint<S: AsRef<str>>(
 ) -> Result<()> {
     let path = path.as_ref();
 
-    compile_endpoint(path.to_string(), code).await?;
+    let mut sources = HashMap::new();
+    sources.insert(path.to_string(), code);
+    compile_endpoints(sources).await?;
     activate_endpoint(path).await?;
 
     let func = Arc::new({


### PR DESCRIPTION
I am changing the client to send all modules to the server. We don't know which modules are used by which endpoints, just that we have the union of all that is needed.

This PR then changes the server to process all endpoints at once as long as possible, in preparation for getting the auxiliary modules too.
