### PR TITLE
trim wc output in test

### DIFF
--- a/cli/tests/lit/cli/describe.deno
+++ b/cli/tests/lit/cli/describe.deno
@@ -40,7 +40,7 @@ $CHISEL describe
 # CHECK: Endpoint: /dev/hello
 # CHECK: Label policy: pii
 
-echo "found $($CHISEL describe | grep Endpoint | wc -l) endpoints"
+echo "found $($CHISEL describe | grep Endpoint | wc -l | awk '{print $1}') endpoints"
 # CHECK: found 1 endpoints
 
 ## check that an endpoint-only scenario works


### PR DESCRIPTION
This pr trims the output of `wc -l` in the test `describe.deno`. The test was failing on macos, because its version of `sed` adds padding to the result.
