### PR TITLE
prepend chisel path to PATH when running test binaries

### DIFF
--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -1,8 +1,16 @@
 use std::env;
-use std::ffi::OsStr;
+use std::ffi::OsString;
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use std::process;
+
+use once_cell::sync::Lazy;
+
+pub static CHISEL_BIN_DIR: Lazy<PathBuf> = Lazy::new(|| repo_dir().join(".chisel_dev"));
+pub static CHISEL_LOCAL_PATH: Lazy<OsString> = Lazy::new(|| {
+    let new_path = format!("{}/bin:{}", CHISEL_BIN_DIR.display(), env!("PATH"));
+    OsString::from(new_path)
+});
 
 pub struct Command {
     inner: process::Command,
@@ -29,12 +37,7 @@ impl DerefMut for Command {
 }
 
 #[allow(dead_code)]
-pub fn run_in<'a, T: IntoIterator<Item = &'a str>>(
-    cmd: &str,
-    args: T,
-    dir: PathBuf,
-    path: Option<&OsStr>,
-) -> Command {
+pub fn run_in<'a, T: IntoIterator<Item = &'a str>>(cmd: &str, args: T, dir: PathBuf) -> Command {
     assert!(
         dir.exists(),
         "{:?} does not exist. Current directory is {:?}",
@@ -45,20 +48,14 @@ pub fn run_in<'a, T: IntoIterator<Item = &'a str>>(
     let mut inner = process::Command::new(cmd);
     inner.args(args).current_dir(dir);
 
-    if let Some(path) = path {
-        inner.env("PATH", path);
-    }
+    inner.env("PATH", &*CHISEL_LOCAL_PATH);
 
     Command { inner }
 }
 
 #[allow(dead_code)]
-pub fn run<'a, T: IntoIterator<Item = &'a str>>(
-    cmd: &str,
-    args: T,
-    path: Option<&OsStr>,
-) -> Command {
-    run_in(cmd, args, repo_dir(), path)
+pub fn run<'a, T: IntoIterator<Item = &'a str>>(cmd: &str, args: T) -> Command {
+    run_in(cmd, args, repo_dir())
 }
 
 #[allow(dead_code)]

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -75,7 +75,7 @@ fn chisel() -> String {
 fn main() {
     // install the current packages in our package.json. This will make things like esbuild
     // generally available. Tests that want a specific extra package can then install on top
-    run("npm", ["install"], None);
+    run("npm", ["install"]);
 
     let opt = Opt::from_args();
 
@@ -84,7 +84,7 @@ fn main() {
     if bd.ends_with("release") {
         args.push("--release");
     }
-    run("cargo", args, None);
+    run("cargo", args);
 
     let ok_without_optimization = run_tests(opt.clone(), false);
     let ok_with_optimization = run_tests(opt, true);

--- a/cli/tests/linters.rs
+++ b/cli/tests/linters.rs
@@ -4,22 +4,13 @@ mod common;
 
 #[cfg(test)]
 mod tests {
-    use crate::common::{repo_dir, run, Command};
-    use once_cell::sync::Lazy;
-    use std::ffi::OsString;
+    use crate::common::{repo_dir, run, Command, CHISEL_BIN_DIR};
     use std::fs::{create_dir_all, File};
     use std::io::Read;
-    use std::path::PathBuf;
     use toml::Value;
 
-    static CHISEL_BIN_CACHE: Lazy<PathBuf> = Lazy::new(|| repo_dir().join(".chisel_dev"));
-    static CHISEL_CARGO_PATH: Lazy<OsString> = Lazy::new(|| {
-        let new_path = format!("{}/bin:{}", CHISEL_BIN_CACHE.display(), env!("PATH"));
-        OsString::from(new_path)
-    });
-
     fn cargo<'a, T: IntoIterator<Item = &'a str>>(args: T) -> Command {
-        run("cargo", args, Some(&CHISEL_CARGO_PATH))
+        run("cargo", args)
     }
 
     fn nightly<'a, T: IntoIterator<Item = &'a str>>(args: T) -> Command {
@@ -29,7 +20,7 @@ mod tests {
     }
 
     fn cargo_install(version: &str, pkg: &str, bin: &str) {
-        create_dir_all(&*CHISEL_BIN_CACHE).unwrap();
+        create_dir_all(&*CHISEL_BIN_DIR).unwrap();
         cargo([
             "install",
             "--version",
@@ -39,14 +30,14 @@ mod tests {
             bin,
             "--locked",
             "--root",
-            &CHISEL_BIN_CACHE.display().to_string(),
+            &CHISEL_BIN_DIR.display().to_string(),
         ]);
     }
 
     #[test]
     fn eslint() {
-        run("npm", ["install"], None);
-        run("npx", ["eslint", ".", "--ext", ".ts"], None);
+        run("npm", ["install"]);
+        run("npx", ["eslint", ".", "--ext", ".ts"]);
     }
 
     fn get_deno_version() -> String {
@@ -66,8 +57,8 @@ mod tests {
         // because that always reinstall the binary.
         let version = get_deno_version();
         cargo_install(&version, "deno", "deno");
-        run("deno", ["lint", "--config", "deno.json"], None);
-        run("deno", ["fmt", "--config", "deno.json", "--check"], None);
+        run("deno", ["lint", "--config", "deno.json"]);
+        run("deno", ["fmt", "--config", "deno.json", "--check"]);
     }
 
     #[test]


### PR DESCRIPTION
This pr fixes the failing CI tests, caused by the deno binary not being found.

I still have no explanation as to why the CI passed in the first place.
