### PR TITLE
add --show-config cli option

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -52,6 +52,12 @@ async fn main() -> Result<()> {
         }
     };
 
+    if opt.show_config {
+        let config = serde_json::to_string(&opt)?;
+        println!("{config}");
+        return Ok(());
+    }
+
     if let DoRepeat::Yes = server::run_all(opt).await? {
         info!("Restarting");
         execv(&CString::new(exe).unwrap(), &args).unwrap();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -23,7 +23,7 @@ use enclose::enclose;
 use futures::future::LocalBoxFuture;
 use futures::FutureExt;
 use futures::StreamExt;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
@@ -35,7 +35,7 @@ use structopt_toml::StructOptToml;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 
-#[derive(StructOpt, Debug, Clone, StructOptToml, Deserialize)]
+#[derive(StructOpt, Debug, Clone, StructOptToml, Deserialize, Serialize)]
 #[structopt(name = "chiseld", version = env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT"))]
 #[serde(deny_unknown_fields, default)]
 pub struct Opt {
@@ -73,6 +73,13 @@ pub struct Opt {
     #[structopt(long, short)]
     #[serde(skip)]
     pub config: Option<PathBuf>,
+
+    /// Prints the configuration resulting from the merging of all the configuration sources,
+    /// including default values, in the JSON format.
+    /// This is the configuration that will be used when starting chiseld.
+    #[structopt(long)]
+    #[serde(skip)]
+    pub show_config: bool,
 }
 
 impl Opt {


### PR DESCRIPTION
This pr adds a `--show-config` flag on chiseld that outputs the configuration that would be used if the server was run, and then exits.

This is useful for two reason:
- Since we now have support for configuration file, it is helpful to be able to print what is the actual configuration of the instance, accounting for environment variables, config file, and cli arguments
- This will allow us to write test for both configuration files, and config being passed through the cli to chiseld
