### PR TITLE
Use exactly the same libraries as deno cli

### DIFF
--- a/api/build.rs
+++ b/api/build.rs
@@ -7,12 +7,13 @@ use std::path::PathBuf;
 use tsc_compile::compile_ts_code;
 use tsc_compile::CompileOptions;
 
-async fn compile(stem: &str) -> Result<()> {
+async fn compile(stem: &str, is_worker: bool) -> Result<()> {
     let src = &format!("src/{}.ts", stem);
     println!("cargo:rerun-if-changed={}", src);
 
     let opts = CompileOptions {
         emit_declarations: true,
+        is_worker,
         ..Default::default()
     };
     let mut map = compile_ts_code(&[src], opts).await?;
@@ -33,8 +34,8 @@ async fn main() -> Result<()> {
     // should be the only rerun-if-changed that we need.
     println!("cargo:rerun-if-changed=../third_party/deno/core/lib.deno_core.d.ts");
 
-    compile("chisel").await?;
-    compile("endpoint").await?;
-    compile("worker").await?;
+    compile("chisel", false).await?;
+    compile("endpoint", false).await?;
+    compile("worker", true).await?;
     Ok(())
 }

--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -1,7 +1,5 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
-/// <reference lib="deno.worker" />
-
 import * as Chisel from "./chisel.ts";
 (globalThis as unknown as { Chisel: unknown }).Chisel = Chisel;
 

--- a/cli/tests/lit/node-std.deno
+++ b/cli/tests/lit/node-std.deno
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com>
+
+# RUN: sh -e @file
+
+cd "$TEMPDIR"
+
+cat << EOF > "$TEMPDIR/endpoints/foo.ts"
+import * as module from "https://deno.land/std@0.144.0/node/module.ts";
+
+export default async function (req: Request): Promise<Response> {
+    return new Response("Hello from foo");
+}
+EOF
+
+$CHISEL apply
+$CURL -o - "$CHISELD_HOST/dev/foo"
+# CHECK: Hello from foo

--- a/tsc_compile/src/lib.rs
+++ b/tsc_compile/src/lib.rs
@@ -197,6 +197,7 @@ pub struct CompileOptions<'a> {
     pub extra_default_lib: Option<&'a str>,
     pub extra_libs: HashMap<String, String>,
     pub emit_declarations: bool,
+    pub is_worker: bool,
 }
 
 struct ModuleLoader {
@@ -370,6 +371,7 @@ impl Compiler {
             let compile: v8::Local<v8::Function> =
                 get_member(global_proxy, scope, "compile").unwrap();
             let emit_declarations = v8::Boolean::new(scope, opts.emit_declarations).into();
+            let is_worker = v8::Boolean::new(scope, opts.is_worker).into();
 
             let urls: Vec<_> = urls
                 .iter()
@@ -377,7 +379,11 @@ impl Compiler {
                 .collect();
             let urls = v8::Array::new_with_elements(scope, &urls).into();
             compile
-                .call(scope, global_proxy.into(), &[urls, lib, emit_declarations])
+                .call(
+                    scope,
+                    global_proxy.into(),
+                    &[urls, is_worker, lib, emit_declarations],
+                )
                 .unwrap();
         }
 

--- a/tsc_compile_build/src/lib.rs
+++ b/tsc_compile_build/src/lib.rs
@@ -9,7 +9,6 @@ pub const JS_FILES: [(&str, &str); 2] = [
 pub fn read(path: &str) -> &'static str {
     if path == "bootstrap.ts" {
         return "/// <reference lib=\"deno.core\" />
-                /// <reference lib=\"deno.worker\" />
                   export {};";
     }
     if let Some(suffix) = path.strip_prefix("/default/lib/location/") {

--- a/tsc_compile_build/src/tsc.js
+++ b/tsc_compile_build/src/tsc.js
@@ -93,18 +93,15 @@
     };
 
     const readCache = {};
-    function compileAux(files, lib, emitDeclarations) {
-        // FIXME: This is probably not exactly what we want. Deno uses
-        // deno.window. We might have to do the same.
+    function compileAux(files, isWorker, lib, emitDeclarations) {
         const defaultLibs = [
-            "lib.deno.ns.d.ts",
-            "lib.deno.shared_globals.d.ts",
             "lib.deno.unstable.d.ts",
-            "lib.deno_broadcast_channel.d.ts",
-            "lib.deno_console.d.ts",
-            "lib.dom.asynciterable.d.ts",
-            "lib.esnext.d.ts",
         ];
+        if (isWorker) {
+            defaultLibs.push("lib.deno.worker.d.ts");
+        } else {
+            defaultLibs.push("lib.deno.window.d.ts");
+        }
         if (lib !== undefined) {
             defaultLibs.push(lib);
         }
@@ -150,9 +147,9 @@
         }
     }
 
-    function compile(files, lib, emitDeclarations) {
+    function compile(files, isWorker, lib, emitDeclarations) {
         try {
-            return compileAux(files, lib, emitDeclarations);
+            return compileAux(files, isWorker, lib, emitDeclarations);
         } catch (e) {
             Deno.core.opSync("diagnostic", e.stack + "\n");
             return false;
@@ -187,7 +184,8 @@
         }
     }
 
-    compile(["bootstrap.ts"], undefined, false);
+    compile(["bootstrap.ts"], false, undefined, false);
+    compile(["bootstrap.ts"], true, undefined, false);
 
     globalThis.compile = compile;
 })();


### PR DESCRIPTION
We can do this now that we don't use a stand alone tsc to process our
own files.
    
This allows us to import https://deno.land/std@0.144.0/node/module.ts
    
Fixes #761