### PR TITLE
Drop EndPointCreationRequest

### DIFF
--- a/cli/src/cmd/apply.rs
+++ b/cli/src/cmd/apply.rs
@@ -140,7 +140,7 @@ pub(crate) async fn apply<S: ToString>(
         client
             .apply(tonic::Request::new(ChiselApplyRequest {
                 types: types_req,
-                endpoints: endpoints_req,
+                sources: endpoints_req,
                 index_candidates: index_candidates_req,
                 policies: policy_req,
                 allow_type_deletion: allow_type_deletion.into(),

--- a/cli/src/cmd/apply/deno.rs
+++ b/cli/src/cmd/apply/deno.rs
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
-use crate::chisel::{EndPointCreationRequest, IndexCandidate};
+use crate::chisel::IndexCandidate;
 use crate::cmd::apply::chiselc_output;
 use crate::cmd::apply::parse_indexes;
 use anyhow::{anyhow, Context, Result};
 use compile::compile_ts_code as swc_compile;
 use endpoint_tsc::compile_endpoints;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 pub(crate) async fn apply(
@@ -14,8 +15,8 @@ pub(crate) async fn apply(
     types_string: &str,
     optimize: bool,
     auto_index: bool,
-) -> Result<(Vec<EndPointCreationRequest>, Vec<IndexCandidate>)> {
-    let mut endpoints_req = vec![];
+) -> Result<(HashMap<String, String>, Vec<IndexCandidate>)> {
+    let mut endpoints_req = HashMap::new();
     let mut index_candidates_req = vec![];
     let paths: Result<Vec<_>> = endpoints
         .iter()
@@ -33,10 +34,7 @@ pub(crate) async fn apply(
         } else {
             swc_compile(code)?
         };
-        endpoints_req.push(EndPointCreationRequest {
-            path: f.display().to_string(),
-            code: code.clone(),
-        });
+        endpoints_req.insert(f.display().to_string(), code.clone());
         if auto_index {
             let mut indexes = parse_indexes(code.clone(), entities)?;
             index_candidates_req.append(&mut indexes);

--- a/cli/src/cmd/apply/node.rs
+++ b/cli/src/cmd/apply/node.rs
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
-use crate::chisel::{EndPointCreationRequest, IndexCandidate};
+use crate::chisel::IndexCandidate;
 use crate::cmd::apply::chiselc_spawn;
 use crate::cmd::apply::parse_indexes;
 use crate::cmd::apply::TypeChecking;
 use crate::project::read_to_string;
 use anyhow::{anyhow, Context, Result};
+use std::collections::HashMap;
 use std::env;
 use std::fs::{self};
 use std::io::Write;
@@ -19,8 +20,8 @@ pub(crate) async fn apply(
     optimize: bool,
     auto_index: bool,
     type_check: &TypeChecking,
-) -> Result<(Vec<EndPointCreationRequest>, Vec<IndexCandidate>)> {
-    let mut endpoints_req = vec![];
+) -> Result<(HashMap<String, String>, Vec<IndexCandidate>)> {
+    let mut endpoints_req = HashMap::new();
     let mut index_candidates_req = vec![];
     let tsc = match type_check {
         TypeChecking::Yes => Some(npx(
@@ -118,10 +119,7 @@ pub(crate) async fn apply(
         }
         let code = read_to_string(bundler_output_file)?;
 
-        endpoints_req.push(EndPointCreationRequest {
-            path: endpoint.display().to_string(),
-            code,
-        });
+        endpoints_req.insert(endpoint.display().to_string(), code);
         if auto_index {
             let code = read_to_string(endpoint_file_path.clone())?;
             let mut indexes = parse_indexes(code, entities)?;

--- a/proto/chisel.proto
+++ b/proto/chisel.proto
@@ -55,11 +55,6 @@ message DescribeResponse {
   repeated VersionDefinition version_defs = 1;
 }
 
-message EndPointCreationRequest {
-  string path = 1;
-  string code = 2;
-}
-
 message RestartRequest { }
 
 message RestartResponse {
@@ -73,7 +68,12 @@ message PolicyUpdateRequest {
 message ChiselApplyRequest {
    repeated AddTypeRequest types = 1;
    repeated IndexCandidate index_candidates = 8;
-   repeated EndPointCreationRequest endpoints = 2;
+
+   // Location to code map. Includes all modules compiled into JS. The
+   // endpoints themselves start with "endpoints/"
+   // FIXME: It is missing non-endpoints for now.
+   map<string, string> sources = 2;
+
    repeated PolicyUpdateRequest policies = 3;
    bool allow_type_deletion = 4;
    string version = 5;

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -221,11 +221,11 @@ impl RpcService {
         let api_info = ApiInfo::new(app_name, api_version_tag);
 
         let mut endpoint_routes = vec![];
-        for endpoint in apply_request.endpoints {
-            let path = without_extension(&endpoint.path);
+        for (path, code) in apply_request.sources {
+            let path = without_extension(&path);
             let name = path.strip_prefix("endpoints/").unwrap();
             let path = format!("/{}/{}", api_version, name);
-            endpoint_routes.push((path, endpoint.code));
+            endpoint_routes.push((path, code));
         }
         endpoint_routes.sort_unstable();
 


### PR DESCRIPTION
The apply request has a map of sources instead. For now only the
sources of the endpoints, but more will be added soon.