### PR TITLE
Restart on apply

### DIFF
--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -75,7 +75,7 @@ function importEndpoints(endpoints: [Endpoint]) {
 
 async function importEndpointsImpl(endpoints: [Endpoint]) {
     for (const endpoint of endpoints) {
-        const { path, apiVersion, version } = endpoint;
+        const { path, apiVersion } = endpoint;
 
         requestContext.path = path;
         const fullPath = "/" + apiVersion + path;
@@ -83,7 +83,7 @@ async function importEndpointsImpl(endpoints: [Endpoint]) {
         // Modules are never unloaded, so we need to create an unique
         // path. This will not be a problem once we publish the entire app
         // at once, since then we can create a new isolate for it.
-        const url = `file:///${apiVersion}/endpoints${path}?ver=${version}`;
+        const url = `file:///${apiVersion}/endpoints${path}`;
         const mod = await import(url);
         const handler = mod.default;
         if (typeof handler !== "function") {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -136,7 +136,7 @@ async fn populate(server_url: String, to_version: String, from_version: String) 
     Ok(())
 }
 
-async fn restart(server_url: String) -> Result<()> {
+pub(crate) async fn restart(server_url: String) -> Result<()> {
     let mut client = ChiselRpcClient::connect(server_url.clone()).await?;
     let response = execute!(client.restart(tonic::Request::new(RestartRequest {})).await);
     anyhow::ensure!(response.ok);


### PR DESCRIPTION
This solves the leak caused by never unloading old modules. It also avoids the somewhat surprising behavior that if `http://example.com/some/module.ts` is updated, we don't reload it until a restart. Last but not least, this opens the way to sending models as plain JS modules, which will fix https://github.com/chiselstrike/chiselstrike/issues/1201.