### PR TITLE
Fix FIXME and cast

### DIFF
--- a/api/src/chisel.ts
+++ b/api/src/chisel.ts
@@ -501,7 +501,7 @@ export class ChiselCursor<T> {
                         const properties = await opAsync(
                             "op_chisel_query_next",
                             rid,
-                        ) as T | null; // FIXME: This is wrong, we can get less than T with ColumnsSelect.
+                        );
 
                         if (properties === null) {
                             break;
@@ -511,7 +511,11 @@ export class ChiselCursor<T> {
                             Object.assign(result, properties);
                             yield result;
                         } else {
-                            yield properties;
+                            // This is the case where we have a
+                            // select, so T is a plain object, not a
+                            // ChiselEntity and op_chisel_query_next
+                            // set all the fields.
+                            yield properties as T;
                         }
                     }
                 } finally {


### PR DESCRIPTION
The FIXME was wrong. When we have a ColumnsSelect, T involves a
Pick<AnEntity, ...>. This means that it is a simple record and rust
has set all the properties.

The cast was wrong when there was no ColumnsSelect. In that case, T is
a base of ChiselEntity, which rust did not construct. We will
construct it using ctor.