### PR TITLE
Drop dummy .js suffix

### DIFF
--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -83,7 +83,7 @@ async function importEndpointsImpl(endpoints: [Endpoint]) {
         // Modules are never unloaded, so we need to create an unique
         // path. This will not be a problem once we publish the entire app
         // at once, since then we can create a new isolate for it.
-        const url = `file:///${apiVersion}/endpoints${path}.js?ver=${version}`;
+        const url = `file:///${apiVersion}/endpoints${path}?ver=${version}`;
         const mod = await import(url);
         const handler = mod.default;
         if (typeof handler !== "function") {

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -1471,7 +1471,7 @@ pub(crate) async fn compile_endpoints(sources: HashMap<String, String>) -> Resul
             let version = handle.versions.entry(path.clone());
             let version = *version.and_modify(|v| *v += 1).or_insert(0);
             let path = without_extension(&path);
-            let url = Url::parse(&format!("file://{}.js?ver={}", path, version)).unwrap();
+            let url = Url::parse(&format!("file://{}?ver={}", path, version)).unwrap();
             code_map.insert(url, code);
 
             let path = endpoint_path_from_source_path(path);


### PR DESCRIPTION
It was used to communicate if the downloaded file should be TSC
compiled or not. The server now never runs TSC, so drop it.