### PR TITLE
Update url in tsc_compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,7 +897,7 @@ dependencies = [
  "swc_common",
  "swc_ecmascript",
  "text_lines",
- "url",
+ "url 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -934,7 +934,7 @@ dependencies = [
  "serde_json",
  "serde_v8",
  "sourcemap",
- "url",
+ "url 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "v8",
 ]
 
@@ -1014,7 +1014,7 @@ dependencies = [
  "serde",
  "serde_json",
  "termcolor",
- "url",
+ "url 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1032,7 +1032,7 @@ dependencies = [
  "fly-accept-encoding",
  "hyper",
  "mime",
- "percent-encoding",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf",
  "ring",
  "serde",
@@ -1599,7 +1599,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
- "percent-encoding",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "git+https://github.com/servo/rust-url.git?rev=e12d76a61add5bc09980599c738099feaacd1d0d#e12d76a61add5bc09980599c738099feaacd1d0d"
+dependencies = [
+ "percent-encoding 2.1.0 (git+https://github.com/servo/rust-url.git?rev=e12d76a61add5bc09980599c738099feaacd1d0d)",
 ]
 
 [[package]]
@@ -1846,7 +1854,7 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "url",
+ "url 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2148,6 +2156,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "git+https://github.com/servo/rust-url.git?rev=e12d76a61add5bc09980599c738099feaacd1d0d#e12d76a61add5bc09980599c738099feaacd1d0d"
+dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -3016,6 +3033,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "git+https://github.com/servo/rust-url.git?rev=e12d76a61add5bc09980599c738099feaacd1d0d#e12d76a61add5bc09980599c738099feaacd1d0d"
+
+[[package]]
 name = "pest"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3535,7 +3557,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mime",
- "percent-encoding",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite",
  "rustls 0.20.6",
  "rustls-pemfile 0.3.0",
@@ -3545,7 +3567,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.23.4",
  "tokio-util 0.6.9",
- "url",
+ "url 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3896,7 +3918,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
- "form_urlencoded",
+ "form_urlencoded 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa",
  "ryu",
  "serde",
@@ -3972,7 +3994,7 @@ dependencies = [
  "tonic-build",
  "tracing",
  "tsc_compile",
- "url",
+ "url 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils",
  "uuid 0.8.2",
  "vergen",
@@ -4119,7 +4141,7 @@ dependencies = [
  "rustc_version 0.2.3",
  "serde",
  "serde_json",
- "url",
+ "url 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4213,7 +4235,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "paste",
- "percent-encoding",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.5",
  "rustls 0.19.1",
  "serde",
@@ -4226,7 +4248,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tokio-stream",
- "url",
+ "url 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.4",
  "webpki-roots 0.21.1",
  "whoami",
@@ -4248,7 +4270,7 @@ dependencies = [
  "sqlx-core",
  "sqlx-rt",
  "syn 1.0.91",
- "url",
+ "url 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4392,7 +4414,7 @@ dependencies = [
  "swc_visit",
  "tracing",
  "unicode-width",
- "url",
+ "url 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4957,7 +4979,7 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-timeout",
- "percent-encoding",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project",
  "prost",
  "prost-derive",
@@ -5071,7 +5093,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "idna",
+ "idna 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnet",
  "lazy_static",
  "log",
@@ -5081,7 +5103,7 @@ dependencies = [
  "thiserror",
  "tinyvec",
  "tokio",
- "url",
+ "url 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5121,6 +5143,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tsc_compile_build",
+ "url 2.2.2 (git+https://github.com/servo/rust-url.git?rev=e12d76a61add5bc09980599c738099feaacd1d0d)",
  "utils",
 ]
 
@@ -5144,7 +5167,7 @@ dependencies = [
  "rustls 0.20.6",
  "sha-1 0.9.8",
  "thiserror",
- "url",
+ "url 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf-8",
  "webpki 0.22.0",
 ]
@@ -5290,11 +5313,21 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
- "form_urlencoded",
- "idna",
+ "form_urlencoded 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches",
- "percent-encoding",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
+]
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "git+https://github.com/servo/rust-url.git?rev=e12d76a61add5bc09980599c738099feaacd1d0d#e12d76a61add5bc09980599c738099feaacd1d0d"
+dependencies = [
+ "form_urlencoded 1.0.1 (git+https://github.com/servo/rust-url.git?rev=e12d76a61add5bc09980599c738099feaacd1d0d)",
+ "idna 0.2.3 (git+https://github.com/servo/rust-url.git?rev=e12d76a61add5bc09980599c738099feaacd1d0d)",
+ "percent-encoding 2.1.0 (git+https://github.com/servo/rust-url.git?rev=e12d76a61add5bc09980599c738099feaacd1d0d)",
 ]
 
 [[package]]
@@ -5307,7 +5340,7 @@ dependencies = [
  "regex",
  "serde",
  "unic-ucd-ident",
- "url",
+ "url 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/tsc_compile/Cargo.toml
+++ b/tsc_compile/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 deno_core = { path = "../third_party/deno/core" }
 deno_graph = "0.26.0"
 tsc_compile_build = { path = "../tsc_compile_build" }
+url = { git = "https://github.com/servo/rust-url.git", rev = "e12d76a61add5bc09980599c738099feaacd1d0d" }
 utils = { path = "../utils" }
 
 [dev-dependencies]

--- a/tsc_compile/tests/relative_a/bar.ts
+++ b/tsc_compile/tests/relative_a/bar.ts
@@ -1,0 +1,3 @@
+import { Foo } from "../relative_b/bar.ts";
+export function foo(a: Foo) {
+}


### PR DESCRIPTION
This brings in a fix to make_relative as shown in the testcase. Once a
new version of url is released and we upgrade to a deno that uses it
we can drop this.