### PR TITLE
Fix filter extraction in chiselc

### DIFF
--- a/chiselc/src/transforms/utils.rs
+++ b/chiselc/src/transforms/utils.rs
@@ -86,6 +86,7 @@ pub fn extract_filter(
         }
         BlockStmtOrExpr::Expr(expr) => match &**expr {
             Expr::Bin(bin_expr) => convert_bin_expr(bin_expr),
+            Expr::Lit(Lit::Bool(value)) => Ok(QExpr::Literal(QLiteral::Bool(value.value))),
             _ => todo!("Unsupported filter predicate expression: {:?}", expr),
         },
     };

--- a/chiselc/src/transforms/utils.rs
+++ b/chiselc/src/transforms/utils.rs
@@ -72,21 +72,13 @@ pub fn extract_filter(
                 }
             };
             match &return_stmt.arg {
-                Some(expr) => match &**expr {
-                    Expr::Bin(bin_expr) => convert_bin_expr(bin_expr),
-                    Expr::Lit(Lit::Bool(value)) => Ok(QExpr::Literal(QLiteral::Bool(value.value))),
-                    _ => todo!("Unsupported filter predicate expression: {:?}", expr),
-                },
+                Some(expr) => convert_filter_expr(&**expr),
                 None => {
                     todo!();
                 }
             }
         }
-        BlockStmtOrExpr::Expr(expr) => match &**expr {
-            Expr::Bin(bin_expr) => convert_bin_expr(bin_expr),
-            Expr::Lit(Lit::Bool(value)) => Ok(QExpr::Literal(QLiteral::Bool(value.value))),
-            _ => todo!("Unsupported filter predicate expression: {:?}", expr),
-        },
+        BlockStmtOrExpr::Expr(expr) => convert_filter_expr(&**expr),
     };
     let expr = match expr {
         Ok(expr) => expr,
@@ -103,6 +95,14 @@ pub fn extract_filter(
     };
     let props = FilterProperties::from_filter(entity_type, &filter);
     (Some(Box::new(QOperator::Filter(filter))), props)
+}
+
+fn convert_filter_expr(expr: &Expr) -> Result<QExpr> {
+    match expr {
+        Expr::Bin(bin_expr) => convert_bin_expr(bin_expr),
+        Expr::Lit(Lit::Bool(value)) => Ok(QExpr::Literal(QLiteral::Bool(value.value))),
+        _ => todo!("Unsupported filter predicate expression: {:?}", expr),
+    }
 }
 
 pub fn convert_bin_expr(expr: &BinExpr) -> Result<QExpr> {

--- a/chiselc/src/transforms/utils.rs
+++ b/chiselc/src/transforms/utils.rs
@@ -75,9 +75,7 @@ pub fn extract_filter(
                 Some(expr) => match &**expr {
                     Expr::Bin(bin_expr) => convert_bin_expr(bin_expr),
                     Expr::Lit(Lit::Bool(value)) => Ok(QExpr::Literal(QLiteral::Bool(value.value))),
-                    _ => {
-                        todo!();
-                    }
+                    _ => todo!("Unsupported filter predicate expression: {:?}", expr),
                 },
                 None => {
                     todo!();

--- a/chiselc/tests/lit/transform-filter.lit
+++ b/chiselc/tests/lit/transform-filter.lit
@@ -264,5 +264,12 @@ await Person.cursor().filter(p => { return true; });
 // CHECK:     value: true
 // CHECK: });
 
+await Person.cursor().filter(p => true);
+// CHECK: await Person.cursor().__filterWithExpression((p)=>true
+// CHECK: , {
+// CHECK:     exprType: "Literal",
+// CHECK:     value: true
+// CHECK: });
+
 await Person.cursor().filter({});
 // CHECK: await Person.cursor().filter({})


### PR DESCRIPTION
A filter lambda can either be a block statement:

```typescript
Person.cursor().filter(person => { return person.age > 20 })
```

or an expression:

```typescript
Person.cursor().filter(person => person.age > 20)
```

However, extract_filter() has different code paths to handle them, which
has already resulted in a bug where a block statement that returns a
literal is handled, but an expression literal is not.

Fix the bug and add a test case for it, and then consolidate the
duplicate code paths to prevent future bugs.