### PR TITLE
pass cli args to chiseld

### DIFF
--- a/cli/src/cmd/dev.rs
+++ b/cli/src/cmd/dev.rs
@@ -17,7 +17,11 @@ use std::time::Duration;
 use tokio::task::JoinHandle;
 use tsc_compile::deno_core;
 
-pub(crate) async fn cmd_dev(server_url: String, type_check: bool) -> Result<()> {
+pub(crate) async fn cmd_dev(
+    server_url: String,
+    type_check: bool,
+    chiseld_args: Vec<String>,
+) -> Result<()> {
     let type_check = type_check.into();
     let manifest = read_manifest()?;
     let (signal_tx, mut signal_rx) = utils::make_signal_channel();
@@ -33,7 +37,7 @@ pub(crate) async fn cmd_dev(server_url: String, type_check: bool) -> Result<()> 
         signal_tx.send(()).await?;
         Ok(())
     });
-    let mut server = start_server()?;
+    let mut server = start_server(chiseld_args)?;
     wait(server_url.clone()).await?;
     apply_from_dev(server_url.clone(), type_check).await;
     let (mut watcher_tx, mut watcher_rx) = channel(1);

--- a/cli/src/server.rs
+++ b/cli/src/server.rs
@@ -9,7 +9,7 @@ use std::thread;
 use std::time::Duration;
 use tonic::transport::Channel;
 
-pub(crate) fn start_server() -> anyhow::Result<std::process::Child> {
+pub(crate) fn start_server(chiseld_args: Vec<String>) -> anyhow::Result<std::process::Child> {
     println!("🚀 Thank you for your interest in the ChiselStrike beta! 🚀");
     println!();
     println!("⚠️  This software is for evaluation purposes only. Do not use it in production. ⚠️ ");
@@ -27,7 +27,7 @@ pub(crate) fn start_server() -> anyhow::Result<std::process::Child> {
     cmd.pop();
     cmd.push("chiseld");
     let server = match std::process::Command::new(cmd.clone())
-        .args(std::env::args().skip(2))
+        .args(chiseld_args)
         .spawn() {
             Ok(server) => server,
             Err(e) => {


### PR DESCRIPTION
Pass any cli arguments after a `--` to chiseld on  `start` and `dev`
command, e.g:

`chiseld dev -- --help` : prints chiseld help


Followup: 
- I need another PR to make chiselstrike correctly exit when chiseld exits.
- Add test
- Add documentation