### PR TITLE
Add a missing test

### DIFF
--- a/cli/tests/lit/use-ts-moduled.deno
+++ b/cli/tests/lit/use-ts-moduled.deno
@@ -19,3 +19,10 @@ $CURL -o - $CHISELD_HOST/dev/pad
 
 # CHECK: HTTP/1.1 200 OK
 # CHECK: test    foo
+
+# Try again after a restart
+
+$CHISEL restart
+
+$CURL -o - $CHISELD_HOST/dev/pad
+# CHECK: test    foo


### PR DESCRIPTION
We were never testing that modules are available after a
restart. Currently we always download the modules, but will soon start
sending them from the client and we should check that they are not
lost on restart.