### PR TITLE
Make type more flexible

### DIFF
--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -113,7 +113,7 @@ async function rollback_on_failure<T>(func: () => Promise<T>): Promise<T> {
 }
 
 function buildReadableStreamForBody(rid: number) {
-    return new ReadableStream<string>({
+    return new ReadableStream<Uint8Array>({
         async pull(controller: ReadableStreamDefaultController) {
             const chunk = await Deno.core.opAsync("op_chisel_read_body", rid);
             if (chunk) {


### PR DESCRIPTION
The BodyInit in lib.dom.d.ts accepts any ReadableStream. The one in
lib.deno_fetch.d.ts only `ReadableStream<Uint8Array>`.

This changes the code to use `ReadableStream<Uint8Array>` so that it
works with both. On the rust side, op_chisel_read_body returns
ZeroCopyBuf, so this is reasonable.