### PR TITLE
bump test license year

### DIFF
--- a/cli/tests/lit/cyclic-models.deno
+++ b/cli/tests/lit/cyclic-models.deno
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com>
+# SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
 # RUN: sh -e @file
 

--- a/cli/tests/lit/out-of-order-models.deno
+++ b/cli/tests/lit/out-of-order-models.deno
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com>
+# SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
 # RUN: sh -e @file
 


### PR DESCRIPTION
Update the license year for tests introduced by #1443. (c.f: (https://github.com/chiselstrike/chiselstrike/pull/1443#discussion_r901243110))
