### PR TITLE
tests: Fix CHECK in duplicated.deno

### DIFF
--- a/cli/tests/lit/duplicated.deno
+++ b/cli/tests/lit/duplicated.deno
@@ -17,4 +17,4 @@ EOF
 cd "$TEMPDIR"
 $CHISEL apply 2>&1 || true
 
-# CHECK: Error: Cannot add both endpoints/foo.js endpoints/foo.ts as routes. ChiselStrike uses filesystem-based routing, so we don't know what to do. Sorry!
+# CHECK: Error: Cannot add both endpoints/foo.[[[jt]s]] endpoints/foo.[[[jt]s]] as routes. ChiselStrike uses filesystem-based routing, so we don't know what to do. Sorry!


### PR DESCRIPTION
Filesystem does not guarantee an ordering on the files so use a regexp
in the CHECK to deal with filenames appearing in different order.