### PR TITLE
Update our docs to cover paging.

### DIFF
--- a/docusaurus/docs/InDepth/pol.md
+++ b/docusaurus/docs/InDepth/pol.md
@@ -17,7 +17,7 @@ transformed like this whenever it is accessed".
 
 Let's first examine more precisely how you define which data we're
 talking about.  This is done using _labels_: TypeScript decorators on
-the fields of your models.  
+the fields of your models.
 
 For instance, suppose we have a BlogComment object defined and add the "labels"
 decorator as shown below:
@@ -68,29 +68,31 @@ curl -s localhost:8080/dev/comments
 
 The `curl` command reports:
 
-```console
-[
-    {
-        "id": "a4ca3ab3-2e26-4da6-a5de-418c1e6b9b83",
-        "content": "First comment",
-        "by": "xxxxx"
-    },
-    {
-        "id": "fed312d7-b36b-4f34-bb04-fba327a3f440",
-        "content": "Second comment",
-        "by": "xxxxx"
-    },
-    {
-        "id": "adc89862-dfaa-43ab-a639-477111afc55e",
-        "content": "Third comment",
-        "by": "xxxxx"
-    },
-    {
-        "id": "5bfef47e-371b-44e8-a2dd-88260b5c3f2c",
-        "content": "Fourth comment",
-        "by": "xxxxx"
-    }
-]
+```json
+{
+    "results": [
+        {
+            "id": "a4ca3ab3-2e26-4da6-a5de-418c1e6b9b83",
+            "content": "First comment",
+            "by": "xxxxx"
+        },
+        {
+            "id": "fed312d7-b36b-4f34-bb04-fba327a3f440",
+            "content": "Second comment",
+            "by": "xxxxx"
+        },
+        {
+            "id": "adc89862-dfaa-43ab-a639-477111afc55e",
+            "content": "Third comment",
+            "by": "xxxxx"
+        },
+        {
+            "id": "5bfef47e-371b-44e8-a2dd-88260b5c3f2c",
+            "content": "Fourth comment",
+            "by": "xxxxx"
+        }
+    ]
+}
 ```
 
 The `pii` fields were anonymized!  It is not possible for any
@@ -124,29 +126,31 @@ curl -s localhost:8080/dev/comments
 
 The `curl` command reports:
 
-```console
-[
-    {
-        "id": "a4ca3ab3-2e26-4da6-a5de-418c1e6b9b83",
-        "content": "First comment",
-        "by": "Jill"
-    },
-    {
-        "id": "fed312d7-b36b-4f34-bb04-fba327a3f440",
-        "content": "Second comment",
-        "by": "Jack"
-    },
-    {
-        "id": "adc89862-dfaa-43ab-a639-477111afc55e",
-        "content": "Third comment",
-        "by": "Jim"
-    },
-    {
-        "id": "5bfef47e-371b-44e8-a2dd-88260b5c3f2c",
-        "content": "Fourth comment",
-        "by": "Jack"
-    }
-]
+```json
+{
+    "results": [
+        {
+            "id": "a4ca3ab3-2e26-4da6-a5de-418c1e6b9b83",
+            "content": "First comment",
+            "by": "Jill"
+        },
+        {
+            "id": "fed312d7-b36b-4f34-bb04-fba327a3f440",
+            "content": "Second comment",
+            "by": "Jack"
+        },
+        {
+            "id": "adc89862-dfaa-43ab-a639-477111afc55e",
+            "content": "Third comment",
+            "by": "Jim"
+        },
+        {
+            "id": "5bfef47e-371b-44e8-a2dd-88260b5c3f2c",
+            "content": "Fourth comment",
+            "by": "Jack"
+        }
+    ]
+}
 ```
 
 As you can see, this endpoint now operates with the raw, untransformed

--- a/docusaurus/docs/Intro/first.md
+++ b/docusaurus/docs/Intro/first.md
@@ -224,38 +224,41 @@ curl localhost:8080/dev/comments
 ```
 
 ```json
-[
-  {
-    "id": "a4ca3ab3-2e26-4da6-a5de-418c1e6b9b83",
-    "content": "First comment",
-    "by": "Jill"
-  },
-  {
-    "id": "fed312d7-b36b-4f34-bb04-fba327a3f440",
-    "content": "Second comment",
-    "by": "Jack"
-  },
-  {
-    "id": "adc89862-dfaa-43ab-a639-477111afc55e",
-    "content": "Third comment",
-    "by": "Jim"
-  },
-  {
-    "id": "5bfef47e-371b-44e8-a2dd-88260b5c3f2c",
-    "content": "Fourth comment",
-    "by": "Jack"
-  },
-  {
-    "id": "d419e629-4304-44d5-b534-9ce446f25e9d",
-    "content": "Wrong comment",
-    "by": "Author"
-  }
-]
+{
+  "results": [
+    {
+      "id": "a4ca3ab3-2e26-4da6-a5de-418c1e6b9b83",
+      "content": "First comment",
+      "by": "Jill"
+    },
+    {
+      "id": "fed312d7-b36b-4f34-bb04-fba327a3f440",
+      "content": "Second comment",
+      "by": "Jack"
+    },
+    {
+      "id": "adc89862-dfaa-43ab-a639-477111afc55e",
+      "content": "Third comment",
+      "by": "Jim"
+    },
+    {
+      "id": "5bfef47e-371b-44e8-a2dd-88260b5c3f2c",
+      "content": "Fourth comment",
+      "by": "Jack"
+    },
+    {
+      "id": "d419e629-4304-44d5-b534-9ce446f25e9d",
+      "content": "Wrong comment",
+      "by": "Author"
+    }
+  ]
+}
 ```
 
 ...note:
 Obviously, If we had 10,000 blog responses we wouldn't want to return them all at once.
-Pagination support for collections of large objects will be coming very soon!
+For that reason, CRUD supports pagination. For further details, please refer to
+[paging docs](Intro/endpoints.md#crud-paging)
 ...
 
 To get a specific comment, we can specify an id in the URL:
@@ -281,33 +284,35 @@ curl -g localhost:8080/dev/comments?.by=Jack
 ```
 
 ```json
-[
-  {
-    "id": "fed312d7-b36b-4f34-bb04-fba327a3f440",
-    "content": "Second comment",
-    "by": "Jack"
-  },
-  {
-    "id": "5bfef47e-371b-44e8-a2dd-88260b5c3f2c",
-    "content": "Fourth comment",
-    "by": "Jack"
-  }
-]
+{
+  "results": [
+    {
+      "id": "fed312d7-b36b-4f34-bb04-fba327a3f440",
+      "content": "Second comment",
+      "by": "Jack"
+    },
+    {
+      "id": "5bfef47e-371b-44e8-a2dd-88260b5c3f2c",
+      "content": "Fourth comment",
+      "by": "Jack"
+    }
+  ]
+}
 ```
 
 will return all comments where field `by` is equal to `Jack`. Our api supports other comparison operators as well. For example
 `curl -g localhost:8080/dev/comments?.by~like=Ji%25` will in our example return all comments by Jim and Jill (`%25` is encoded wildcard `%`). We support the following comparators:
 
-| symbol      | Description |
-| ----------- | ----------- |
-|             | If no comparator is specified, the filter will check for equality |
-| ~ne         | Not equal |
-| ~lt         | Lower than |
-| ~lte        | Lower than or equal |
-| ~gt         | Greater than |
-| ~gte        | Greater than or equal |
-| ~like       | Like operator - supports the same syntax as SQL Like operator |
-| ~unlike    | Equivalent to SQL's NOT LIKE |
+| symbol  | Description                                                       |
+| ------- | ----------------------------------------------------------------- |
+|         | If no comparator is specified, the filter will check for equality |
+| ~ne     | Not equal                                                         |
+| ~lt     | Lower than                                                        |
+| ~lte    | Lower than or equal                                               |
+| ~gt     | Greater than                                                      |
+| ~gte    | Greater than or equal                                             |
+| ~like   | Like operator - supports the same syntax as SQL Like operator     |
+| ~unlike | Equivalent to SQL's NOT LIKE                                      |
 
 Relationships are supported as well. Imagine that Comments's field `by` would be of type `Person` which would have a field `age`. In such a scenario, to get all comments that were written byt authors under 40 and are named John, we would do:
 
@@ -321,33 +326,35 @@ curl -g localhost:8080/dev/comments?sort=-by
 ```
 
 ```json
-[
-  {
-    "id": "adc89862-dfaa-43ab-a639-477111afc55e",
-    "content": "Third comment",
-    "by": "Jim"
-  },
-  {
-    "id": "a4ca3ab3-2e26-4da6-a5de-418c1e6b9b83",
-    "content": "First comment",
-    "by": "Jill"
-  },
-  {
-    "id": "5bfef47e-371b-44e8-a2dd-88260b5c3f2c",
-    "content": "Fourth comment",
-    "by": "Jack"
-  },
-  {
-    "id": "fed312d7-b36b-4f34-bb04-fba327a3f440",
-    "content": "Second comment",
-    "by": "Jack"
-  },
-  {
-    "id": "d419e629-4304-44d5-b534-9ce446f25e9d",
-    "content": "Wrong comment",
-    "by": "Author"
-  }
-]
+{
+  "results": [
+    {
+      "id": "adc89862-dfaa-43ab-a639-477111afc55e",
+      "content": "Third comment",
+      "by": "Jim"
+    },
+    {
+      "id": "a4ca3ab3-2e26-4da6-a5de-418c1e6b9b83",
+      "content": "First comment",
+      "by": "Jill"
+    },
+    {
+      "id": "5bfef47e-371b-44e8-a2dd-88260b5c3f2c",
+      "content": "Fourth comment",
+      "by": "Jack"
+    },
+    {
+      "id": "fed312d7-b36b-4f34-bb04-fba327a3f440",
+      "content": "Second comment",
+      "by": "Jack"
+    },
+    {
+      "id": "d419e629-4304-44d5-b534-9ce446f25e9d",
+      "content": "Wrong comment",
+      "by": "Author"
+    }
+  ]
+}
 ```
 
 Note the minus `-` sign in front of the field name `by`. It signifies a descending sort ordering.
@@ -363,23 +370,25 @@ curl -g localhost:8080/dev/comments?sort=by&limit=3
 ```
 
 ```json
-[
+{
+  "results": [
     {
-    "id": "d419e629-4304-44d5-b534-9ce446f25e9d",
-    "content": "Wrong comment",
-    "by": "Author"
-  },
-  {
-    "id": "fed312d7-b36b-4f34-bb04-fba327a3f440",
-    "content": "Second comment",
-    "by": "Jack"
-  },
+      "id": "d419e629-4304-44d5-b534-9ce446f25e9d",
+      "content": "Wrong comment",
+      "by": "Author"
+    },
     {
-    "id": "5bfef47e-371b-44e8-a2dd-88260b5c3f2c",
-    "content": "Fourth comment",
-    "by": "Jack"
-  },
-]
+      "id": "fed312d7-b36b-4f34-bb04-fba327a3f440",
+      "content": "Second comment",
+      "by": "Jack"
+    },
+      {
+      "id": "5bfef47e-371b-44e8-a2dd-88260b5c3f2c",
+      "content": "Fourth comment",
+      "by": "Jack"
+    },
+  ]
+}
 ```
 
 To skip the first `n` elements, you can use the `offset` parameter:
@@ -388,13 +397,15 @@ curl -g localhost:8080/dev/comments?sort=by&offset=4
 ```
 
 ```json
-[
-  {
-    "id": "adc89862-dfaa-43ab-a639-477111afc55e",
-    "content": "Third comment",
-    "by": "Jim"
-  },
-]
+{
+  "results": [
+    {
+      "id": "adc89862-dfaa-43ab-a639-477111afc55e",
+      "content": "Third comment",
+      "by": "Jim"
+    },
+  ]
+}
 ```
 
 ...note:


### PR DESCRIPTION
This PR adds coverage of paging to our docs and modifies all examples to reflect the fact that CRUD response has been changed from `[...]` to `{"results": [...]}`.

closes https://github.com/chiselstrike/chiselstrike/issues/1204
closes https://github.com/chiselstrike/chiselstrike/issues/610 