### PR TITLE
chiseld test config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4475,9 +4475,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-toml"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27d68c57e6cc3fb03041c49534e50a6ccef677c511effc1c5bf12a4bc865a62"
+checksum = "4d887e6156acb1f4e2d2968d61d1d3b6c5e102af5f23c3ca606723b5ac2c45cb"
 dependencies = [
  "anyhow",
  "clap",
@@ -4491,10 +4491,11 @@ dependencies = [
 
 [[package]]
 name = "structopt-toml-derive"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316302a563af68baf93e5e77b8355a8bfe168c67c4424623365ca5bf521d013e"
+checksum = "216c57b49178d22a3ec2f0ce5e961219d11772f7ca70b00c08879d15827d6daf"
 dependencies = [
+ "heck 0.4.0",
  "proc-macro2 1.0.40",
  "quote 1.0.20",
  "syn 1.0.98",

--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -18,8 +18,10 @@ pub struct Command {
 
 impl Drop for Command {
     fn drop(&mut self) {
-        let status = self.inner.status().unwrap();
-        assert!(status.success());
+        let out = self.inner.output().unwrap();
+        let stderr = std::str::from_utf8(&out.stderr).unwrap();
+        eprintln!("{stderr}");
+        assert!(out.status.success());
     }
 }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -51,7 +51,7 @@ sqlx = { version = "0.6.0", features = [
     "runtime-tokio-rustls",
 ] }
 structopt = "0.3.23"
-structopt-toml = "0.5.0"
+structopt-toml = "0.5.1"
 thiserror = "1.0"
 tokio = { version = "1.11.0", features = ["rt", "time"] }
 tonic = "0.5.2"

--- a/server/tests/test_config_file.rs
+++ b/server/tests/test_config_file.rs
@@ -1,0 +1,183 @@
+use std::fs::create_dir_all;
+use std::io::Write;
+use std::path::PathBuf;
+
+use tempfile::{NamedTempFile, TempDir};
+
+fn chiseld() -> PathBuf {
+    let mut current_exe = std::env::current_exe().unwrap();
+    current_exe.pop();
+    current_exe.pop();
+    current_exe.join("chiseld")
+}
+
+fn chiseld_check_config(args: &[&str], env: &[(&str, &str)]) -> serde_json::Value {
+    let mut cmd = std::process::Command::new(chiseld());
+
+    cmd.args(args);
+    cmd.envs(env.iter().cloned());
+    cmd.arg("--show-config");
+
+    let out = cmd.output().unwrap();
+
+    let stderr = std::str::from_utf8(&out.stderr).unwrap();
+    println!("{stderr}");
+
+    assert!(out.status.success());
+
+    serde_json::from_slice(&out.stdout).unwrap()
+}
+
+fn write_config(s: &str) -> NamedTempFile {
+    let mut file = NamedTempFile::new().unwrap();
+    file.write_all(s.as_bytes()).unwrap();
+    file.flush().unwrap();
+
+    file
+}
+
+#[allow(dead_code)]
+fn write_config_default_path(s: &str) -> TempDir {
+    let tmp_dir = tempfile::tempdir().unwrap();
+
+    let chisel_dir = tmp_dir.path().join("chiselstrike");
+    create_dir_all(&chisel_dir).unwrap();
+
+    std::fs::write(chisel_dir.join("config.toml"), s.as_bytes()).unwrap();
+
+    tmp_dir
+}
+
+#[test]
+fn test_simple_config_file() {
+    let conf = write_config(
+        r#"
+api_listen_addr = "localhost:12345"
+executor_threads = 21
+    "#,
+    );
+    let out = chiseld_check_config(&["-c", &conf.path().display().to_string()], &[]);
+
+    let expected = serde_json::json!({
+        "api_listen_addr": "localhost:12345",
+        "rpc_listen_addr":"127.0.0.1:50051",
+        "internal_routes_listen_addr":"127.0.0.1:9090",
+        "_metadata_db_uri":"sqlite://chiseld.db?mode=rwc",
+        "_data_db_uri":"sqlite://chiseld-data.db?mode=rwc",
+        "db_uri":"sqlite://.chiseld.db?mode=rwc",
+        "inspect_brk":false,
+        "nr_connections":10,
+        "executor_threads":21,
+        "webui":false
+    });
+
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn test_simple_cli_priority() {
+    let conf = write_config(
+        r#"
+api_listen_addr = "localhost:12345"
+executor_threads = 21
+    "#,
+    );
+    let out = chiseld_check_config(
+        &[
+            "-c",
+            &conf.path().display().to_string(),
+            "--api-listen-addr",
+            "localhost:123457",
+        ],
+        &[],
+    );
+
+    let expected = serde_json::json!({
+        "api_listen_addr": "localhost:123457",
+        "rpc_listen_addr":"127.0.0.1:50051",
+        "internal_routes_listen_addr":"127.0.0.1:9090",
+        "_metadata_db_uri":"sqlite://chiseld.db?mode=rwc",
+        "_data_db_uri":"sqlite://chiseld-data.db?mode=rwc",
+        "db_uri":"sqlite://.chiseld.db?mode=rwc",
+        "inspect_brk":false,
+        "nr_connections":10,
+        "executor_threads":21,
+        "webui":false
+    });
+
+    assert_eq!(out, expected);
+}
+
+#[test]
+// we can only run this test on linux, since we are setting XDG_CONFIG_HOME
+#[cfg(target_os = "linux")]
+fn test_default_file_location() {
+    let conf = write_config_default_path(
+        r#"
+api_listen_addr = "localhost:12345"
+executor_threads = 21
+    "#,
+    );
+
+    let out = chiseld_check_config(
+        &[],
+        &[("XDG_CONFIG_HOME", &conf.path().display().to_string())],
+    );
+
+    let expected = serde_json::json!({
+        "api_listen_addr": "localhost:12345",
+        "rpc_listen_addr":"127.0.0.1:50051",
+        "internal_routes_listen_addr":"127.0.0.1:9090",
+        "_metadata_db_uri":"sqlite://chiseld.db?mode=rwc",
+        "_data_db_uri":"sqlite://chiseld-data.db?mode=rwc",
+        "db_uri":"sqlite://.chiseld.db?mode=rwc",
+        "inspect_brk":false,
+        "nr_connections":10,
+        "executor_threads":21,
+        "webui":false
+    });
+
+    assert_eq!(out, expected);
+}
+
+#[test]
+// we can only run this test on linux, since we are setting XDG_CONFIG_HOME
+#[cfg(target_os = "linux")]
+fn exlicit_config_file_over_default() {
+    let default_conf = write_config_default_path(
+        r#"
+api_listen_addr = "localhost:12345"
+executor_threads = 21
+    "#,
+    );
+
+    let explicit_conf = write_config(
+        r#"
+api_listen_addr = "localhost:12346"
+executor_threads = 21
+    "#,
+    );
+
+    let out = chiseld_check_config(
+        &["-c", &explicit_conf.path().display().to_string()],
+        &[(
+            "XDG_CONFIG_HOME",
+            &default_conf.path().display().to_string(),
+        )],
+    );
+
+    let expected = serde_json::json!({
+        "api_listen_addr": "localhost:12346",
+        "rpc_listen_addr":"127.0.0.1:50051",
+        "internal_routes_listen_addr":"127.0.0.1:9090",
+        "_metadata_db_uri":"sqlite://chiseld.db?mode=rwc",
+        "_data_db_uri":"sqlite://chiseld-data.db?mode=rwc",
+        "db_uri":"sqlite://.chiseld.db?mode=rwc",
+        "inspect_brk":false,
+        "nr_connections":10,
+        "executor_threads":21,
+        "webui":false
+    });
+
+    assert_eq!(out, expected);
+}


### PR DESCRIPTION
add test for configuration file.

I have caught a bug in the library that handle the toml parsing for us in the meantime, and there is already an open PR to fix it https://github.com/dalance/structopt-toml/pull/28. It hasn't been merged in a long time, but I have pinged the owner to see if we can get it merged.

We should probably for this, for safety, until this is merged.
