### PR TITLE
Use a super long timeout

### DIFF
--- a/cli/src/server.rs
+++ b/cli/src/server.rs
@@ -75,7 +75,7 @@ async fn connect_with_retry(server_url: String) -> Result<ChiselRpcClient<Channe
 }
 
 // Timeout when waiting for connection or server status.
-const TIMEOUT: Duration = Duration::from_secs(10);
+const TIMEOUT: Duration = Duration::from_secs(120);
 
 pub(crate) async fn wait(server_url: String) -> Result<tonic::Response<StatusResponse>> {
     let client = connect_with_retry(server_url).await?;


### PR DESCRIPTION
We have been hitting timeouts in the bots and I have seen them locally
too.

Some operations, like collecting backtraces in debug builds, are
super slow, so it is not clear if we have a bug causes the server to
be stuck or we just need more time when the system is under load.

An indication that we might just need more time is that I never get a
timeout when running a test in isolation.