### PR TITLE
Always include deno.core

### DIFF
--- a/api/src/chisel.ts
+++ b/api/src/chisel.ts
@@ -1,7 +1,5 @@
 // SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com>
 
-/// <reference lib="deno.core" />
-
 function opSync(opName: string, a?: unknown, b?: unknown): unknown {
     return Deno.core.opSync(opName, a, b);
 }

--- a/api/src/endpoint.ts
+++ b/api/src/endpoint.ts
@@ -1,7 +1,5 @@
 // SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com>
 
-/// <reference lib="deno.core" />
-
 const endpointWorker = new Worker("file:///worker.js", {
     type: "module",
     name: "endpointWorker",

--- a/tsc_compile_build/src/lib.rs
+++ b/tsc_compile_build/src/lib.rs
@@ -8,8 +8,7 @@ pub const JS_FILES: [(&str, &str); 2] = [
 
 pub fn read(path: &str) -> &'static str {
     if path == "bootstrap.ts" {
-        return "/// <reference lib=\"deno.core\" />
-                  export {};";
+        return "export {};";
     }
     if let Some(suffix) = path.strip_prefix("/default/lib/location/") {
         macro_rules! inc_and_rerun {

--- a/tsc_compile_build/src/tsc.js
+++ b/tsc_compile_build/src/tsc.js
@@ -96,6 +96,7 @@
     function compileAux(files, isWorker, lib, emitDeclarations) {
         const defaultLibs = [
             "lib.deno.unstable.d.ts",
+            "lib.deno_core.d.ts",
         ];
         if (isWorker) {
             defaultLibs.push("lib.deno.worker.d.ts");


### PR DESCRIPTION
This makes Deno.core always available according to the compiler. It
was already always available at runtime.

Fixes #1232 by not explicitly referencing deno.core from code.