### PR TITLE
Make the window in worker hack more flexible

### DIFF
--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -6,7 +6,7 @@ import * as Chisel from "./chisel.ts";
 // Hack to pretend we are not in a web worker. On workers 'window'
 // doesn't exist, but globalThis does. They are not exactly the same,
 // so we need to force typescript to accept this.
-globalThis.window = globalThis as unknown as (Window & typeof globalThis);
+(globalThis as unknown as { window: unknown }).window = globalThis;
 
 Deno.core.opSync(
     "op_set_promise_reject_callback",


### PR DESCRIPTION
The new version doesn't depend on globalThis.window or the Window type
existing.

This makes it easier to change which .d.ts libraries we use.