### PR TITLE
spawn chiseld with tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,7 @@ version = "0.11.0-dev.0"
 dependencies = [
  "anyhow",
  "endpoint_tsc",
+ "futures",
  "glob",
  "handlebars",
  "itertools 0.10.3",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 anyhow = "1.0"
 chisel_server = { package = "server", path = "../server" }
 endpoint_tsc = { path = "../endpoint_tsc" }
+futures = "0.3.21"
 handlebars = "4.2.2"
 nix = "0.22.2"
 notify = "5.0.0-pre.12"

--- a/cli/src/cmd/dev.rs
+++ b/cli/src/cmd/dev.rs
@@ -102,8 +102,8 @@ pub(crate) async fn cmd_dev(
             }
         }
     }
-    server.kill()?;
-    server.wait()?;
+    server.kill().await?;
+    server.wait().await?;
     sig_task.await??;
 
     Ok(())

--- a/cli/src/cmd/dev.rs
+++ b/cli/src/cmd/dev.rs
@@ -2,7 +2,7 @@
 
 use crate::cmd::apply::{apply, AllowTypeDeletion, TypeChecking};
 use crate::project::read_manifest;
-use crate::server::{start_server, wait};
+use crate::server::wait;
 use crate::DEFAULT_API_VERSION;
 use anyhow::Result;
 use deno_core::futures;
@@ -20,8 +20,7 @@ use tsc_compile::deno_core;
 pub(crate) async fn cmd_dev(
     server_url: String,
     type_check: bool,
-    chiseld_args: Vec<String>,
-) -> Result<()> {
+) -> Result<JoinHandle<Result<()>>> {
     let type_check = type_check.into();
     let manifest = read_manifest()?;
     let (signal_tx, mut signal_rx) = utils::make_signal_channel();
@@ -37,7 +36,6 @@ pub(crate) async fn cmd_dev(
         signal_tx.send(()).await?;
         Ok(())
     });
-    let mut server = start_server(chiseld_args)?;
     wait(server_url.clone()).await?;
     apply_from_dev(server_url.clone(), type_check).await;
     let (mut watcher_tx, mut watcher_rx) = channel(1);
@@ -102,11 +100,7 @@ pub(crate) async fn cmd_dev(
             }
         }
     }
-    server.kill().await?;
-    server.wait().await?;
-    sig_task.await??;
-
-    Ok(())
+    Ok(sig_task)
 }
 
 async fn apply_from_dev(server_url: String, type_check: TypeChecking) {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -263,7 +263,7 @@ async fn main() -> Result<()> {
         Command::Start => {
             let mut server = start_server(chiseld_args)?;
             wait(server_url).await?;
-            server.wait()?;
+            server.wait().await?;
         }
         Command::Status => {
             let mut client = ChiselRpcClient::connect(server_url).await?;

--- a/cli/src/server.rs
+++ b/cli/src/server.rs
@@ -9,7 +9,7 @@ use std::thread;
 use std::time::Duration;
 use tonic::transport::Channel;
 
-pub(crate) fn start_server(chiseld_args: Vec<String>) -> anyhow::Result<std::process::Child> {
+pub(crate) fn start_server(chiseld_args: Vec<String>) -> anyhow::Result<tokio::process::Child> {
     println!("🚀 Thank you for your interest in the ChiselStrike beta! 🚀");
     println!();
     println!("⚠️  This software is for evaluation purposes only. Do not use it in production. ⚠️ ");
@@ -26,7 +26,7 @@ pub(crate) fn start_server(chiseld_args: Vec<String>) -> anyhow::Result<std::pro
     let mut cmd = std::env::current_exe()?;
     cmd.pop();
     cmd.push("chiseld");
-    let server = match std::process::Command::new(cmd.clone())
+    let server = match tokio::process::Command::new(cmd.clone())
         .args(chiseld_args)
         .spawn() {
             Ok(server) => server,


### PR DESCRIPTION
Spawn chiseld command with tokio instead of std.

This allows us to early exit when chiseld exit.

This is necessary for cases where chiseld would exit while chisel is still waiting for it to go up:
```
chisel start -- --help
```

in this case, we were waiting for the server url, before checking if it had exited (https://github.com/chiselstrike/chiselstrike/pull/1523/files#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bL265), basically blocking the process.

followup to #1521
