### PR TITLE
Split eval ops recursive

### DIFF
--- a/api/src/chisel.ts
+++ b/api/src/chisel.ts
@@ -33,7 +33,7 @@ abstract class Operator<Input, Output> {
      */
     public abstract apply(
         iter: AsyncIterable<Input>,
-    ): AsyncIterable<unknown>;
+    ): AsyncIterable<Output>;
 
     /** Recursively examines operator chain searching for `ctor` operator.
      * Returns true if found, false otherwise.

--- a/api/src/chisel.ts
+++ b/api/src/chisel.ts
@@ -19,7 +19,7 @@ function opAsync(opName: string, a?: unknown, b?: unknown): Promise<unknown> {
  * The base class is generic so that the apply function type is
  * sound. Note that TypeScript *doesn't* check this.
  */
-abstract class Operator<T> {
+abstract class Operator<Input> {
     // Read by rust
     readonly type;
     constructor(
@@ -32,7 +32,7 @@ abstract class Operator<T> {
      * `iter` creating a new iterable.
      */
     public abstract apply(
-        iter: AsyncIterable<T>,
+        iter: AsyncIterable<Input>,
     ): AsyncIterable<unknown>;
 
     /** Recursively examines operator chain searching for `ctor` operator.


### PR DESCRIPTION
This makes the type assertions a lot easier to understand IMHO. It also improves type checking in the internal functions.