### PR TITLE
Fix transactionality bug when deleting entity

### DIFF
--- a/cli/tests/lit/delete.deno
+++ b/cli/tests/lit/delete.deno
@@ -26,6 +26,15 @@ export default async function chisel(req: Request) {
 }
 EOF
 
+cat << EOF > "$TEMPDIR/endpoints/update-delete.ts"
+import { User } from "../models/user.ts";
+export default async function chisel(req: Request) {
+    await User.delete({ email: "test@example.com"});
+    await User.build({ email: "test@example.com", username: "test"}).save();
+    return new Response("OK");
+}
+EOF
+
 $CHISEL apply
 # CHECK: Model defined: User
 # CHECK: End point defined: /dev/user
@@ -51,3 +60,9 @@ $CURL $CHISELD_HOST/dev/delete
 
 $CURL -X POST $CHISELD_HOST/dev/delete
 # CHECK: OK
+
+$CURL -X POST -d '{"username": "test", "email": "test@example.com"}' $CHISELD_HOST/dev/user
+# CHECK: 200 OK
+
+$CURL -X POST $CHISELD_HOST/dev/update-delete
+# CHECK: 200 OK

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -557,7 +557,16 @@ async fn op_chisel_entity_delete(
         )?
     };
     let query_engine = query_engine_arc(&state.borrow());
-    query_engine.mutate(mutation).await
+    let transaction = {
+        let state = state.borrow();
+        current_transaction(&state)
+    };
+    let mut transaction = transaction.lock().await;
+    query_engine
+        .mutate_with_transaction(mutation, &mut transaction)
+        .await?;
+
+    Ok(())
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
This PR fixes a bug that was caused because the `op_chisel_entity_delete` method was mutating the DB with its own transaction rather than the current one. This caused SQL to deadlock, and throw an error, as well as break the transactionality guarantee of chiselstrike.

I have also added a test.

close #1482 