### PR TITLE
Make deno unstable API always available at compile time

### DIFF
--- a/api/src/endpoint.ts
+++ b/api/src/endpoint.ts
@@ -2,7 +2,6 @@
 
 /// <reference lib="deno.core" />
 /// <reference lib="dom" />
-/// <reference lib="deno.unstable" />
 
 const endpointWorker = new Worker("file:///worker.js", {
     type: "module",

--- a/tsc_compile_build/src/lib.rs
+++ b/tsc_compile_build/src/lib.rs
@@ -9,7 +9,6 @@ pub const JS_FILES: [(&str, &str); 2] = [
 pub fn read(path: &str) -> &'static str {
     if path == "bootstrap.ts" {
         return "/// <reference lib=\"deno.core\" />
-                   /// <reference lib=\"deno.unstable\" />
                   export {};";
     }
     if let Some(suffix) = path.strip_prefix("/default/lib/location/") {

--- a/tsc_compile_build/src/tsc.js
+++ b/tsc_compile_build/src/tsc.js
@@ -100,11 +100,11 @@
         // be the subset of deno that we want + our own chisel namespace.
         const defaultLibs = [
             "lib.deno.ns.d.ts",
-            "lib.dom.asynciterable.d.ts",
-            "lib.dom.iterable.d.ts",
-            "lib.dom.d.ts",
-            "lib.deno_console.d.ts",
             "lib.deno_broadcast_channel.d.ts",
+            "lib.deno_console.d.ts",
+            "lib.dom.asynciterable.d.ts",
+            "lib.dom.d.ts",
+            "lib.dom.iterable.d.ts",
             "lib.esnext.d.ts",
         ];
         if (lib !== undefined) {

--- a/tsc_compile_build/src/tsc.js
+++ b/tsc_compile_build/src/tsc.js
@@ -100,6 +100,7 @@
         // be the subset of deno that we want + our own chisel namespace.
         const defaultLibs = [
             "lib.deno.ns.d.ts",
+            "lib.deno.unstable.d.ts",
             "lib.deno_broadcast_channel.d.ts",
             "lib.deno_console.d.ts",
             "lib.dom.asynciterable.d.ts",


### PR DESCRIPTION
It was already optionally available, but https://deno.land/std@0.144.0/node/module.ts expects to be able to use it without an explicit reference.