### PR TITLE
api, chiselc: Rename __filterWithExpression() to __filter()

### DIFF
--- a/api/src/chisel.ts
+++ b/api/src/chisel.ts
@@ -356,7 +356,7 @@ export class ChiselCursor<T> {
     }
 
     // Filtering function used by Chisel Compiler. Not intended for direct usage.
-    __filterWithExpression(
+    __filter(
         predicate: (arg: T) => boolean,
         expression: Record<string, unknown>,
     ) {
@@ -697,7 +697,7 @@ export class ChiselEntity {
         expression: Record<string, unknown>,
         take?: number,
     ): Promise<T[]> {
-        let it = chiselIterator<T>(this).__filterWithExpression(
+        let it = chiselIterator<T>(this).__filter(
             predicate,
             expression,
         );
@@ -747,7 +747,7 @@ export class ChiselEntity {
         predicate: (arg: T) => boolean,
         expression: Record<string, unknown>,
     ): Promise<T | undefined> {
-        const it = chiselIterator<T>(this).__filterWithExpression(
+        const it = chiselIterator<T>(this).__filter(
             predicate,
             expression,
         );

--- a/chiselc/docs/query-expr.md
+++ b/chiselc/docs/query-expr.md
@@ -27,7 +27,7 @@ BlogPost.cursor().filter({
 
 ## Filtering
 
-The `ChiselCursor.filter(<predicate>)` method call is transformed into a `__filterWithExpression(<predicate>, <expression>)` method call where `<expression>` is an object that represents the query expression.
+The `ChiselCursor.filter(<predicate>)` method call is transformed into a `__filter(<predicate>, <expression>)` method call where `<expression>` is an object that represents the query expression.
 
 ## Query Expressions
 

--- a/chiselc/src/rewrite.rs
+++ b/chiselc/src/rewrite.rs
@@ -307,7 +307,7 @@ impl Rewriter {
         }
     }
 
-    /// Rewrites the filter() call with __filterWithExpression().
+    /// Rewrites the filter() call with __filter().
     fn rewrite_filter_callee(&self, callee: &Callee, function: &str) -> Callee {
         match callee {
             Callee::Expr(expr) => match &**expr {

--- a/chiselc/src/transforms/filter.rs
+++ b/chiselc/src/transforms/filter.rs
@@ -18,7 +18,7 @@ pub fn infer_filter(
         Ok(entity_type) => entity_type,
         _ => return (None, None),
     };
-    extract_filter(call_expr, entity_type, "__filterWithExpression".to_string())
+    extract_filter(call_expr, entity_type, "__filter".to_string())
 }
 
 fn is_rewritable_filter(callee: &Callee, symbols: &Symbols) -> bool {

--- a/chiselc/tests/lit/transform-filter.lit
+++ b/chiselc/tests/lit/transform-filter.lit
@@ -14,7 +14,7 @@ const main = async () => {
     }).toArray();
 };
 // CHECK: const main = async ()=>{
-// CHECK:     const people = await Person.cursor().__filterWithExpression((p)=>{
+// CHECK:     const people = await Person.cursor().__filter((p)=>{
 // CHECK:         return p.age > 4;
 // CHECK:     }, {
 // CHECK:         exprType: "Binary",
@@ -38,7 +38,7 @@ const people = await Person.cursor()
   .filter((p) => {
     return p.age > 4
   }).toArray();
-// CHECK: const people = await Person.cursor().__filterWithExpression((p)=>{
+// CHECK: const people = await Person.cursor().__filter((p)=>{
 // CHECK:     return p.age > 4;
 // CHECK: }, {
 // CHECK:     exprType: "Binary",
@@ -67,7 +67,7 @@ const people = await Person.cursor()
 // CHECK: }).toArray();
 
 await Person.cursor().filter((p) => { return p.age < 4 });
-// CHECK: await Person.cursor().__filterWithExpression((p)=>{
+// CHECK: await Person.cursor().__filter((p)=>{
 // CHECK:     return p.age < 4;
 // CHECK: }, {
 // CHECK:    exprType: "Binary",
@@ -87,7 +87,7 @@ await Person.cursor().filter((p) => { return p.age < 4 });
 // CHECK: });
 
 await Person.cursor().filter((p) => { return p.age > 4 });
-// CHECK: await Person.cursor().__filterWithExpression((p)=>{
+// CHECK: await Person.cursor().__filter((p)=>{
 // CHECK:     return p.age > 4;
 // CHECK: }, {
 // CHECK:     exprType: "Binary",
@@ -107,7 +107,7 @@ await Person.cursor().filter((p) => { return p.age > 4 });
 // CHECK: });
 
 await Person.cursor().filter((p) => { return p.age <= 4 });
-// CHECK: await Person.cursor().__filterWithExpression((p)=>{
+// CHECK: await Person.cursor().__filter((p)=>{
 // CHECK:     return p.age <= 4;
 // CHECK: }, {
 // CHECK:     exprType: "Binary",
@@ -127,7 +127,7 @@ await Person.cursor().filter((p) => { return p.age <= 4 });
 // CHECK: });
 
 await Person.cursor().filter((p) => { return p.age != 4 });
-// CHECK: await Person.cursor().__filterWithExpression((p)=>{
+// CHECK: await Person.cursor().__filter((p)=>{
 // CHECK:     return p.age != 4;
 // CHECK: }, {
 // CHECK:     exprType: "Binary",
@@ -147,7 +147,7 @@ await Person.cursor().filter((p) => { return p.age != 4 });
 // CHECK: });
 
 await Person.cursor().filter((p) => p.age < 4);
-// CHECK: await Person.cursor().__filterWithExpression((p)=>p.age < 4
+// CHECK: await Person.cursor().__filter((p)=>p.age < 4
 // CHECK: , {
 // CHECK:     exprType: "Binary",
 // CHECK:     left: {
@@ -166,7 +166,7 @@ await Person.cursor().filter((p) => p.age < 4);
 // CHECK: });
 
 await Person.cursor().filter((p) => { return p.age < 4 || (p.age > 10 && p.age != 12) });
-// CHECK: await Person.cursor().__filterWithExpression((p)=>{
+// CHECK: await Person.cursor().__filter((p)=>{
 // CHECK:     return p.age < 4 || (p.age > 10 && p.age != 12);
 // CHECK: }, {
 // CHECK:     exprType: "Binary",
@@ -226,7 +226,7 @@ await Person.cursor().filter((p) => { return p.age < 4 || (p.age > 10 && p.age !
 // CHECK: });
 
 await Person.cursor().filter((p) => { return p.name == 'Alice' })
-// CHECK: await Person.cursor().__filterWithExpression((p)=>{
+// CHECK: await Person.cursor().__filter((p)=>{
 // CHECK:     return p.name == 'Alice';
 // CHECK: }, {
 // CHECK:     exprType: "Binary",
@@ -257,7 +257,7 @@ await Person.cursor().filter((p) => { return foo(p) || (p.age > 10 && p.age != 1
 // CHECK: });
 
 await Person.cursor().filter(p => { return true; });
-// CHECK: await Person.cursor().__filterWithExpression((p)=>{
+// CHECK: await Person.cursor().__filter((p)=>{
 // CHECK:     return true;
 // CHECK: }, {
 // CHECK:     exprType: "Literal",
@@ -265,7 +265,7 @@ await Person.cursor().filter(p => { return true; });
 // CHECK: });
 
 await Person.cursor().filter(p => true);
-// CHECK: await Person.cursor().__filterWithExpression((p)=>true
+// CHECK: await Person.cursor().__filter((p)=>true
 // CHECK: , {
 // CHECK:     exprType: "Literal",
 // CHECK:     value: true

--- a/cli/tests/lit/filter-with-predicate.deno
+++ b/cli/tests/lit/filter-with-predicate.deno
@@ -287,7 +287,7 @@ import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
     const filtered = Person.cursor()
-        .__filterWithExpression((p) => {
+        .__filter((p) => {
             return p.age == 89;
         }, {
             exprType: "Binary",
@@ -325,7 +325,7 @@ import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
     const filtered = Person.cursor()
-        .__filterWithExpression((p) => {
+        .__filter((p) => {
             return p.biography.title == "The importance of being erinaceous";
         }, {
             exprType: "Binary",
@@ -367,7 +367,7 @@ import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
     const filtered = Person.cursor()
-        .__filterWithExpression((p) => {
+        .__filter((p) => {
             return p.age == 89;
         }, {
             exprType: "Binary",
@@ -405,7 +405,7 @@ import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
     const filtered = Person.cursor()
-        .__filterWithExpression((p) => {
+        .__filter((p) => {
             return p.biography.title == "The importance of being erinaceous";
         }, {
             exprType: "Binary",
@@ -450,7 +450,7 @@ export default async function chisel(req: Request) {
     const all = url.searchParams.get("return_all") == "true";
     console.log(url.searchParams.get("return_all"), all);
     const filtered = Person.cursor()
-        .__filterWithExpression((p) => {
+        .__filter((p) => {
             return all;
         }, {
             exprType: "Literal",


### PR DESCRIPTION
We have __findMany() and findOne() as the other internal function names
so rename __filterWithExpression() to __filter() for consistency and
brevity.