### PR TITLE
Export less from the server lib

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -5,7 +5,6 @@ extern crate log;
 
 use anyhow::Result;
 use chisel_server::server;
-use enclose::enclose;
 use env_logger::Env;
 use log::LevelFilter;
 use nix::unistd::execv;
@@ -17,8 +16,6 @@ use structopt::StructOpt;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let mut executors = vec![];
-
     env_logger::Builder::from_env(Env::default().default_filter_or("info"))
         .format(|buf, record| {
             writeln!(
@@ -33,28 +30,9 @@ async fn main() -> Result<()> {
         .init();
 
     let args: Vec<CString> = env::args().map(|x| CString::new(x).unwrap()).collect();
-    let (tasks, shared, mut commands) = server::run_shared_state(server::Opt::from_args()).await?;
     let exe = env::current_exe()?.into_os_string().into_string().unwrap();
 
-    for id in 0..shared.executor_threads() {
-        debug!("Starting executor {}", id);
-        let cmd = commands.pop().unwrap();
-        executors.push(std::thread::spawn(enclose! { (shared) move || {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(async {
-                    server::run_on_new_localset(shared, cmd).await
-                }).unwrap();
-        }}));
-    }
-
-    for ex in executors.drain(..) {
-        ex.join().unwrap();
-    }
-
-    if let DoRepeat::Yes = tasks.join().await? {
+    if let DoRepeat::Yes = server::run_all(server::Opt::from_args()).await? {
         info!("Restarting");
         execv(&CString::new(exe).unwrap(), &args).unwrap();
     }


### PR DESCRIPTION
This exports run_all instead of run_shared_state and
run_on_new_localset, which lets us hide a lot of types.