### PR TITLE
Enable tests in subdirectories

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -135,8 +135,8 @@ fn run_tests(opt: Opt, optimize: bool) -> bool {
         let path = Path::new("tests/lit").join(test_file);
         vec![std::fs::canonicalize(path).unwrap()]
     } else {
-        let deno_lits = glob::glob("tests/lit/*.deno").unwrap();
-        let node_lits = glob::glob("tests/lit/*.node").unwrap();
+        let deno_lits = glob::glob("tests/lit/**/*.deno").unwrap();
+        let node_lits = glob::glob("tests/lit/**/*.node").unwrap();
         deno_lits
             .chain(node_lits)
             .map(|path| std::fs::canonicalize(path.unwrap()).unwrap())


### PR DESCRIPTION
We were not running the tests in cli/tests/lit/cli