### PR TITLE
Fix clearing secrets

### DIFF
--- a/cli/tests/lit/secrets-update.deno
+++ b/cli/tests/lit/secrets-update.deno
@@ -22,3 +22,14 @@ echo '{ "secret" : 42 }' > ${TEMPDIR}/.env
 sleep 2.5
 $CURL -o - $CHISELD_HOST/dev/secret
 # CHECK: [42]
+
+# Restart so that these are the initial secrets
+$CHISEL restart
+$CURL -o - $CHISELD_HOST/dev/secret
+# CHECK: [42]
+
+# Test that we still clear the secrets on the periodic reread.
+echo '{ }' > ${TEMPDIR}/.env
+sleep 2.5
+$CURL -o - $CHISELD_HOST/dev/secret
+# CHECK: [undefined]

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -316,7 +316,6 @@ pub async fn run_shared_state(
     let secret_shutdown = signal_rx.clone();
     // Spawn periodic hot-reload of secrets.  This doesn't load secrets immediately, though.
     let _secret_reader = tokio::task::spawn(async move {
-        let mut last_secrets = JsonObject::default();
         loop {
             futures::select! {
                 _ = sleep(Duration::from_millis(1000)).fuse() => {},
@@ -326,13 +325,8 @@ pub async fn run_shared_state(
             };
 
             let secrets = read_secrets().await;
-            if secrets == last_secrets {
-                continue;
-            }
-            last_secrets = secrets;
-
             for cmd in &secret_commands {
-                let v = last_secrets.clone();
+                let v = secrets.clone();
                 let payload = send_command!({
                     update_secrets(v).await;
                     Ok(())


### PR DESCRIPTION
If reading secrets during startup, the last_secrets variable had the
wrong value since it was not aware of the initial secrets. This means
we would never clear the secrets, since last_secrets already thought
they were clear.

This simply removes the attempt at optimizing the secret reading
logic. We can add it back, but in read_secrets, where we can track all
reads, startup and periodic. Before adding it back I would like to see
if it this is actually expensive.