### PR TITLE
Non-recursive Type

### DIFF
--- a/server/src/datastore/crud.rs
+++ b/server/src/datastore/crud.rs
@@ -1,7 +1,7 @@
 use crate::datastore::engine::{QueryEngine, TransactionStatic};
 use crate::datastore::expr::{BinaryExpr, BinaryOp, Expr, Literal, PropertyAccess};
 use crate::datastore::query::{Mutation, QueryOp, QueryPlan, RequestContext, SortBy, SortKey};
-use crate::types::{Entity, Type};
+use crate::types::{Entity, Type, TypeSystem};
 use crate::JsonObject;
 use anyhow::{Context, Result};
 use deno_core::futures;
@@ -41,7 +41,7 @@ fn run_query_impl(
         .lookup_entity(&params.type_name, &context.api_version)
         .context("unexpected type name as crud query base type")?;
 
-    let query = Query::from_url(base_type, &params.url)?;
+    let query = Query::from_url(base_type, &params.url, context.ts)?;
     let ops = query.make_query_ops()?;
     let query_plan = QueryPlan::from_ops(context, base_type, ops)?;
     let stream = query_engine.query(tr.clone(), query_plan)?;
@@ -178,7 +178,7 @@ pub(crate) fn delete_from_url(c: &RequestContext, type_name: &str, url: &str) ->
         Ok(ty) => anyhow::bail!("Cannot delete scalar type {type_name} ({})", ty.name()),
         Err(_) => anyhow::bail!("Cannot delete from type `{type_name}`, type not found"),
     };
-    let filter_expr = url_to_filter(&base_entity, url)
+    let filter_expr = url_to_filter(&base_entity, url, c.ts)
         .context("failed to convert crud URL to filter expression")?;
     if filter_expr.is_none() {
         let q = Url::parse(url).with_context(|| format!("failed to parse query string '{url}'"))?;
@@ -219,7 +219,7 @@ impl Query {
     }
 
     /// Parses provided `url` and builds a `Query` that can be used to build a `QueryPlan`.
-    fn from_url(base_type: &Entity, url: &Url) -> Result<Self> {
+    fn from_url(base_type: &Entity, url: &Url, ts: &TypeSystem) -> Result<Self> {
         let mut q = Query::new();
         for (param_key, value) in url.query_pairs().into_owned() {
             match param_key.as_str() {
@@ -245,8 +245,8 @@ impl Query {
                 }
                 _ => {
                     if let Some(param_key) = param_key.strip_prefix('.') {
-                        let expr =
-                            filter_from_param(base_type, param_key, &value).with_context(|| {
+                        let expr = filter_from_param(base_type, param_key, &value, ts)
+                            .with_context(|| {
                                 format!("failed to parse filter {param_key}={value}")
                             })?;
                         q.filters.push(expr);
@@ -258,7 +258,7 @@ impl Query {
         ensure_sort_by_id(&mut q.sort);
         if let Some(cursor) = &q.cursor {
             q.sort = cursor.get_sort();
-            q.filters.push(cursor.get_filter(base_type)?);
+            q.filters.push(cursor.get_filter(base_type, ts)?);
         }
         Ok(q)
     }
@@ -353,7 +353,7 @@ impl Cursor {
     /// The crux of this function is using the sort axes (each axis represents one dimension
     /// in lexicographical sort) to create a filter that filters for entries that are after
     /// the last element in the given sort.
-    fn get_filter(&self, base_type: &Entity) -> Result<Expr> {
+    fn get_filter(&self, base_type: &Entity, ts: &TypeSystem) -> Result<Expr> {
         let mut cmp_pairs: Vec<(Expr, BinaryOp, Expr)> = vec![];
         for axis in &self.axes {
             let op = if axis.key.ascending == self.forward {
@@ -368,7 +368,7 @@ impl Cursor {
                 BinaryOp::Lt
             };
             let (property_chain, field_type) =
-                make_property_chain(base_type, &[&axis.key.field_name])?;
+                make_property_chain(base_type, &[&axis.key.field_name], ts)?;
             let literal = json_to_literal(&field_type, &axis.value)
                 .context("Failed to convert axis value to literal")?;
 
@@ -415,13 +415,13 @@ fn json_to_literal(field_type: &Type, value: &serde_json::Value) -> Result<Expr>
 }
 
 /// Parses all CRUD query-string filters over `base_type` from provided `url`.
-fn url_to_filter(base_type: &Entity, url: &str) -> Result<Option<Expr>> {
+fn url_to_filter(base_type: &Entity, url: &str, ts: &TypeSystem) -> Result<Option<Expr>> {
     let mut filter = None;
     let q = Url::parse(url).with_context(|| format!("failed to parse query string '{}'", url))?;
     for (param_key, value) in q.query_pairs().into_owned() {
         let param_key = param_key.to_string();
         if let Some(param_key) = param_key.strip_prefix('.') {
-            let expression = filter_from_param(base_type, param_key, &value)
+            let expression = filter_from_param(base_type, param_key, &value, ts)
                 .context("failed to parse filter")?;
 
             filter = filter
@@ -457,7 +457,12 @@ fn parse_sort(base_type: &Entity, value: &str) -> Result<SortBy> {
 }
 
 /// Constructs results filter by parsing query string's `param_key` and `value`.
-fn filter_from_param(base_type: &Entity, param_key: &str, value: &str) -> Result<Expr> {
+fn filter_from_param(
+    base_type: &Entity,
+    param_key: &str,
+    value: &str,
+    ts: &TypeSystem,
+) -> Result<Expr> {
     let tokens: Vec<_> = param_key.split('~').collect();
     anyhow::ensure!(
         tokens.len() <= 2,
@@ -468,7 +473,7 @@ fn filter_from_param(base_type: &Entity, param_key: &str, value: &str) -> Result
     let operator = tokens.get(1).copied();
     let operator = convert_operator(operator)?;
 
-    let (property_chain, field_type) = make_property_chain(base_type, &fields)?;
+    let (property_chain, field_type) = make_property_chain(base_type, &fields, ts)?;
 
     let err_msg = |ty_name| format!("failed to convert filter value '{}' to {}", value, ty_name);
     let literal = match field_type {
@@ -487,7 +492,11 @@ fn filter_from_param(base_type: &Entity, param_key: &str, value: &str) -> Result
 
 /// Converts `fields` of `base_type` into PropertyAccess expression while ensuring that
 /// provided fields are, in fact, applicable to `base_type`.
-fn make_property_chain(base_type: &Entity, fields: &[&str]) -> Result<(Expr, Type)> {
+fn make_property_chain(
+    base_type: &Entity,
+    fields: &[&str],
+    ts: &TypeSystem,
+) -> Result<(Expr, Type)> {
     anyhow::ensure!(
         !fields.is_empty(),
         "cannot make property chain from no fields"
@@ -497,7 +506,7 @@ fn make_property_chain(base_type: &Entity, fields: &[&str]) -> Result<(Expr, Typ
     for &field_str in fields {
         if let Type::Entity(entity) = last_type {
             if let Some(field) = entity.get_field(field_str) {
-                last_type = field.type_.clone();
+                last_type = ts.get(&field.type_id)?;
             } else {
                 anyhow::bail!(
                     "entity '{}' doesn't have field '{}'",
@@ -636,6 +645,7 @@ mod tests {
         )
     });
     static ENTITIES: Lazy<[Entity; 2]> = Lazy::new(|| [PERSON_TY.clone(), COMPANY_TY.clone()]);
+    static TYPE_SYSTEM: Lazy<TypeSystem> = Lazy::new(|| make_type_system(&*ENTITIES));
 
     #[test]
     fn test_replace_host_address() {
@@ -700,8 +710,9 @@ mod tests {
                 make_field("ceo", person_type.into()),
             ],
         );
-        let filter_expr =
-            |key: &str, value: &str| filter_from_param(&base_type, key, value).unwrap();
+        let filter_expr = |key: &str, value: &str| {
+            filter_from_param(&base_type, key, value, &TYPE_SYSTEM).unwrap()
+        };
         let ops = [
             (BinaryOp::Eq, ""),
             (BinaryOp::NotEq, "~ne"),
@@ -803,9 +814,9 @@ mod tests {
 
         let (query_engine, _db_file) = setup_clear_db(&*ENTITIES).await;
         let qe = &query_engine;
-        add_row(qe, &PERSON_TY, &alan).await;
-        add_row(qe, &PERSON_TY, &john).await;
-        add_row(qe, &PERSON_TY, &steve).await;
+        add_row(qe, &PERSON_TY, &alan, &TYPE_SYSTEM).await;
+        add_row(qe, &PERSON_TY, &john, &TYPE_SYSTEM).await;
+        add_row(qe, &PERSON_TY, &steve, &TYPE_SYSTEM).await;
 
         let mut r = run_query_vec("Person", url(""), qe).await;
         r.sort();
@@ -846,7 +857,7 @@ mod tests {
         assert_eq!(r, vec!["John", "Steve"]);
 
         let alex = json!({"name": "Alex", "age": json!(40f32)});
-        add_row(qe, &PERSON_TY, &alex).await;
+        add_row(qe, &PERSON_TY, &alex, &TYPE_SYSTEM).await;
         // Test permutations of parameters
         {
             let raw_ops = vec!["page_size=2", "offset=1", "sort=age"];
@@ -876,8 +887,8 @@ mod tests {
         let chiselstrike = json!({"name": "ChiselStrike", "ceo": john});
         let thunderstrike = json!({"name": "ThunderStrike", "ceo": alan});
         {
-            add_row(qe, &COMPANY_TY, &chiselstrike).await;
-            add_row(qe, &COMPANY_TY, &thunderstrike).await;
+            add_row(qe, &COMPANY_TY, &chiselstrike, &TYPE_SYSTEM).await;
+            add_row(qe, &COMPANY_TY, &thunderstrike, &TYPE_SYSTEM).await;
 
             let r = run_query_vec("Company", url(".ceo.age~lte=20"), qe).await;
             assert_eq!(r, vec!["ChiselStrike"]);
@@ -893,10 +904,10 @@ mod tests {
 
         let (query_engine, _db_file) = setup_clear_db(&*ENTITIES).await;
         let qe = &query_engine;
-        add_row(qe, &PERSON_TY, &alan).await;
-        add_row(qe, &PERSON_TY, &john).await;
-        add_row(qe, &PERSON_TY, &steve).await;
-        add_row(qe, &PERSON_TY, &alex).await;
+        add_row(qe, &PERSON_TY, &alan, &TYPE_SYSTEM).await;
+        add_row(qe, &PERSON_TY, &john, &TYPE_SYSTEM).await;
+        add_row(qe, &PERSON_TY, &steve, &TYPE_SYSTEM).await;
+        add_row(qe, &PERSON_TY, &alex, &TYPE_SYSTEM).await;
 
         fn get_url(raw: &serde_json::Value) -> Url {
             Url::parse(raw.as_str().unwrap()).unwrap()
@@ -1099,7 +1110,7 @@ mod tests {
         let alan = json!({"name": "Alan", "age": json!(30f32)});
         {
             let (qe, _db_file) = setup_clear_db(&*ENTITIES).await;
-            add_row(&qe, &PERSON_TY, &john).await;
+            add_row(&qe, &PERSON_TY, &john, &TYPE_SYSTEM).await;
 
             let mutation = delete_from_url("Person", &url(".name=John"));
             qe.mutate(mutation).await.unwrap();
@@ -1108,8 +1119,8 @@ mod tests {
         }
         {
             let (qe, _db_file) = setup_clear_db(&*ENTITIES).await;
-            add_row(&qe, &PERSON_TY, &john).await;
-            add_row(&qe, &PERSON_TY, &alan).await;
+            add_row(&qe, &PERSON_TY, &john, &TYPE_SYSTEM).await;
+            add_row(&qe, &PERSON_TY, &alan, &TYPE_SYSTEM).await;
 
             let mutation = delete_from_url("Person", &url(".age=30"));
             qe.mutate(mutation).await.unwrap();
@@ -1122,7 +1133,7 @@ mod tests {
         let chiselstrike = json!({"name": "ChiselStrike", "ceo": john});
         {
             let (qe, _db_file) = setup_clear_db(&*ENTITIES).await;
-            add_row(&qe, &COMPANY_TY, &chiselstrike).await;
+            add_row(&qe, &COMPANY_TY, &chiselstrike, &TYPE_SYSTEM).await;
 
             let mutation = delete_from_url("Company", &url(".ceo.name=John"));
             qe.mutate(mutation).await.unwrap();

--- a/server/src/datastore/crud.rs
+++ b/server/src/datastore/crud.rs
@@ -407,7 +407,7 @@ fn json_to_literal(field_type: &Type, value: &serde_json::Value) -> Result<Expr>
             "trying to filter by property of type '{}' which is not supported",
             ty.name()
         ),
-        Type::String | Type::Id => Literal::String(convert!(as_str, "string")),
+        Type::String => Literal::String(convert!(as_str, "string")),
         Type::Float => Literal::F64(convert!(as_f64, "float")),
         Type::Boolean => Literal::Bool(convert!(as_bool, "bool")),
     };
@@ -482,7 +482,7 @@ fn filter_from_param(
             fields.last().unwrap(),
             ty.name()
         ),
-        Type::String | Type::Id => Literal::String(value.to_owned()),
+        Type::String => Literal::String(value.to_owned()),
         Type::Float => Literal::F64(value.parse::<f64>().with_context(|| err_msg("f64"))?),
         Type::Boolean => Literal::Bool(value.parse::<bool>().with_context(|| err_msg("bool"))?),
     };

--- a/server/src/datastore/engine.rs
+++ b/server/src/datastore/engine.rs
@@ -383,7 +383,7 @@ impl QueryEngine {
             match s_field {
                 QueryField::Scalar {
                     name,
-                    type_kind,
+                    type_id,
                     column_idx,
                     is_optional,
                     transform,
@@ -400,7 +400,7 @@ impl QueryEngine {
                             json!(val)
                         }};
                     }
-                    let mut val = match type_kind {
+                    let mut val = match type_id {
                         TypeId::Float => {
                             // https://github.com/launchbadge/sqlx/issues/1596
                             // sqlx gets confused if the float doesn't have decimal points.

--- a/server/src/datastore/engine.rs
+++ b/server/src/datastore/engine.rs
@@ -4,7 +4,7 @@ use crate::datastore::query::{
     KeepOrOmitField, Mutation, QueriedEntity, QueryField, QueryPlan, SqlValue, TargetDatabase,
 };
 use crate::datastore::{DbConnection, Kind};
-use crate::types::{DbIndex, Field, ObjectDelta, ObjectType, Type};
+use crate::types::{DbIndex, Field, ObjectDelta, ObjectType, Type, TypeId, TypeSystem};
 use crate::JsonObject;
 use anyhow::{anyhow, Context as AnyhowContext, Result};
 use async_lock::Mutex;
@@ -23,6 +23,7 @@ use sqlx::any::{Any, AnyArguments, AnyPool, AnyRow};
 use sqlx::{Executor, Row, Transaction, ValueRef};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -93,12 +94,12 @@ impl TryFrom<&Field> for ColumnDef {
         if field.is_unique {
             column_def.unique_key();
         }
-        match field.type_ {
-            Type::String => column_def.text(),
-            Type::Id => column_def.text().primary_key(),
-            Type::Float => column_def.double(),
-            Type::Boolean => column_def.boolean(),
-            Type::Entity(_) => column_def.text(), // Foreign key, must the be same type as Type::Id
+        match field.type_id {
+            TypeId::String => column_def.text(),
+            TypeId::Id => column_def.text().primary_key(),
+            TypeId::Float => column_def.double(),
+            TypeId::Boolean => column_def.boolean(),
+            TypeId::Entity { .. } => column_def.text(), // Foreign key, must the be same type as Type::Id
         };
 
         Ok(column_def)
@@ -382,7 +383,7 @@ impl QueryEngine {
             match s_field {
                 QueryField::Scalar {
                     name,
-                    type_,
+                    type_kind,
                     column_idx,
                     is_optional,
                     transform,
@@ -399,16 +400,16 @@ impl QueryEngine {
                             json!(val)
                         }};
                     }
-                    let mut val = match type_ {
-                        Type::Float => {
+                    let mut val = match type_kind {
+                        TypeId::Float => {
                             // https://github.com/launchbadge/sqlx/issues/1596
                             // sqlx gets confused if the float doesn't have decimal points.
                             let val: f64 = row.get_unchecked(column_idx);
                             json!(val)
                         }
-                        Type::String => to_json!(&str),
-                        Type::Id => to_json!(&str),
-                        Type::Boolean => {
+                        TypeId::String => to_json!(&str),
+                        TypeId::Id => to_json!(&str),
+                        TypeId::Boolean => {
                             // Similarly to the float issue, type information is not filled in
                             // *if* this value was put in as a result of coalesce() (default).
                             match db_kind {
@@ -419,7 +420,7 @@ impl QueryEngine {
                                 _ => to_json!(bool),
                             }
                         }
-                        Type::Entity(_) => anyhow::bail!("object is not a scalar"),
+                        TypeId::Entity { .. } => anyhow::bail!("object is not a scalar"),
                     };
                     if let Some(tr) = transform {
                         // Apply policy transformation
@@ -517,15 +518,19 @@ impl QueryEngine {
     ///     ...
     /// }
     ///
-    pub(crate) async fn add_row(
-        &self,
+    pub(crate) fn add_row<'a>(
+        &'a self,
         ty: &ObjectType,
         ty_value: &JsonObject,
-        transaction: Option<&mut Transaction<'_, Any>>,
-    ) -> Result<IdTree> {
-        let (inserts, id_tree) = self.prepare_insertion(ty, ty_value)?;
-        self.run_sql_queries(&inserts, transaction).await?;
-        Ok(id_tree)
+        transaction: Option<&'a mut Transaction<'static, Any>>,
+        ts: &TypeSystem,
+    ) -> impl Future<Output = Result<IdTree>> + 'a {
+        let res = self.prepare_insertion(ty, ty_value, ts);
+        async {
+            let (inserts, id_tree) = res?;
+            self.run_sql_queries(&inserts, transaction).await?;
+            Ok(id_tree)
+        }
     }
 
     pub(crate) async fn add_row_shallow(
@@ -577,6 +582,7 @@ impl QueryEngine {
         &self,
         ty: &ObjectType,
         ty_value: &JsonObject,
+        ts: &TypeSystem,
     ) -> Result<(Vec<SqlWithArguments>, IdTree)> {
         let mut child_ids = HashMap::<String, IdTree>::new();
         let mut obj_id = Option::<String>::None;
@@ -589,7 +595,7 @@ impl QueryEngine {
                 continue;
             }
             let incompatible_data = || QueryEngine::incompatible(field, ty);
-            let arg = match &field.type_ {
+            let arg = match ts.get(&field.type_id)? {
                 Type::Entity(nested_type) => {
                     let nested_value = field_value
                         .context("json object doesn't have required field")
@@ -610,7 +616,7 @@ impl QueryEngine {
                         }
                     } else {
                         let (nested_inserts, nested_ids) =
-                            self.prepare_insertion(nested_type, nested_value)?;
+                            self.prepare_insertion(&nested_type, nested_value, ts)?;
                         inserts.extend(nested_inserts);
                         let nested_id = nested_ids.id.to_owned();
                         child_ids.insert(field.name.to_owned(), nested_ids);
@@ -678,13 +684,14 @@ impl QueryEngine {
             }};
         }
 
-        let arg = match &field.type_ {
-            Type::String | Type::Id | Type::Entity(_) => {
+        let arg = match field.type_id {
+            TypeId::String | TypeId::Id | TypeId::Entity { .. } => {
                 SqlValue::String(convert_json_value!(as_str, str))
             }
-            Type::Float => SqlValue::F64(convert_json_value!(as_f64, f64)),
-            Type::Boolean => SqlValue::Bool(convert_json_value!(as_bool, bool)),
+            TypeId::Float => SqlValue::F64(convert_json_value!(as_f64, f64)),
+            TypeId::Boolean => SqlValue::Bool(convert_json_value!(as_bool, bool)),
         };
+
         Ok(arg)
     }
 
@@ -714,7 +721,7 @@ impl QueryEngine {
             field_binds.push(',');
 
             field_names.push(f.name.clone());
-            if f.type_ == Type::Id {
+            if f.type_id == TypeId::Id {
                 if let Some(idstr) = val {
                     let idstr = idstr.as_str().context("invalid ID: It is not a string")?;
                     Uuid::parse_str(idstr).map_err(|_| anyhow!("invalid ID '{}'", idstr))?;

--- a/server/src/datastore/meta/mod.rs
+++ b/server/src/datastore/meta/mod.rs
@@ -101,7 +101,7 @@ async fn update_field_query(
         let mut query = sqlx::query(&querystr);
 
         query = query
-            .bind(field.type_.name())
+            .bind(field.type_id.name())
             .bind(field.is_optional)
             .bind(field.is_unique)
             .bind(field_id);
@@ -166,7 +166,7 @@ async fn insert_field_query(
                 RETURNING *"#,
             );
             query
-                .bind(field.type_.name())
+                .bind(field.type_id.name())
                 .bind(type_id)
                 .bind(field.is_optional)
                 .bind(field.is_unique)
@@ -184,7 +184,7 @@ async fn insert_field_query(
                 RETURNING *"#,
             );
             query
-                .bind(field.type_.name())
+                .bind(field.type_id.name())
                 .bind(type_id)
                 .bind(value.to_owned())
                 .bind(field.is_optional)

--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -3,7 +3,7 @@
 use crate::auth::AUTH_USER_NAME;
 use crate::datastore::expr::{BinaryExpr, Expr, Literal, PropertyAccess};
 use crate::policies::{FieldPolicies, Policies};
-use crate::types::{Entity, Field, ObjectType, Type, TypeSystem};
+use crate::types::{Entity, Field, ObjectType, Type, TypeId, TypeSystem};
 
 use anyhow::{anyhow, Context, Result};
 use enum_as_inner::EnumAsInner;
@@ -65,7 +65,7 @@ pub(crate) enum QueryField {
         /// Name of the original Type field
         name: String,
         /// Type of the field
-        type_: Type,
+        type_kind: TypeId,
         is_optional: bool,
         /// Index of a column containing this field in the resulting row we get from
         /// the database.
@@ -263,8 +263,8 @@ impl QueryPlan {
         let mut builder = Self::new(ty.clone());
         for field in ty.all_fields() {
             let mut field = field.clone();
-            field.type_ = match field.type_ {
-                Type::Entity(_) => Type::String, // This is actually a foreign key.
+            field.type_id = match field.type_id {
+                TypeId::Entity { .. } => TypeId::String, // This is actually a foreign key.
                 ty => ty,
             };
             let field =
@@ -283,7 +283,7 @@ impl QueryPlan {
             })?;
 
         let mut builder = Self::new(ty.clone());
-        builder.entity = builder.load_entity(c, &ty);
+        builder.entity = builder.load_entity(c, &ty)?;
         Ok(builder)
     }
 
@@ -295,7 +295,7 @@ impl QueryPlan {
         operators: Vec<QueryOp>,
     ) -> Result<Self> {
         let mut query_plan = Self::new(ty.clone());
-        query_plan.entity = query_plan.load_entity(c, ty);
+        query_plan.entity = query_plan.load_entity(c, ty)?;
         query_plan.extend_operators(operators);
         Ok(query_plan)
     }
@@ -338,7 +338,7 @@ impl QueryPlan {
         let column_idx = self.columns.len();
         let select_field = QueryField::Scalar {
             name: field.name.clone(),
-            type_: field.type_.clone(),
+            type_kind: field.type_id.clone(),
             is_optional: field.is_optional,
             column_idx,
             transform,
@@ -354,8 +354,12 @@ impl QueryPlan {
 
     /// Prepares the retrieval of Entity of type `ty` from the database and
     /// ensures login restrictions are respected.
-    fn load_entity(&mut self, context: &RequestContext, ty: &Entity) -> QueriedEntity {
-        self.add_login_filters_recursive(context, ty, Expr::Parameter { position: 0 });
+    fn load_entity(
+        &mut self,
+        context: &RequestContext,
+        ty: &Entity,
+    ) -> anyhow::Result<QueriedEntity> {
+        self.add_login_filters_recursive(context, ty, Expr::Parameter { position: 0 })?;
         self.load_entity_recursive(context, ty, ty.backing_table())
     }
 
@@ -367,7 +371,7 @@ impl QueryPlan {
         context: &RequestContext,
         ty: &Entity,
         current_table: &str,
-    ) -> QueriedEntity {
+    ) -> anyhow::Result<QueriedEntity> {
         let field_policies = context.make_field_policies(ty);
 
         let mut fields = vec![];
@@ -379,7 +383,9 @@ impl QueryPlan {
                 _ => KeepOrOmitField::Keep,
             };
 
-            let query_field = if let Type::Entity(nested_ty) = &field.type_ {
+            let ty = context.ts.get(&field.type_id)?;
+
+            let query_field = if let Type::Entity(nested_ty) = &ty {
                 let nested_table = format!(
                     "JOIN{}_{}_TO_{}",
                     self.join_counter,
@@ -394,7 +400,7 @@ impl QueryPlan {
                 joins.insert(
                     field.name.to_owned(),
                     Join {
-                        entity: self.load_entity_recursive(context, nested_ty, &nested_table),
+                        entity: self.load_entity_recursive(context, nested_ty, &nested_table)?,
                         lkey: field.name.to_owned(),
                         rkey: "id".to_owned(),
                     },
@@ -410,12 +416,13 @@ impl QueryPlan {
             };
             fields.push(query_field);
         }
-        QueriedEntity {
+
+        Ok(QueriedEntity {
             ty: ty.clone(),
             fields,
             table_alias: current_table.to_owned(),
             joins,
-        }
+        })
     }
 
     /// Adds filters that ensure login constrains are satisfied for a type
@@ -425,7 +432,7 @@ impl QueryPlan {
         context: &RequestContext,
         ty: &Entity,
         property_chain: Expr,
-    ) {
+    ) -> anyhow::Result<()> {
         let field_policies = context.make_field_policies(ty);
         let user_id: Literal = match &field_policies.current_userid {
             None => "NULL",
@@ -434,7 +441,8 @@ impl QueryPlan {
         .into();
 
         for field in ty.all_fields() {
-            if let Type::Entity(nested_ty) = &field.type_ {
+            let ty = context.ts.get(&field.type_id)?;
+            if let Type::Entity(nested_ty) = &ty {
                 let property_access = PropertyAccess {
                     property: field.name.to_owned(),
                     object: property_chain.clone().into(),
@@ -445,10 +453,12 @@ impl QueryPlan {
                         self.operators.push(QueryOp::Filter { expression: expr });
                     }
                 } else {
-                    self.add_login_filters_recursive(context, nested_ty, property_access.into());
+                    self.add_login_filters_recursive(context, nested_ty, property_access.into())?;
                 }
             }
         }
+
+        Ok(())
     }
 
     fn make_column_string(&self) -> String {
@@ -915,13 +925,17 @@ pub(crate) mod tests {
         query_engine: &QueryEngine,
         entity: &Entity,
         values: &serde_json::Value,
+        ts: &TypeSystem,
     ) {
         let ins_row = values.as_object().unwrap();
-        query_engine.add_row(entity, ins_row, None).await.unwrap();
+        query_engine
+            .add_row(entity, ins_row, None, ts)
+            .await
+            .unwrap();
         let rows = fetch_rows(query_engine, entity).await;
         assert!(rows.iter().any(|row| {
             ins_row.iter().all(|(key, value)| {
-                if let Type::Entity(_) = entity.get_field(key).unwrap().type_ {
+                if let TypeId::Entity { .. } = entity.get_field(key).unwrap().type_id {
                     true
                 } else {
                     row[key] == *value
@@ -966,6 +980,7 @@ pub(crate) mod tests {
         )
     });
     static ENTITIES: Lazy<[Entity; 2]> = Lazy::new(|| [PERSON_TY.clone(), COMPANY_TY.clone()]);
+    static TYPE_SYSTEM: Lazy<TypeSystem> = Lazy::new(|| make_type_system(&*ENTITIES));
 
     #[tokio::test]
     async fn test_query_plan() {
@@ -999,7 +1014,7 @@ pub(crate) mod tests {
         {
             let (qe, _db_file) = setup_clear_db(&*ENTITIES).await;
             for person in ppl {
-                add_row(&qe, &PERSON_TY, &person).await;
+                add_row(&qe, &PERSON_TY, &person, &TYPE_SYSTEM).await;
             }
             let make_sort_op = |keys: &[(&str, bool)]| {
                 let keys = keys
@@ -1057,7 +1072,7 @@ pub(crate) mod tests {
         let alan = json!({"name": "Alan", "age": json!(30f32)});
         {
             let (qe, _db_file) = setup_clear_db(&*ENTITIES).await;
-            add_row(&qe, &PERSON_TY, &john).await;
+            add_row(&qe, &PERSON_TY, &john, &TYPE_SYSTEM).await;
 
             let expr = binary(&["name"], BinaryOp::Eq, "John".into());
             let mutation = delete_with_expr("Person", expr);
@@ -1067,8 +1082,8 @@ pub(crate) mod tests {
         }
         {
             let (qe, _db_file) = setup_clear_db(&*ENTITIES).await;
-            add_row(&qe, &PERSON_TY, &john).await;
-            add_row(&qe, &PERSON_TY, &alan).await;
+            add_row(&qe, &PERSON_TY, &john, &TYPE_SYSTEM).await;
+            add_row(&qe, &PERSON_TY, &alan, &TYPE_SYSTEM).await;
 
             let expr = binary(&["age"], BinaryOp::Eq, (30.).into());
             let mutation = delete_with_expr("Person", expr);
@@ -1082,7 +1097,7 @@ pub(crate) mod tests {
         let chiselstrike = json!({"name": "ChiselStrike", "ceo": john});
         {
             let (qe, _db_file) = setup_clear_db(&*ENTITIES).await;
-            add_row(&qe, &COMPANY_TY, &chiselstrike).await;
+            add_row(&qe, &COMPANY_TY, &chiselstrike, &TYPE_SYSTEM).await;
 
             let expr = binary(&["ceo", "name"], BinaryOp::Eq, "John".into());
             let mutation = delete_with_expr("Company", expr);

--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -65,7 +65,7 @@ pub(crate) enum QueryField {
         /// Name of the original Type field
         name: String,
         /// Type of the field
-        type_kind: TypeId,
+        type_id: TypeId,
         is_optional: bool,
         /// Index of a column containing this field in the resulting row we get from
         /// the database.
@@ -338,7 +338,7 @@ impl QueryPlan {
         let column_idx = self.columns.len();
         let select_field = QueryField::Scalar {
             name: field.name.clone(),
-            type_kind: field.type_id.clone(),
+            type_id: field.type_id.clone(),
             is_optional: field.is_optional,
             column_idx,
             transform,

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -531,9 +531,13 @@ async fn op_chisel_store(
         current_transaction(&state)
     };
     let mut transaction = transaction.lock().await;
-    query_engine
-        .add_row(&ty, value, Some(transaction.deref_mut()))
-        .await
+
+    {
+        let state = state.borrow();
+        let ts = current_type_system(&state);
+        query_engine.add_row(&ty, value, Some(transaction.deref_mut()), ts)
+    }
+    .await
 }
 
 #[derive(Deserialize)]

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -603,7 +603,6 @@ impl From<Type> for TypeMsg {
     fn from(ty: Type) -> TypeMsg {
         let ty = match ty {
             Type::Float => TypeEnum::Number(true),
-            Type::Id => TypeEnum::String(true),
             Type::String => TypeEnum::String(true),
             Type::Boolean => TypeEnum::Bool(true),
             Type::Entity(entity) => TypeEnum::Entity(entity.name().to_owned()),

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -374,7 +374,7 @@ or
 
             match version_types.lookup_custom_type(&name) {
                 Ok(old_type) => {
-                    let delta = TypeSystem::generate_type_delta(&old_type, ty)?;
+                    let delta = TypeSystem::generate_type_delta(&old_type, ty, &state.type_system)?;
                     to_update.push((old_type.clone(), delta));
                 }
                 Err(TypeSystemError::NoSuchType(_) | TypeSystemError::NoSuchVersion(_)) => {
@@ -679,9 +679,10 @@ impl ChiselRpc for RpcService {
                 {
                     let mut field_defs = vec![];
                     for field in ty.user_fields() {
+                        let field_type = state.type_system.get(&field.type_id).unwrap();
                         field_defs.push(chisel::FieldDefinition {
                             name: field.name.to_owned(),
-                            field_type: Some(field.type_.clone().into()),
+                            field_type: Some(field_type.into()),
                             labels: field.labels.clone(),
                             default_value: field.user_provided_default().clone(),
                             is_optional: field.is_optional,

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -86,7 +86,6 @@ fn optional_string_field(name: &str) -> Field {
 }
 
 fn optional_number_field(name: &str) -> Field {
-    let api_version = "__chiselstrike".to_string();
     Field {
         id: None,
         name: name.into(),
@@ -95,7 +94,7 @@ fn optional_number_field(name: &str) -> Field {
         default: None,
         effective_default: None,
         is_optional: true,
-        api_version,
+        api_version: "__chiselstrike".into(),
         is_unique: false,
     }
 }
@@ -494,13 +493,11 @@ impl TypeSystem {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum Type {
     String,
     Float,
     Boolean,
-    Id,
     Entity(Entity),
 }
 
@@ -508,7 +505,7 @@ impl Type {
     pub(crate) fn name(&self) -> &str {
         match self {
             Type::Float => "number",
-            Type::String | Type::Id => "string",
+            Type::String => "string",
             Type::Boolean => "boolean",
             Type::Entity(ty) => &ty.name,
         }
@@ -711,7 +708,6 @@ impl From<Type> for TypeId {
         match other {
             Type::String => Self::String,
             Type::Float => Self::Float,
-            Type::Id => Self::Id,
             Type::Boolean => Self::Boolean,
             Type::Entity(e) => Self::Entity {
                 name: e.name().to_string(),


### PR DESCRIPTION
The `Field`s of an `Entity` have a `type_: Type` field, which makes the
`Type` being reccursive. This makes it impossible to instanciate types
that that cyclic dependency between them (including self-reference).

This PR makes another step towards supporting self-referential Entity,
and cyclic dependency in Entitities

step towards #1448 