### PR TITLE
Introduce `Entity` type covering Custom entity type and Auth types.

### DIFF
--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -21,7 +21,7 @@ pub(crate) const AUTH_ACCOUNT_NAME: &str = "AuthAccount";
 
 fn get_auth_user_type(state: &OpState) -> Result<Arc<ObjectType>> {
     match lookup_builtin_type(state, AUTH_USER_NAME) {
-        Ok(Type::Object(t)) => Ok(t),
+        Ok(Type::Entity(t)) => Ok(t),
         _ => anyhow::bail!("Internal error: type AuthUser not found"),
     }
 }

--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -5,21 +5,20 @@ use crate::datastore::engine::SqlWithArguments;
 use crate::datastore::query::SqlValue;
 use crate::deno::lookup_builtin_type;
 use crate::deno::query_engine_arc;
-use crate::types::{ObjectType, Type};
+use crate::types::{Entity, Type};
 use anyhow::Result;
 use deno_core::OpState;
 use sqlx::Row;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::Arc;
 
 pub(crate) const AUTH_USER_NAME: &str = "AuthUser";
 pub(crate) const AUTH_SESSION_NAME: &str = "AuthSession";
 pub(crate) const AUTH_TOKEN_NAME: &str = "AuthToken";
 pub(crate) const AUTH_ACCOUNT_NAME: &str = "AuthAccount";
 
-fn get_auth_user_type(state: &OpState) -> Result<Arc<ObjectType>> {
+fn get_auth_user_type(state: &OpState) -> Result<Entity> {
     match lookup_builtin_type(state, AUTH_USER_NAME) {
         Ok(Type::Entity(t)) => Ok(t),
         _ => anyhow::bail!("Internal error: type AuthUser not found"),

--- a/server/src/datastore/crud.rs
+++ b/server/src/datastore/crud.rs
@@ -38,7 +38,7 @@ fn run_query_impl(
     let host = context.headers.get("host").cloned();
     let base_type = &context
         .ts
-        .lookup_object_type(&params.type_name, &context.api_version)
+        .lookup_entity(&params.type_name, &context.api_version)
         .context("unexpected type name as crud query base type")?;
 
     let query = Query::from_url(base_type, &params.url)?;

--- a/server/src/datastore/engine.rs
+++ b/server/src/datastore/engine.rs
@@ -97,7 +97,7 @@ impl TryFrom<&Field> for ColumnDef {
             Type::Id => column_def.text().primary_key(),
             Type::Float => column_def.double(),
             Type::Boolean => column_def.boolean(),
-            Type::Object(_) => column_def.text(), // Foreign key, must the be same type as Type::Id
+            Type::Entity(_) => column_def.text(), // Foreign key, must the be same type as Type::Id
         };
 
         Ok(column_def)
@@ -416,7 +416,7 @@ impl QueryEngine {
                                 _ => to_json!(bool),
                             }
                         }
-                        Type::Object(_) => anyhow::bail!("object is not a scalar"),
+                        Type::Entity(_) => anyhow::bail!("object is not a scalar"),
                     };
                     if let Some(tr) = transform {
                         // Apply policy transformation
@@ -585,7 +585,7 @@ impl QueryEngine {
             }
             let incompatible_data = || QueryEngine::incompatible(field, ty);
             let arg = match &field.type_ {
-                Type::Object(nested_type) => {
+                Type::Entity(nested_type) => {
                     let nested_value = field_value
                         .context("json object doesn't have required field")
                         .with_context(incompatible_data)?
@@ -674,7 +674,7 @@ impl QueryEngine {
         }
 
         let arg = match &field.type_ {
-            Type::String | Type::Id | Type::Object(_) => {
+            Type::String | Type::Id | Type::Entity(_) => {
                 SqlValue::String(convert_json_value!(as_str, str))
             }
             Type::Float => SqlValue::F64(convert_json_value!(as_f64, f64)),

--- a/server/src/datastore/meta/mod.rs
+++ b/server/src/datastore/meta/mod.rs
@@ -6,7 +6,6 @@ use crate::api::{ApiInfo, ApiInfoMap};
 use crate::datastore::{DbConnection, Kind};
 use crate::policies::Policies;
 use crate::prefix_map::PrefixMap;
-use crate::types::AuthOrNot::IsNotAuth;
 use crate::types::{
     DbIndex, Entity, ExistingField, ExistingObject, Field, FieldDelta, ObjectDelta, ObjectType,
     TypeSystem,
@@ -518,7 +517,7 @@ impl MetaService {
             let fields = self.load_type_fields(&ts, type_id).await?;
             let indexes = self.load_type_indexes(type_id, backing_table).await?;
 
-            let ty = ObjectType::new(desc, fields, indexes, IsNotAuth)?;
+            let ty = ObjectType::new(desc, fields, indexes)?;
             ts.add_custom_type(Entity::Custom(Arc::new(ty)))?;
         }
         Ok(ts)

--- a/server/src/datastore/meta/mod.rs
+++ b/server/src/datastore/meta/mod.rs
@@ -8,7 +8,8 @@ use crate::policies::Policies;
 use crate::prefix_map::PrefixMap;
 use crate::types::AuthOrNot::IsNotAuth;
 use crate::types::{
-    DbIndex, ExistingField, ExistingObject, Field, FieldDelta, ObjectDelta, ObjectType, TypeSystem,
+    DbIndex, Entity, ExistingField, ExistingObject, Field, FieldDelta, ObjectDelta, ObjectType,
+    TypeSystem,
 };
 use anyhow::Context;
 use sqlx::any::{Any, AnyPool};
@@ -518,7 +519,7 @@ impl MetaService {
             let indexes = self.load_type_indexes(type_id, backing_table).await?;
 
             let ty = ObjectType::new(desc, fields, indexes, IsNotAuth)?;
-            ts.add_type(Arc::new(ty))?;
+            ts.add_type(Entity::Custom(Arc::new(ty)))?;
         }
         Ok(ts)
     }

--- a/server/src/datastore/meta/mod.rs
+++ b/server/src/datastore/meta/mod.rs
@@ -519,7 +519,7 @@ impl MetaService {
             let indexes = self.load_type_indexes(type_id, backing_table).await?;
 
             let ty = ObjectType::new(desc, fields, indexes, IsNotAuth)?;
-            ts.add_type(Entity::Custom(Arc::new(ty)))?;
+            ts.add_custom_type(Entity::Custom(Arc::new(ty)))?;
         }
         Ok(ts)
     }

--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -253,7 +253,7 @@ impl QueryPlan {
         for field in ty.all_fields() {
             let mut field = field.clone();
             field.type_ = match field.type_ {
-                Type::Object(_) => Type::String, // This is actually a foreign key.
+                Type::Entity(_) => Type::String, // This is actually a foreign key.
                 ty => ty,
             };
             let field = builder.make_scalar_field(&field, ty.backing_table(), None);
@@ -361,7 +361,7 @@ impl QueryPlan {
         for field in ty.all_fields() {
             let field_policy = field_policies.transforms.get(&field.name).cloned();
 
-            let query_field = if let Type::Object(nested_ty) = &field.type_ {
+            let query_field = if let Type::Entity(nested_ty) = &field.type_ {
                 let nested_table = format!(
                     "JOIN{}_{}_TO_{}",
                     self.join_counter,
@@ -415,7 +415,7 @@ impl QueryPlan {
         .into();
 
         for field in ty.all_fields() {
-            if let Type::Object(nested_ty) = &field.type_ {
+            if let Type::Entity(nested_ty) = &field.type_ {
                 let property_access = PropertyAccess {
                     property: field.name.to_owned(),
                     object: property_chain.clone().into(),
@@ -786,7 +786,7 @@ impl Mutation {
         filter_expr: &Option<Expr>,
     ) -> Result<Self> {
         let base_entity = match c.ts.lookup_type(type_name, &c.api_version) {
-            Ok(Type::Object(ty)) => ty,
+            Ok(Type::Entity(ty)) => ty,
             Ok(ty) => anyhow::bail!("Cannot delete scalar type {type_name} ({})", ty.name()),
             Err(_) => anyhow::bail!("Cannot delete from type `{type_name}`, type not found"),
         };
@@ -901,7 +901,7 @@ pub(crate) mod tests {
         let rows = fetch_rows(query_engine, entity).await;
         assert!(rows.iter().any(|row| {
             ins_row.iter().all(|(key, value)| {
-                if let Type::Object(_) = entity.get_field(key).unwrap().type_ {
+                if let Type::Entity(_) = entity.get_field(key).unwrap().type_ {
                     true
                 } else {
                     row[key] == *value
@@ -941,7 +941,7 @@ pub(crate) mod tests {
             "Company",
             vec![
                 make_field("name", Type::String),
-                make_field("ceo", Type::Object(PERSON_TY.clone())),
+                make_field("ceo", Type::Entity(PERSON_TY.clone())),
             ],
         )
     });

--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -859,9 +859,7 @@ pub(crate) mod tests {
 
     pub(crate) fn make_entity(name: &str, fields: Vec<Field>) -> Entity {
         let desc = types::NewObject::new(name, VERSION);
-        Entity::Custom(Arc::new(
-            ObjectType::new(desc, fields, vec![], types::AuthOrNot::IsNotAuth).unwrap(),
-        ))
+        Entity::Custom(Arc::new(ObjectType::new(desc, fields, vec![]).unwrap()))
     }
 
     pub(crate) fn make_field(name: &str, ty: Type) -> Field {

--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -852,7 +852,7 @@ pub(crate) mod tests {
     pub(crate) fn make_type_system(entities: &[Entity]) -> TypeSystem {
         let mut ts = TypeSystem::default();
         for ty in entities {
-            ts.add_type(ty.clone()).unwrap();
+            ts.add_custom_type(ty.clone()).unwrap();
         }
         ts
     }

--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -265,7 +265,7 @@ impl QueryPlan {
     fn from_entity_name(c: &RequestContext, entity_name: &str) -> Result<Self> {
         let ty = c
             .ts
-            .lookup_object_type(entity_name, &c.api_version)
+            .lookup_entity(entity_name, &c.api_version)
             .with_context(|| {
                 format!("unable to construct QueryPlan from an unknown entity name `{entity_name}`")
             })?;

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -506,7 +506,7 @@ async fn op_chisel_store(
     let (query_engine, ty) = {
         let state = state.borrow();
         let ty = match current_type_system(&state).lookup_type(type_name, &c.api_version) {
-            Ok(Type::Object(ty)) => ty,
+            Ok(Type::Entity(ty)) => ty,
             _ => anyhow::bail!("Cannot save into type {}.", type_name),
         };
         if ty.is_auth() && !is_auth_path(&c.api_version, &c.path) {

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -343,7 +343,7 @@ or
                 let field_ty = match state.type_system.lookup_builtin_type(&field.field_type) {
                     Ok(ty) => ty,
                     Err(_) => match new_types.get(&field.field_type) {
-                        Some(ty) => Type::Object(ty.clone()),
+                        Some(ty) => Type::Entity(ty.clone()),
                         None => anyhow::bail!(
                             "field type `{}` is neither a built-in nor a custom type",
                             &field.field_type

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -13,7 +13,6 @@ use crate::prefix_map::PrefixMap;
 use crate::runtime;
 use crate::server::CommandTrait;
 use crate::server::CoordinatorChannel;
-use crate::types::AuthOrNot::IsNotAuth;
 use crate::types::{
     DbIndex, Entity, Field, NewField, NewObject, ObjectType, Type, TypeSystem, TypeSystemError,
 };
@@ -364,7 +363,6 @@ or
                 NewObject::new(&name, &api_version),
                 fields,
                 ty_indexes,
-                IsNotAuth,
             )?);
             new_types.insert(name.to_owned(), Entity::Custom(ty.clone()));
 

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -51,7 +51,7 @@ impl VersionTypes {
         }
     }
 
-    fn add_type(&mut self, ty: Entity) -> Result<(), TypeSystemError> {
+    fn add_custom_type(&mut self, ty: Entity) -> Result<(), TypeSystemError> {
         if let Entity::Auth(_) = ty {
             return Err(TypeSystemError::NotACustomType(ty.name().into()));
         }
@@ -207,9 +207,9 @@ impl TypeSystem {
     ///
     /// If type `ty` already exists in the type system isn't Entity::Custom type,
     /// the function returns `TypeSystemError`.
-    pub(crate) fn add_type(&mut self, ty: Entity) -> Result<(), TypeSystemError> {
+    pub(crate) fn add_custom_type(&mut self, ty: Entity) -> Result<(), TypeSystemError> {
         let version = self.get_version_mut(&ty.api_version);
-        version.add_type(ty)
+        version.add_custom_type(ty)
     }
 
     /// Generate an [`ObjectDelta`] with the necessary information to evolve a specific type.

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -394,13 +394,13 @@ impl TypeSystem {
     }
 
     /// Tries to lookup a type of name `type_name` of version `api_version` that
-    /// is an object. That means it's either a built-in object type like
+    /// is an Entity. That means it's either a built-in object type like
     /// `AuthUser` or a user-defined entity object.
     ///
     /// # Errors
     ///
     /// If the looked up type does not exists, the function returns a `NoSuchType`.
-    pub(crate) fn lookup_object_type(
+    pub(crate) fn lookup_entity(
         &self,
         type_name: &str,
         api_version: &str,

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -168,7 +168,7 @@ impl TypeSystem {
     ) -> anyhow::Result<()> {
         let mut transaction = query_engine.start_transaction().await?;
         for ty in self.builtin_types.values() {
-            if let Type::Object(ty) = ty {
+            if let Type::Entity(ty) = ty {
                 query_engine.create_table(&mut transaction, ty).await?;
             }
         }
@@ -386,7 +386,7 @@ impl TypeSystem {
         } else {
             let version = self.get_version(api_version)?;
             if let Ok(ty) = version.lookup_custom_type(type_name) {
-                Ok(Type::Object(ty))
+                Ok(Type::Entity(ty))
             } else {
                 Err(TypeSystemError::NoSuchType(type_name.to_owned()))
             }
@@ -406,7 +406,7 @@ impl TypeSystem {
         api_version: &str,
     ) -> Result<Arc<ObjectType>, TypeSystemError> {
         match self.lookup_builtin_type(type_name) {
-            Ok(Type::Object(ty)) => Ok(ty),
+            Ok(Type::Entity(ty)) => Ok(ty),
             Err(TypeSystemError::NotABuiltinType(_)) => {
                 self.lookup_custom_type(type_name, api_version)
             }
@@ -477,7 +477,7 @@ impl TypeSystem {
                 name: type_name,
                 backing_table: backing_table_name,
             };
-            Type::Object(Arc::new(
+            Type::Entity(Arc::new(
                 ObjectType::new(desc, fields, vec![], is_auth).unwrap(),
             ))
         });
@@ -490,7 +490,7 @@ pub(crate) enum Type {
     Float,
     Boolean,
     Id,
-    Object(Arc<ObjectType>),
+    Entity(Arc<ObjectType>),
 }
 
 impl Type {
@@ -500,7 +500,7 @@ impl Type {
             Type::Id => "string",
             Type::String => "string",
             Type::Boolean => "boolean",
-            Type::Object(ty) => &ty.name,
+            Type::Entity(ty) => &ty.name,
         }
     }
 }


### PR DESCRIPTION
This PR aims to make our type system more expressive and paves a way for extended typing support (`List`, `Array`, etc.)

There are multiple patches so reviewers are advised to go patch by patch. 
First thing this PR does is it introduces `Type::Entity(Entity)` and standalone `enum Entity {Auth, Custom}` types and makes amendments where necessary for the code to compile. 
Then it renames `add_builtin_object_type` -> `add_auth_type` and `add_type` -> `add_custom_type`.
Finally it brings home the idea and removes the `is_auth` field from `ObjectType` in favor of `Entity::is_auth` convenience method. 