### PR TITLE
Introduce more expressive type support in protobuf between client and server

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
+chisel_server = { package = "server", path = "../server" }
 endpoint_tsc = { path = "../endpoint_tsc" }
 handlebars = "4.2.2"
 nix = "0.22.2"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,7 +7,8 @@ use crate::server::{start_server, wait, wait_with_cond};
 use anyhow::{anyhow, Result};
 use chisel::chisel_rpc_client::ChiselRpcClient;
 use chisel::{
-    ChiselDeleteRequest, DescribeRequest, PopulateRequest, RestartRequest, StatusRequest,
+    type_msg::TypeEnum, ChiselDeleteRequest, DescribeRequest, PopulateRequest, RestartRequest,
+    StatusRequest,
 };
 use std::env;
 use std::fs;
@@ -192,17 +193,18 @@ async fn main() -> Result<()> {
                             labels.pop();
                             format!("@labels({}) ", labels)
                         };
+                        let field_type = field.field_type()?;
                         println!(
                             "    {}{}{}{}: {}{};",
                             if field.is_unique { "@unique " } else { "" },
                             labels,
                             field.name,
                             if field.is_optional { "?" } else { "" },
-                            field.field_type,
+                            field_type,
                             field
                                 .default_value
                                 .as_ref()
-                                .map(|d| if field.field_type == "string" {
+                                .map(|d| if matches!(field_type, TypeEnum::String(_)) {
                                     format!(" = \"{}\"", d)
                                 } else {
                                     format!(" = {}", d)

--- a/cli/src/ts.rs
+++ b/cli/src/ts.rs
@@ -164,14 +164,11 @@ fn validate_type_vec(type_vec: &[AddTypeRequest], valid_types: &BTreeSet<String>
 }
 
 fn parse_class_prop(x: &ClassProp, class_name: &str, handler: &Handler) -> Result<FieldDefinition> {
-    let (default_value, field_type) = match get_field_value(handler, &x.value)? {
-        None => (None, get_field_type(handler, &x.type_ann)?),
-        Some((val, t)) => (Some(val), t),
-    };
     let (field_name, is_optional) = get_field_info(handler, &x.key)?;
-
     anyhow::ensure!(field_name != "id", "Creating a field with the name `id` is not supported. 😟\nBut don't worry! ChiselStrike creates an id field automatically, and you can access it in your endpoints as {}.id 🤩", class_name);
 
+    let default_value = get_field_value(handler, &x.value)?.map(|(v, _)| v);
+    let field_type = get_field_type(handler, &x.type_ann)?;
     let (labels, is_unique) = get_type_decorators(handler, &x.decorators)?;
 
     Ok(FieldDefinition {

--- a/cli/src/ts.rs
+++ b/cli/src/ts.rs
@@ -1,5 +1,6 @@
 use crate::chisel::{AddTypeRequest, FieldDefinition};
 use anyhow::{anyhow, bail, ensure, Context, Result};
+use chisel_server::auth::is_auth_entity_name;
 use std::collections::BTreeSet;
 use std::path::Path;
 use swc_common::sync::Lrc;
@@ -142,15 +143,15 @@ fn get_type_decorators(handler: &Handler, x: &[Decorator]) -> Result<(Vec<String
 }
 
 fn validate_type_vec(type_vec: &[AddTypeRequest], valid_types: &BTreeSet<String>) -> Result<()> {
-    let mut builtin_types: BTreeSet<&str> = BTreeSet::new();
-    builtin_types.insert("string");
-    builtin_types.insert("number");
-    builtin_types.insert("boolean");
-    builtin_types.insert("AuthUser");
+    let mut scalar_types: BTreeSet<&str> = BTreeSet::new();
+    scalar_types.insert("string");
+    scalar_types.insert("number");
+    scalar_types.insert("boolean");
 
     for t in type_vec {
         for field in t.field_defs.iter() {
-            if builtin_types.get(&field.field_type as &str).is_none()
+            if scalar_types.get(&field.field_type as &str).is_none()
+                && !is_auth_entity_name(&field.field_type)
                 && valid_types.get(&field.field_type).is_none()
             {
                 bail!("field {} in class {} neither a basic type, nor refers to a type defined in this context",

--- a/cli/src/ts.rs
+++ b/cli/src/ts.rs
@@ -51,10 +51,6 @@ fn type_to_string(handler: &Handler, x: &TsType) -> Result<String> {
             TsEntityName::Ident(id) => Ok(ident_to_string(id)),
             TsEntityName::TsQualifiedName(_) => Err(anyhow!("qualified names not supported")),
         },
-        TsType::TsArrayType(arr) => {
-            Ok("Array[".to_string() + &type_to_string(handler, &arr.elem_type)? + "]")
-        }
-        TsType::TsOptionalType(opt) => Ok(type_to_string(handler, &opt.type_ann)? + "?"),
         t => Err(swc_err(handler, t, "type not supported")),
     }
 }

--- a/cli/tests/lit/types.deno
+++ b/cli/tests/lit/types.deno
@@ -46,7 +46,7 @@ set +e
 $CHISEL apply --allow-type-deletion 2>&1
 set -e
 
-# CHECK: field a in class Bad neither a basic type, nor refers to a type defined in this context
+# CHECK: Error: field 'a' in class 'Bad' is of unknown entity type 'SomeType'
 
 cat << EOF > "$TEMPDIR/models/types.ts"
 export class Malformed extends ChiselEntity { name: string(); }

--- a/proto/chisel.proto
+++ b/proto/chisel.proto
@@ -34,11 +34,20 @@ message TypeDefinition {
 
 message FieldDefinition {
   string name = 1;
-  string field_type = 2;
+  TypeMsg field_type = 2;
   repeated string labels = 3;
   bool is_optional = 4;
   optional string default_value = 5;
   bool is_unique = 6;
+}
+
+message TypeMsg {
+  oneof type_enum {
+    bool string = 1;
+    bool number = 2;
+    bool bool = 3;
+    string entity = 4;
+  };
 }
 
 message EndpointDefinition {

--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -18,6 +18,17 @@ pub(crate) const AUTH_SESSION_NAME: &str = "AuthSession";
 pub(crate) const AUTH_TOKEN_NAME: &str = "AuthToken";
 pub(crate) const AUTH_ACCOUNT_NAME: &str = "AuthAccount";
 
+const AUTH_ENTITY_NAMES: [&str; 4] = [
+    AUTH_USER_NAME,
+    AUTH_SESSION_NAME,
+    AUTH_TOKEN_NAME,
+    AUTH_ACCOUNT_NAME,
+];
+
+pub fn is_auth_entity_name(entity_name: &str) -> bool {
+    AUTH_ENTITY_NAMES.contains(&entity_name)
+}
+
 fn get_auth_user_type(state: &OpState) -> Result<Entity> {
     match lookup_builtin_type(state, AUTH_USER_NAME) {
         Ok(Type::Entity(t)) => Ok(t),

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -15,7 +15,7 @@ macro_rules! send_command {
 extern crate log;
 
 pub(crate) mod api;
-pub(crate) mod auth;
+pub mod auth;
 pub(crate) mod datastore;
 pub(crate) mod deno;
 pub(crate) mod internal;


### PR DESCRIPTION
Next PR in the `List` odyssey. 
This PR introduces new protobuf type 
```
message TypeMsg {
  oneof type_enum {
    bool string = 1;
    bool number = 2;
    bool bool = 3;
    string entity = 4;
  };
}
``` 
which represents various type flavors which map nicely to server's `Type` enum. I tried splitting the PR into multiple patches, but unfortunately, the main bulk of changes needs to go all at once to make the for a nice standalone commit. 