### PR TITLE
Install cargo tools in isolated path in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /node_modules
 .vscode
 *.code-workspace
+/.chisel_dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "lit 1.0.4 (git+https://github.com/chiselstrike/lit?rev=607b0b9)",
  "nix 0.22.3",
  "notify",
+ "once_cell",
  "prost",
  "rayon",
  "regex",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,6 +10,7 @@ endpoint_tsc = { path = "../endpoint_tsc" }
 handlebars = "4.2.2"
 nix = "0.22.2"
 notify = "5.0.0-pre.12"
+once_cell = "1.12.0"
 prost = "0.8.0"
 regex = "1.5.4"
 serde = "1.0.137"

--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::ffi::OsStr;
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use std::process;
@@ -28,7 +29,12 @@ impl DerefMut for Command {
 }
 
 #[allow(dead_code)]
-pub fn run_in<'a, T: IntoIterator<Item = &'a str>>(cmd: &str, args: T, dir: PathBuf) -> Command {
+pub fn run_in<'a, T: IntoIterator<Item = &'a str>>(
+    cmd: &str,
+    args: T,
+    dir: PathBuf,
+    path: Option<&OsStr>,
+) -> Command {
     assert!(
         dir.exists(),
         "{:?} does not exist. Current directory is {:?}",
@@ -38,12 +44,21 @@ pub fn run_in<'a, T: IntoIterator<Item = &'a str>>(cmd: &str, args: T, dir: Path
     assert!(dir.is_dir(), "{:?} is not a directory", dir);
     let mut inner = process::Command::new(cmd);
     inner.args(args).current_dir(dir);
+
+    if let Some(path) = path {
+        inner.env("PATH", path);
+    }
+
     Command { inner }
 }
 
 #[allow(dead_code)]
-pub fn run<'a, T: IntoIterator<Item = &'a str>>(cmd: &str, args: T) -> Command {
-    run_in(cmd, args, repo_dir())
+pub fn run<'a, T: IntoIterator<Item = &'a str>>(
+    cmd: &str,
+    args: T,
+    path: Option<&OsStr>,
+) -> Command {
+    run_in(cmd, args, repo_dir(), path)
 }
 
 #[allow(dead_code)]

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -75,7 +75,7 @@ fn chisel() -> String {
 fn main() {
     // install the current packages in our package.json. This will make things like esbuild
     // generally available. Tests that want a specific extra package can then install on top
-    run("npm", ["install"]);
+    run("npm", ["install"], None);
 
     let opt = Opt::from_args();
 
@@ -84,7 +84,7 @@ fn main() {
     if bd.ends_with("release") {
         args.push("--release");
     }
-    run("cargo", args);
+    run("cargo", args, None);
 
     let ok_without_optimization = run_tests(opt.clone(), false);
     let ok_with_optimization = run_tests(opt, true);

--- a/cli/tests/linters.rs
+++ b/cli/tests/linters.rs
@@ -10,7 +10,7 @@ mod tests {
     use toml::Value;
 
     fn cargo<'a, T: IntoIterator<Item = &'a str>>(args: T) -> Command {
-        run("cargo", args)
+        run("cargo", args, None)
     }
 
     fn nightly<'a, T: IntoIterator<Item = &'a str>>(args: T) -> Command {
@@ -33,8 +33,8 @@ mod tests {
 
     #[test]
     fn eslint() {
-        run("npm", ["install"]);
-        run("npx", ["eslint", ".", "--ext", ".ts"]);
+        run("npm", ["install"], None);
+        run("npx", ["eslint", ".", "--ext", ".ts"], None);
     }
 
     fn get_deno_version() -> String {
@@ -54,8 +54,8 @@ mod tests {
         // because that always reinstall the binary.
         let version = get_deno_version();
         cargo_install(&version, "deno", "deno");
-        run("deno", ["lint", "--config", "deno.json"]);
-        run("deno", ["fmt", "--config", "deno.json", "--check"]);
+        run("deno", ["lint", "--config", "deno.json"], None);
+        run("deno", ["fmt", "--config", "deno.json", "--check"], None);
     }
 
     #[test]


### PR DESCRIPTION
This PR makes the test install the cargo tool in a custom directory, so we don't mess with the developper rust environment.
