### PR TITLE
scripts: Add centos-devtool helper

### DIFF
--- a/scripts/centos-devtool
+++ b/scripts/centos-devtool
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+podman run \
+	-it \
+	-v $(pwd):/src:Z \
+	--privileged \
+        --pids-limit -1 \
+	centos:7 \
+	/bin/bash


### PR DESCRIPTION
This adds a helper script to start a CentOS 7 container within the
source tree for building releases. Please note that you need to install
prerequisites in the container as per RELEASING.md.