### PR TITLE
chiselc: Fix find{One,Many} filter splitting

### DIFF
--- a/chiselc/tests/lit/filter_splitting/filter-with-side-effects-return.lit
+++ b/chiselc/tests/lit/filter_splitting/filter-with-side-effects-return.lit
@@ -20,6 +20,6 @@ Person.cursor().filter(person => { return person.age > 40 && fetch("foobar"); })
 // CHECK:         exprType: "Literal",
 // CHECK:         value: 40
 // CHECK:     }
-// CHECK: }).filter((person)=>{
+// CHECK: }, (person)=>{
 // CHECK:     return fetch("foobar");
 // CHECK: });

--- a/chiselc/tests/lit/filter_splitting/filter-with-side-effects.lit
+++ b/chiselc/tests/lit/filter_splitting/filter-with-side-effects.lit
@@ -19,7 +19,7 @@ Person.cursor().filter(person => person.age > 40 && fetch("foobar"))
 // CHECK:         exprType: "Literal",
 // CHECK:         value: 40
 // CHECK:     }
-// CHECK: }).filter((person)=>fetch("foobar")
+// CHECK: }, (person)=>fetch("foobar")
 // CHECK: );
 
 Person.cursor().filter(person => person.name == "Glauber Costa" && person.age > 40 && validate(person));
@@ -60,5 +60,5 @@ Person.cursor().filter(person => person.name == "Glauber Costa" && person.age > 
 // CHECK:             value: 40
 // CHECK:         }
 // CHECK:     }
-// CHECK: }).filter((person)=>validate(person)
+// CHECK: }, (person)=>validate(person)
 // CHECK: );

--- a/chiselc/tests/lit/filter_splitting/findone.ts
+++ b/chiselc/tests/lit/filter_splitting/findone.ts
@@ -1,0 +1,23 @@
+// Test splitting a findOne filter with side-effects.
+// RUN: @chiselc @file -e Person
+
+Person.findOne(person => person.name == "Glauber Costa" && validate(person));
+
+// CHECK: Person.__findOne((person)=>person.name == "Glauber Costa"
+// CHECK: , {
+// CHECK:     exprType: "Binary",
+// CHECK:     left: {
+// CHECK:         exprType: "Property",
+// CHECK:         object: {
+// CHECK:             exprType: "Parameter",
+// CHECK:             position: 0
+// CHECK:         },
+// CHECK:         property: "name"
+// CHECK:     },
+// CHECK:     op: "Eq",
+// CHECK:     right: {
+// CHECK:         exprType: "Literal",
+// CHECK:         value: "Glauber Costa"
+// CHECK:     }
+// CHECK: }, (person)=>validate(person)
+// CHECK: );

--- a/cli/tests/lit/entity-findone-filter.deno
+++ b/cli/tests/lit/entity-findone-filter.deno
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
+
+# RUN: sh -e @file
+
+cd "$TEMPDIR"
+
+cat << EOF > "$TEMPDIR/models/user.ts"
+import { ChiselEntity } from "@chiselstrike/api";
+
+export class User extends ChiselEntity {
+    username: string = "";
+}
+EOF
+
+cat << EOF > "$TEMPDIR/endpoints/entity-methods.ts"
+import { User } from "../models/user.ts";
+
+function validate(user: User): boolean {
+    return true;
+}
+
+export default async function (req: Request): Promise<Response> {
+    await User.findOne(user => user.username == 'penberg' && validate(user));
+    return new Response("Ok");
+}
+EOF
+
+$CHISEL apply
+# CHECK: Model defined: User
+# CHECK: End point defined: /dev/entity-methods
+
+$CURL -X POST $CHISELD_HOST/dev/entity-methods
+# CHECK: Ok

--- a/cli/tests/lit/find.deno
+++ b/cli/tests/lit/find.deno
@@ -38,6 +38,7 @@ export default async function chisel(req: Request) {
                   value: first_name
                 }
             },
+            undefined,
             1
         );
     } else if (use_predicate) {


### PR DESCRIPTION
The `find{Many,One}` methods don't return a `ChiselCursor`, which is why
we can't chain an additional `filter`. Instead, change the internal
functions to take a third parameter -- postPredicate -- that contains
the part of a predicate that may have side-effects.

Bug spotted by Glauber.