### PR TITLE
Compile all sources in the graph

### DIFF
--- a/tsc_compile/src/lib.rs
+++ b/tsc_compile/src/lib.rs
@@ -368,8 +368,8 @@ impl Compiler {
         graph.valid()?;
 
         let mut root_code = "".to_string();
-        for u in &urls {
-            write!(root_code, "import \"{}\";", u.0).unwrap();
+        for u in graph.modules() {
+            write!(root_code, "import \"{}\";", u.specifier).unwrap();
         }
         root_code += "export {};";
 
@@ -741,6 +741,21 @@ export default foo;
     #[tokio::test]
     async fn deno_types() -> Result<()> {
         compile_ts_code(&["tests/deno_types.ts"], Default::default()).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn deno_types_import() -> Result<()> {
+        let written =
+            compile_ts_code(&["tests/deno_types_import/a.ts"], Default::default()).await?;
+        let mut keys: Vec<_> = written.keys().collect();
+        keys.sort();
+        let expected = vec![
+            "tests/deno_types_import/a.ts",
+            "tests/deno_types_import/b.js",
+            "tests/deno_types_import/c.ts",
+        ];
+        assert_eq!(keys, expected);
         Ok(())
     }
 

--- a/tsc_compile/src/lib.rs
+++ b/tsc_compile/src/lib.rs
@@ -391,13 +391,12 @@ impl Compiler {
             let emit_declarations = v8::Boolean::new(scope, opts.emit_declarations).into();
             let is_worker = v8::Boolean::new(scope, opts.is_worker).into();
 
-            let urls = vec![v8::String::new(scope, ROOT_URL).unwrap().into()];
-            let urls = v8::Array::new_with_elements(scope, &urls).into();
+            let root = v8::String::new(scope, ROOT_URL).unwrap().into();
             compile
                 .call(
                     scope,
                     global_proxy.into(),
-                    &[urls, is_worker, lib, emit_declarations],
+                    &[root, is_worker, lib, emit_declarations],
                 )
                 .unwrap();
         }

--- a/tsc_compile/tests/deno_types_import/a.ts
+++ b/tsc_compile/tests/deno_types_import/a.ts
@@ -1,0 +1,2 @@
+// @deno-types="./b.d.ts"
+export { foo } from "./b.js";

--- a/tsc_compile/tests/deno_types_import/b.d.ts
+++ b/tsc_compile/tests/deno_types_import/b.d.ts
@@ -1,0 +1,1 @@
+export const foo: number;

--- a/tsc_compile/tests/deno_types_import/b.js
+++ b/tsc_compile/tests/deno_types_import/b.js
@@ -1,0 +1,2 @@
+import { bar } from "./c.ts";
+export const foo = 42;

--- a/tsc_compile/tests/deno_types_import/c.ts
+++ b/tsc_compile/tests/deno_types_import/c.ts
@@ -1,0 +1,1 @@
+export const bar = 41;

--- a/tsc_compile_build/src/tsc.js
+++ b/tsc_compile_build/src/tsc.js
@@ -94,7 +94,7 @@
     };
 
     const readCache = {};
-    function compileAux(files, isWorker, lib, emitDeclarations) {
+    function compileAux(root, isWorker, lib, emitDeclarations) {
         const defaultLibs = [
             "lib.deno.unstable.d.ts",
             "lib.deno_core.d.ts",
@@ -125,7 +125,7 @@
             types: [],
         };
 
-        const program = ts.createProgram(files, options, host);
+        const program = ts.createProgram([root], options, host);
         const emitResult = program.emit();
 
         let allDiagnostics = ts
@@ -149,9 +149,9 @@
         }
     }
 
-    function compile(files, isWorker, lib, emitDeclarations) {
+    function compile(root, isWorker, lib, emitDeclarations) {
         try {
-            return compileAux(files, isWorker, lib, emitDeclarations);
+            return compileAux(root, isWorker, lib, emitDeclarations);
         } catch (e) {
             Deno.core.opSync("diagnostic", e.stack + "\n");
             return false;
@@ -186,8 +186,8 @@
         }
     }
 
-    compile(["bootstrap.ts"], false, undefined, false);
-    compile(["bootstrap.ts"], true, undefined, false);
+    compile("bootstrap.ts", false, undefined, false);
+    compile("bootstrap.ts", true, undefined, false);
 
     globalThis.compile = compile;
 })();


### PR DESCRIPTION
Support for deno-types is implemented by resolving a reference to a
.js to the corresponding .d.ts. This unfortunately means that if the
.js then references a .ts, we would not compile that .ts.
    
In the included example, we were not compiling c.ts.

Fix that by passing all the files that deno_graph finds to TSC.