### PR TITLE
Enable deno fmt and lint in tsc_compile_build

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,8 @@
                 "server",
                 "packages",
                 "deno.json",
-                "tsc_compile"
+                "tsc_compile",
+                "tsc_compile_build"
             ],
             "exclude": [
                 "tsc_compile/tests/",
@@ -28,7 +29,13 @@
     },
     "lint": {
         "files": {
-            "include": ["api", "server", "packages", "tsc_compile"],
+            "include": [
+                "api",
+                "server",
+                "packages",
+                "tsc_compile",
+                "tsc_compile_build"
+            ],
             "exclude": [
                 "tsc_compile/tests/",
                 "third_party",

--- a/tsc_compile_build/src/tsc.js
+++ b/tsc_compile_build/src/tsc.js
@@ -132,7 +132,7 @@
             .concat(emitResult.diagnostics);
 
         allDiagnostics = ts.sortAndDeduplicateDiagnostics(allDiagnostics);
-        allDiagnostics = allDiagnostics.filter(({code}) => {
+        allDiagnostics = allDiagnostics.filter(({ code }) => {
             // Ignore the error
             //   Cannot write file '...' because it would overwrite input file.
             // It happens when trying to compile an URL that doesn't end in .ts


### PR DESCRIPTION
I forgot to do this when splitting out tsc_compile_build.