### PR TITLE
Remove lib dom

### DIFF
--- a/api/src/chisel.ts
+++ b/api/src/chisel.ts
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com>
 
 /// <reference lib="deno.core" />
-/// <reference lib="dom" />
-/// <reference lib="dom.iterable" />
 
 function opSync(opName: string, a?: unknown, b?: unknown): unknown {
     return Deno.core.opSync(opName, a, b);

--- a/api/src/endpoint.ts
+++ b/api/src/endpoint.ts
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com>
 
 /// <reference lib="deno.core" />
-/// <reference lib="dom" />
 
 const endpointWorker = new Worker("file:///worker.js", {
     type: "module",

--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
+/// <reference lib="deno.worker" />
+
 import * as Chisel from "./chisel.ts";
 (globalThis as unknown as { Chisel: unknown }).Chisel = Chisel;
 

--- a/tsc_compile_build/src/lib.rs
+++ b/tsc_compile_build/src/lib.rs
@@ -9,6 +9,7 @@ pub const JS_FILES: [(&str, &str); 2] = [
 pub fn read(path: &str) -> &'static str {
     if path == "bootstrap.ts" {
         return "/// <reference lib=\"deno.core\" />
+                /// <reference lib=\"deno.worker\" />
                   export {};";
     }
     if let Some(suffix) = path.strip_prefix("/default/lib/location/") {
@@ -67,10 +68,9 @@ pub fn read(path: &str) -> &'static str {
                 "lib.deno.shared_globals.d.ts",
                 "lib.deno.unstable.d.ts",
                 "lib.deno.window.d.ts",
+                "lib.deno.worker.d.ts",
                 "lib.dom.asynciterable.d.ts",
-                "lib.dom.d.ts",
                 "lib.dom.extras.d.ts",
-                "lib.dom.iterable.d.ts",
                 "lib.es2015.collection.d.ts",
                 "lib.es2015.core.d.ts",
                 "lib.es2015.d.ts",

--- a/tsc_compile_build/src/tsc.js
+++ b/tsc_compile_build/src/tsc.js
@@ -95,17 +95,14 @@
     const readCache = {};
     function compileAux(files, lib, emitDeclarations) {
         // FIXME: This is probably not exactly what we want. Deno uses
-        // deno.window. This is the subset of deno.window that is
-        // compatible with lib.dom.d.ts + lib.dom.d.ts. It should probably
-        // be the subset of deno that we want + our own chisel namespace.
+        // deno.window. We might have to do the same.
         const defaultLibs = [
             "lib.deno.ns.d.ts",
+            "lib.deno.shared_globals.d.ts",
             "lib.deno.unstable.d.ts",
             "lib.deno_broadcast_channel.d.ts",
             "lib.deno_console.d.ts",
             "lib.dom.asynciterable.d.ts",
-            "lib.dom.d.ts",
-            "lib.dom.iterable.d.ts",
             "lib.esnext.d.ts",
         ];
         if (lib !== undefined) {
@@ -179,6 +176,7 @@
         "deno.webgpu": "deno_webgpu",
         "deno.websocket": "deno_websocket",
         "deno.webstorage": "deno_webstorage",
+        "deno.worker": "deno.worker",
     };
 
     for (const k in libs) {


### PR DESCRIPTION
This is required for being able to import
https://deno.land/std@0.144.0/node/module.ts which requires
lib.deno_web.d.ts which conflicts with lib.dom.d.ts.
    
We also need to add deno.worker since it defines apis (also defined in
lib.dom.d.ts) used by worker.ts.