### PR TITLE
Support secrets V2

### DIFF
--- a/server/src/secrets.rs
+++ b/server/src/secrets.rs
@@ -219,110 +219,91 @@ fn decode_base64(data: &str) -> Result<Vec<u8>> {
 mod tests {
 
     use super::*;
-    use rsa::{BigUint, PublicKey, RsaPublicKey};
+    use once_cell::sync::Lazy;
+    use serde_json::json;
 
-    fn get_private_key() -> RsaPrivateKey {
-        RsaPrivateKey::from_components(
-            rsa::BigUint::parse_bytes(b"00d397b84d98a4c26138ed1b695a8106ead91d553bf06041b62d3fdc50a041e222b8f4529689c1b82c5e71554f5dd69fa2f4b6158cf0dbeb57811a0fc327e1f28e74fe74d3bc166c1eabdc1b8b57b934ca8be5b00b4f29975bcc99acaf415b59bb28a6782bb41a2c3c2976b3c18dbadef62f00c6bb226640095096c0cc60d22fe7ef987d75c6a81b10d96bf292028af110dc7cc1bbc43d22adab379a0cd5d8078cc780ff5cd6209dea34c922cf784f7717e428d75b5aec8ff30e5f0141510766e2e0ab8d473c84e8710b2b98227c3db095337ad3452f19e2b9bfbccdd8148abf6776fa552775e6e75956e45229ae5a9c46949bab1e622f0e48f56524a84ed3483b", 16).unwrap(),
-            BigUint::parse_bytes(b"10001", 16).unwrap(),
-            BigUint::parse_bytes(b"00c4e70c689162c94c660828191b52b4d8392115df486a9adbe831e458d73958320dc1b755456e93701e9702d76fb0b92f90e01d1fe248153281fe79aa9763a92fae69d8d7ecd144de29fa135bd14f9573e349e45031e3b76982f583003826c552e89a397c1a06bd2163488630d92e8c2bb643d7abef700da95d685c941489a46f54b5316f62b5d2c3a7f1bbd134cb37353a44683fdc9d95d36458de22f6c44057fe74a0a436c4308f73f4da42f35c47ac16a7138d483afc91e41dc3a1127382e0c0f5119b0221b4fc639d6b9c38177a6de9b526ebd88c38d7982c07f98a0efd877d508aae275b946915c02e2e1106d175d74ec6777f5e80d12c053d9c7be1e341", 16).unwrap(),
-            vec![
-                BigUint::parse_bytes(b"00f827bbf3a41877c7cc59aebf42ed4b29c32defcb8ed96863d5b090a05a8930dd624a21c9dcf9838568fdfa0df65b8462a5f2ac913d6c56f975532bd8e78fb07bd405ca99a484bcf59f019bbddcb3933f2bce706300b4f7b110120c5df9018159067c35da3061a56c8635a52b54273b31271b4311f0795df6021e6355e1a42e61",16).unwrap(),
-                BigUint::parse_bytes(b"00da4817ce0089dd36f2ade6a3ff410c73ec34bf1b4f6bda38431bfede11cef1f7f6efa70e5f8063a3b1f6e17296ffb15feefa0912a0325b8d1fd65a559e717b5b961ec345072e0ec5203d03441d29af4d64054a04507410cf1da78e7b6119d909ec66e6ad625bf995b279a4b3c5be7d895cd7c5b9c4c497fde730916fcdb4e41b", 16).unwrap()
-            ],
-        )
-    }
+    const PRIVATE_KEY_PEM: &str = r#"-----BEGIN RSA PRIVATE KEY-----
+MIIG4wIBAAKCAYEAzN5yRYmZ9j9oWxiEkFiE3C78NSGrXkWDdT8UC3/jQWzR4mBh
+cmzqUgMYi7lotDL8C2lTPJe0Wwcx1a5QrU1fhdcfN7PUpWTuXxOlnX38ds8z+DTL
+Hs/duwtVVWxK2Cub/M1p5SQB3OBKI+IYRWKicsbOIAGm7pxo2dervd8hE0VJtJ/P
+qwp4rzRZQLlQrzMD2UfF2VcLGDndP6G+ty8osOPdQZvPPhzW+FmX2s1bQEJ4frF+
+y6eu2pH2S6OnW9wk0m6u7xXF0esEW5DW72vS1AoSLmbI1ACRwdkRaRWPgKyr3+VL
+ZoKhp4JkCkqpUzO1sP6QmC/4vMMtxebEYdNPVUgHNWggnu2j2rWCyxh+TVdjg4bK
+YIx4eUXXFUYIubeiDcbLdJ+N3TY4guezNPjcM2kwDFUxSCR5syeGc8oIszx7TjZo
+aLbHnG+/1hjT2B2pMzAr2NQE73irbMa0viKyjj0D0wfsepUXssOPe9H9cUkU/i55
++EJViDzBzUB1wmf3AgMBAAECggGANLhVzcFARpdAopinnIG7BvJsYrvcXrEiyCxI
+W0E42SBIzqmgyhJvJlW3nlVDNYQdSk57Zg9gEUDDuUpXZpGPsGCQnwP/B+T2Vq82
+olXGf0iJBimHz9EMLVMYTZhFlmV6ic7OnnHqrM1nJt7LAigEx+aTKrdiHutPLCgN
+ARqHZ28gLYQmq8xRDD07bqWBtuQ47FRE/M4ig8R4RCS6cGeJYCPzTyvqZACF7XkY
+0+yeu+WfHnNMvtnS7Fo9eG+P5Nq8hQTUvOAHARXXN7v843rLv1bsF4wxxLZ8hHHA
+VKlc4RVpDUXkRtPi853qO62Ta+cLmePqRCC82yjgmB2m0OsoXOHi9kbfAEzryHVi
+SyyI0GxHneZXSZIG3BePog5eRrvjU1+vZHlIOtNUAYP7s8qSrYSg+BRQC3fy9cNx
+znO32W36duHtihWSAOvMkFzG4FIy54e6MDdRWQ49Bjy4KM4CjEjF9bC5go0TbwvD
+UgbfhQ42LAWygLOu6gNdZXTUCA7JAoHBAPGocNdB3TR2yhfBbFoaIJXguEY+ZQR4
+zgitcWGVTsqVYa/vrkc48EejYSvoUBbox//oE1DEs2/6KvsWOKocxyPdy6wkjkoG
+1MVTekxpcwSiTnvcINTL791s/PS5KsfdEEYz/WbbahijF3cRjsUlKf2oQdE9PokR
+7MMHX5RGVRnANuEo5jCRpgpLNQrcg5JtkZwMIHWMyaBWhb6KAG3IjeSUQYMqOv0r
+qeHqAgVBGLWrIflKCpCpc/R0T4LcXB42ewKBwQDZBw/oH2Hduc4iL09j0vHy1NNw
+37yUvJ2YA7y2R+YVbZzfyGqcC2pP71DtWpsH4u1QMKvhBNsTiF2gLAxLGuTJW0xl
+4iVuqYNsfqpMZarN+xLXZZvHkbbEde6rry62bJBNn00Sgc91xSmvh+t09/PYG4N+
+dI4/QyX7EFOISS43WnrJEGqtCif0NFYmPvN+lDgrX3X2ho0qb5s1DIjBnjO/HjK1
+SLwzzFaDfibuAm1FuRJFFn0e6mKPmrwznlnlubUCgcAyBNheZb6ghlnsMtf3imLm
+Qt5Bg9aq50pWF3hZZ2somWTf4q9jBJEPcuzBBtPU+hezi1i8JgqyCcjtsbrG0zAQ
+526p0eM1xVYzBcVRnZ31/pZaIsUU5qVeYpm1GcKWHdapgUdZC99Y/CD2P0ca3Udk
+vnfpFFEmU/R6pcMN0MT6kIOLdUi4Et2YUdrHxb7iBxXVg9kQG7T8IAyM1Mmj75gX
+EOzCdnJBRtFh9mq2pbO0nphonf+z068xkQWII45ZnpMCgcBPRXcX8C6NEIssjV9Q
+NQLPEdHRjseRBHwDxImvgv+VoB4G12upZ7oDTISgzdGGxeqsubpuTJnAvrSEBtLO
+tBoROlnjdQD7NMueW33UveXvqt+s8Z4+/QhnJjRxXWGQnILw91jtg6DFgajCRsFI
+TjExJIuZKvWyQdKjq8j3JNPOwCvNOUPdxLHnTx6Qhbnm6DjEDvBFhcwWTgHBFLz3
+C9QW4O7grJqhyOdozDFoClbjesAjoB0/p5ksnvZTXGm1sWkCgcEAifyWYeMwqugf
+vq8+pmdj9qiqYKfmSNVbkQBRWnR0C9oIV88k3O3DMJWgMzA+/hnM/EpEqv5hy5Er
+0Pd667hkWjpyQppw4ICBr8Gen142gbWM8FaeDGtSGgcDRL7lz1kQp6L1R/hmM7Mp
+4010Mru9X2JpNRsNegafUtz12o7WHjeo6+G6Dbi6QMxoY+PGVZbpIJ8uIXYjK3MX
+MSFoUvsxlBCwBc/KlwzO4lJ1/V8+U6aCEAQoLdGEZXyQq7WGyJg/
+-----END RSA PRIVATE KEY-----"#;
 
-    fn encrypt_v0(public_key: &RsaPublicKey, data: &[u8]) -> Result<Vec<u8>> {
-        let padding = PaddingScheme::new_pkcs1v15_encrypt();
-        let ciphertext = public_key
-            .encrypt(&mut rand::rngs::OsRng, padding, data)
-            .map_err(|x| anyhow!("Failed to encrypt: {:?}", x))?;
-        Ok(ciphertext)
-    }
+    static PRIVATE_KEY: Lazy<RsaPrivateKey> =
+        Lazy::new(|| parse_rsa_key(PRIVATE_KEY_PEM).unwrap().unwrap());
 
-    fn rsa_encrypt(public_key: &RsaPublicKey, data: &[u8]) -> Result<Vec<u8>> {
-        let padding = PaddingScheme::new_oaep::<Sha256>();
-        let ciphertext = public_key
-            .encrypt(&mut rand::rngs::OsRng, padding, data)
-            .map_err(|x| anyhow!("Failed to encrypt: {:?}", x))?;
-        Ok(ciphertext)
-    }
+    const PAYLOAD_V2: &str = "eyJ2ZXJzaW9uIjoiVjIiLCJzZWNyZXQiOnsibXlzZWNyZXQyIjp7InNlY3JldCI6ImkvVFlaR2l6SlE3TjdRUGV1ZDR5MjNpTENlTHU1KzRKRzNRVSIsImtleSI6Ik04Qkt2a3puT1k4VmMvMWs1aVpXbldzZHB6RXBHM1lYMk1PTHJBRHNrc20yMkFBRlB0SlVnTlBzMkZCSjl4WDBGQlFBOG9ZUlBlc2NWbXRhQXhoRHNkeCtRSU9kS21NM2lJNzBlY3dSeVlJMWFpVU84cnBuS0tBdkRXNkZJTXFPZ2dHbzdLZm01bmd0c055Y3QyR3ROeXUrQ20rUG1FSy9rVTltdnhUNVI0MUhycGJBaC96MXBaOWlzU2hrN3Ird1JFcnZmV2kvcEFXelY1WDFNK2NMZ3d3Nm9KTno0b1FnTjZ2OW9mOWdVNGluZis3OWJtWXovVG91MHV5VHhVemI3Q1ErUXV5NmM1bDd1QjJzbEhBQmVBVjB0aTJWU0tNK24yMndqNHcySHlXWWlUNXBwTWYybDI5OUFPRWVjVWRQK2RvTFdrOU5pTE5Gd1ZWTmRWaDM5M1c2akxudlFpSGV5aldjOHF6U3lyMzdwckNGejhFNFhKVzZITkNSdWQ3d2RyVmV3MmZpRG53WExtb3NyWlJiSFBvL1BuVlY4dGhXMzF4VG41L3RtMGdQd3YwZUhxdjQvdFhCMk5MOWF0WlhRTlVWS25nVkxJOGtJODAzT2ptd1hmN2lyQm5WVUlKZnNCbEllVEhkZEtmc2VGTVZNcnc5dWNuMkd0bUNZdTZVIiwibm9uY2UiOiJycE9OekxyZU00cGEvdkkwemJWZWpqUjdvT2I4aGZrVndrK2Fzd2ZIbVVVNWtjeTJkSkk4Rnc2R1MxY2orVXR0OTN0MkhsbXhCK2NHRW1GL1J0TzFYdENsRVY1OTE5cUx2UUhHdGd1ODVIcGJCZXN2UnBnYVZwTFVjQlJDYTRnRHMyeEhvYW1QU1l6cE05UldrK25mS1BtamxPVmFxanh2bGhwcVV2R0hBZEwzWGhJdXcybnZFRFl5eGNIWXd1UDFMQldsMlE3VndxOERQK1RFa01QUmRmTnNnOGJ0ZktmNmtJbmhoNkFxdVBDMGs2SEZsc0tadTBySU44Nk4wczREaXZBbmRmNTJ4aHFjUW9tMzdpVTJXNDlUcXVlWXp3NkhRallCVXNRdjdsaE5Ud2lqcGFoZFo0UFkzOVp5aXdianVFRldvdklRRTZ0NFk1eWd4S3cxOEVyQlNtUlcyUjRrNFpvSVZwQWNSQWROU2VxRlV5VUlBWEtWTDFRaUJlSGRIYjh3VTRjeTA5eHhCc0pwWUd0WTRUenNqTnU3TUVzVXlKd0JoRzVVWXg1SDVXazV1TU5HUHNnY1FNMHJmNnFoditwNXBUaTN5Q2tBV04rc0VkQ3VNcWVZMkxKMlZtclA0eFNPTWE2eXo4N3NteXQ4Zk5ldzhVOXRkOWR0MDUzTyIsImhhc2giOiJZd0V3ZHoxYThQTnRQNUFBOGxqNVB3MWtTWGFsT1hQQlFPaVh1d3FMSFNFPSIsImhhc2hTYWx0IjoiWDc3aitpb3ZIcXVmdUlHSyJ9LCJteXNlY3JldDEiOnsic2VjcmV0IjoiMFBZeXVxa2MyV2J5c3hlL09tNGtWOXNxdFpFRTJiLzh2aUJWIiwia2V5IjoiTUxOK1M3aDBJNGR5MnR6L0hQMk92MkcyTkV2N1o1T283MkNOTllpV05LWFJpMHN5anM2YUYzY3RPb3RnN1pRYjBvRXFkbzFkdllZZXd1bWhkR3hta2ppQ0dSWFpCc0JVRG1FV1ZoVitaaHJIZ0ZaV1JUbVptRmg5ZmhNOXdxWGd2cm5NaU0vaVlVbThQTWVCNHhwRHA1ZWJjRlBIcTRjUWZQSVVMbk5oTThVbFVwVjRmbjB4L21hSXIzOUJXS2JITU5yZlk2bnhndmdmcGgrWDlaWHl5SGtxR2ZPRzZJUUI2OTFEcVUzQysrbEdHbnRNcjhJSUxRZ000SVlHT1ZRWWpFWmduTGNLZTBkd1hNc2Z4UHJ5bkh5TEYyRGp5Q2hhQlF5UUtINTU0TEU5ZG1Ya0xybnltZmJMVlFEcVlZUXhucnhoZkdwS3NSaEsrTFNMTE8xZ0I0NEZaejllMkRtMTcrT21EQVROWlU5elplaXFyVStDd2d0eVpuTjFjRzZYOVRITmlxdTc5K1l1Tm93VWFUZTJlajJUTy9rNjBQYzZ4dmZyS2ZaRXVZUVNLR1J4VjIrOEtna1ZCdC9nQlpPYWVENnd3cXAzaUlvRE1ienM4Rzc4UHZXWGdjQ3N6YzJLVitIQmRaTDFiUE9UeGh1SlBIWkkwSnUwd0dXRU1zK3EiLCJub25jZSI6Ilh1ZWdHT1RVaSs1aG9vRzVFKzIrWXJHd1RNeThWSjlxRHVVZWJmazFNVXFGUXNaZVlVTE1VREtQTW9jcENRVWdXYXNZOHNkZ0UvZjBKQ3JFcTVVL0t1cHVQaFhaNklIa2F5NGpGRmt0aXBFcFptemZyd3VPYkNLZ09rVWVJTDhNUGMxNWdzM0VQL216WVEzSXdBSUpYL3MzZDJSaDN1RGNpKytXVzFmNS9rbjRZeCswNTI4UDEzcm4xWFRFcGs1NVpaSUhVQkRhVnovWWJXeHNFUlNoYnhvSzdxNGwxaEt3R05jSlE3WDc5T2poTXBMbDREbFpHbkhsb0FIS1ZkajdON0pPR1ZZRGdGbGdqSFQ3eWthVVpqQzNoUHhLc1NRQlc4S1hSY1hxZ01GK1FTc2wyWkkrcUMxYTBFZ0FoUmwrbFJvTFA3MGwwNkg4R1NKcXlQRUh0UXNoKytzU01rNnRGd3hIeGhoenBsd2pRK0dnM2FnbW9iVHlVNnNETEJxMks0RVpvMVZsMnJRY25FSTlEQ01zT1JDN1pMR2M2cWNycDJJM3UyT05janRwOW5VL0RMMGNvbUZwZlNneDR0VjhTK25ORnNVMDJRZnFodVhldStqVFkvbkhJZWlHOG9udU5UZXJ1S0Rsb055OTl3NTJmOXBNWGJYQld5bnhRSnFCIiwiaGFzaCI6ImE5K21KS3ZFTE1KOWdTMmZ6Y1VDbkpKN1hZLzZ1MTZsYXBjQ2V4c2NTQ2s9IiwiaGFzaFNhbHQiOiJKVDh2b1R4QnNqVkt0MS91In19fQ==";
 
-    fn encrypt_v1(public_key: &RsaPublicKey, data: &[u8]) -> Result<AesPayload> {
-        let key = b"secret key that no one can know!";
-        let key = aes_gcm::Key::from_slice(key);
-        let cipher = Aes256Gcm::new(key);
+    const PAYLOAD_V1: &str = "eyJ2ZXJzaW9uIjoiVjEiLCJzZWNyZXQiOiJSTVE1bHNNM3p4dHBjWjFhYmVpaThqdmpQSXNCemlNdFYzalgzRXRhRkRlSGFoemZwMmpZMW41RVdYcUs4aTBHdmQvQ2JYNko1ZlVQVTFYRkNXd2RTeDNraXpGNCIsIm5vbmNlIjoidng2M2NrbkJaMCs4SEVFNnIrQWdzQlpjdlU4V1RPVU1PSzM3akJwem9VamRseFlBZ2c5TVorbUZ1V0pyZEQrWjJpUFc0T1VhblhVSy9zVENNVEZLNlo3RHVCQTdobzN2MG9GcmVpMml5WTRFMFF4L1A0WCtvYmVUM3gwVmdCNCs4bW5rd0lZRzlUVVdjMWZjWDMvRzg0ZWFXZkkwZ0orYzRHQUh5czEyQ3hUVWxVb096SFk3SEI2TExobyt6bXVGMldkTHU4WEk4WG55c1dxMGd2WWVPb1JJSElNY1V4YUgyVHhaZEV2ci9qcGFnY2MvY3RJZThtVXd5eU9MMy9XcmpqU1E4VHdrUjJvdGZHTVgyZU5hdFlYRG1LTG54SVFyNlRITlpETGxNZUVzMDZ4UlJlamRlNkZUR3I0ckJ0NzZGbTJjMDlFZkhFVTBQOTlPWEIzUmViTDVDZmRFdldyd0hjSVhzWWEyNjdYZkRsc1JvK2toZzFpUlk0UHZvdHcvNWV0ZDNlbjdNVkxHcnQ3dkJ5UFQyYUdmTzFJbkVSVTFWSHVIUE1VUDkrVFR2THAvS0g3Sk8yVEY3YndSTld3SHFlbVh0R1Y1ajRBWmZ2VkFVU0lPWFR6eVVzNXI4azRoa3FZVDJIbXdGN0svak9BUHQ5WGdEbHhJRlRaOHE1aWgiLCJrZXkiOiJGOWorbzBXYWxaOUNhVEFoSWtNZHFTaEg1K1NYL3BRV0JhN1JvV00ramFoaGlnUUZVWmNrRmxuTFVDek8yeHBMcXZ0YXBwZGhXWWFqMHIyay9GekU2S0JlVWtUZk5vSjAvQUNobW5SOUFUMTVmWDhRaVVRZWNuclY3RDhlS1BVVDZQL1JrOFcyNFBaMGNLN2NvbHNBZG9OUWJDa2x0aWFYcCswdmpIUlBHcWpVb09hOXM2dXpKclcrUE91NmI1WDIrYUorenVPN2pxVll3N0hFTVpHVEw4ZUl5VldaTjM3a2VyWTNJcHV1V3lsK2pRU0twQmtiMC9BaTZ4bGNsN2RqNUJDandUM3R0K2lBazIrUTRzdUh3d25OTStLQ2hQcnBldjN5bnlmWnhWUGJDN3p1dStiRE50NWlNMERWTUtNMzNjTEk3SHNiOWZHdmVjUHltN0p3ekxKekVvWHd6QXo5cmZoU1NNcWpvNXIyZUlkdEgzMnZhQ3F0bFdISnY2NGJpYm90YTlzb0twOHFmYk0wbUM2byt6dFR6dnd3RVdvdW1EMGVMNFg3TFVtOCs1M2NGMnV0VnZzWkwxaW8ya0dGamgxN0szditGckR3T3k3aFVCaDlmY1FCTGpoNHEyeUt4NlFiN0RuaVk5WkkrNXNkMUhPcTNsSFhBUS80M29OcCJ9";
 
-        let nonce = b"such random!";
-        let nonce = Nonce::from_slice(nonce);
+    const PAYLOAD_V0: &str = "eyJ2ZXJzaW9uIjoiVjAiLCJzZWNyZXQiOiJHSkdaWkJsMzJodlZWV01SQ1EvdEthaHVUV1FVN1MwQVRkdGhYQ0JzU0pWVFAvOWFweG5OaXJnNGRPVVZBNHZPeldsUWdzQldkSzZYaUVvOThraUNWTWtoVDhTTGErRnNsRjc2S1lKS0lhZ3U2MVRrUzFUak8rNU5ZSUEydElZZnJ5NytJalBidWF5NHFKbVJVQzQyaTVMUk1LcHozd0JkYnZPWDNyaEROam5lUjBVYTV2N2NzVkRCNlNQOE5lK2pNSFI2YXVXS2Yyc2lEcStPamNwVHI5NUU4U04ySS8vWU02T3JBdjBpRm10c25UZ05zdHA5QXdyOSt0bzFhZThFRWRWOEZRSGtrSS9wV1AvTjhvTVhmaTdFRFd1M1Z6Y0FCV3cyTGZVV2hFbXZ6OExrN3ByVjhBT0pCUHRVdGxTbGlUNXEzdWphQ05DV0hRMXZkSHBOdThsOU1NVWFTMFpmZmRmTGRub2pBdm1xUkxtczNMRGdVNVU1bjlGMUs4WTRIcjFNRzUyVGpMK2MrUzBQVnlKcm9XVU81YkdoS01aenZqSkJHWUFlUXZ1S0pwQ1lUWU0vWjFOcUd3eDE5dTdQSUVmSmdMeGpEYzlrU011SnRnN1QzVUViOHJtU0dOcFp2VGNIZnlnSHV2SC9FaktBUy92UnFsWnRRcjFPK0ZSZSJ9";
 
-        let ciphertext = cipher
-            .encrypt(nonce, data.as_ref())
-            .expect("encryption failure!");
+    #[test]
+    fn test_extract_secrets_v2() {
+        let actual = extract_secrets(&PRIVATE_KEY, PAYLOAD_V2).unwrap();
 
-        let key = rsa_encrypt(public_key, key.as_slice()).unwrap();
-        let nonce = rsa_encrypt(public_key, nonce.as_slice()).unwrap();
+        let expected = json!({
+            "mysecret1": "testsecret1",
+            "mysecret2": "testsecret2",
+        });
 
-        Ok(AesPayload {
-            key,
-            secret: ciphertext,
-            nonce,
-        })
-    }
-
-    fn serialize(payload: &Payload) -> String {
-        match payload {
-            Payload::V0(data) => base64::encode(data),
-            Payload::V1(data) => base64::encode(&serde_json::to_vec(data).unwrap()),
-        }
+        assert_eq!(expected.as_object().unwrap(), &actual);
     }
 
     #[test]
-    fn test_v0_decryption() {
-        let private_key = get_private_key();
-        let public_key = private_key.to_public_key();
-        let data = "a bunch of arbitrary data to be encrypted";
+    fn test_extract_secrets_v1() {
+        let actual = extract_secrets(&PRIVATE_KEY, PAYLOAD_V1).unwrap();
 
-        let ciphertext = encrypt_v0(&public_key, data.as_bytes()).unwrap();
-        let ciphertext = serialize(&Payload::V0(ciphertext));
+        let expected = json!({
+            "mysecret1": "testsecret1",
+            "mysecret2": "testsecret2",
+        });
 
-        let decrypted = decrypt(&private_key, &ciphertext).unwrap();
-        assert_eq!(decrypted, data)
+        assert_eq!(expected.as_object().unwrap(), &actual);
     }
 
     #[test]
-    fn test_v1_decryption() {
-        let private_key = get_private_key();
-        let public_key = private_key.to_public_key();
-        let data = "a bunch of arbitrary data to be encrypted";
+    fn test_extract_secrets_v0() {
+        let actual = extract_secrets(&PRIVATE_KEY, PAYLOAD_V0).unwrap();
 
-        let ciphertext = encrypt_v1(&public_key, data.as_bytes()).unwrap();
-        let ciphertext = serialize(&Payload::V1(ciphertext));
+        let expected = json!({
+            "mysecret1": "testsecret1",
+            "mysecret2": "testsecret2",
+        });
 
-        let decrypted = decrypt(&private_key, &ciphertext).unwrap();
-        assert_eq!(decrypted, data)
-    }
-
-    #[test]
-    fn test_parse_v0() {
-        let payload = "anything that is not a valid AesPayload serialized as JSON";
-        let payload = base64::encode(payload);
-        let payload = parse(&payload).unwrap();
-        assert!(matches!(payload, Payload::V0(_)));
-    }
-
-    #[test]
-    fn test_parse_v1() {
-        let payload = r#"{"key": "Y2hpc2Vsc3RyaWtlIHJ1bGVz", "nonce": "c29tZSBrZXk=", "secret": "amFuIGlzIHNtYXJ0"}"#;
-        let payload = base64::encode(payload);
-        let payload = parse(&payload).unwrap();
-        assert!(matches!(payload, Payload::V1(_)));
-    }
-
-    #[test]
-    fn test_parse_error() {
-        let payload = "not a valid base64.";
-        assert!(parse(payload).is_err());
+        assert_eq!(expected.as_object().unwrap(), &actual);
     }
 }


### PR DESCRIPTION
This PR adds support for secrets V2. There are a couple of change in the payload that makes the secret version explicit, for a nicer handling with serde.

I have exported a sample secret from the actual backend for each version as test for compatibility with all versions of the secrets. The payloads in the tests are encrypted with a dummy RSA key.
