### PR TITLE
refactor(chisel-secret): change the error response

### DIFF
--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -1193,7 +1193,7 @@ async fn special_response(
     if req_path.starts_with("/__chiselstrike/auth/") {
         let auth_header = req.headers().get("ChiselAuth");
         if auth_header.is_none() {
-            return Ok(Some(ApiService::forbidden("ChiselAuth")?));
+            return Ok(Some(ApiService::forbidden("AuthSecret")?));
         }
         let expected_secret = current_secrets(&state.borrow())
             .get("CHISELD_AUTH_SECRET")


### PR DESCRIPTION
## Description

Change the error response from 'ChiselAuth' to 'AuthSecret' to match the web UI text as @dekimir suggested [here](https://github.com/chiselstrike/frontend/issues/486#issuecomment-1171333695)

## Related

- https://github.com/chiselstrike/frontend/pull/509