### PR TITLE
Add a missing test

### DIFF
--- a/cli/tests/lit/duplicated.deno
+++ b/cli/tests/lit/duplicated.deno
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com>
+
+# RUN: sh -e @file
+
+cat << EOF > "$TEMPDIR/endpoints/foo.ts"
+export default async function chisel(req: Request) {
+    return new Response("");
+}
+EOF
+
+cat << EOF > "$TEMPDIR/endpoints/foo.js"
+export default async function chisel(req) {
+    return new Response("");
+}
+EOF
+
+cd "$TEMPDIR"
+$CHISEL apply 2>&1 || true
+
+# CHECK: Error: Cannot add both endpoints/foo.js endpoints/foo.ts as routes. ChiselStrike uses filesystem-based routing, so we don't know what to do. Sorry!


### PR DESCRIPTION
We were not testing that we reject files that map to the same endpoint
path.