### PR TITLE
Switch to self-hosted runners in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
     - name: checkout repo
       uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,10 @@ jobs:
       with:
           components: rustfmt, clippy
 
+    - uses: actions/setup-node@v3
+      with:
+          node-version: 16
+
     - name: Install nightly rust toolchain
       uses: actions-rs/toolchain@v1
       with:

--- a/cli/tests/lit/introspect.node
+++ b/cli/tests/lit/introspect.node
@@ -57,7 +57,7 @@ $CURL $CHISELD_HOST/dev
 # CHECK: "title": "glauber",
 # CHECK: "version": "1.0.0"
 
-git init ./ --initial-branch main
+git init ./
 git add endpoints/simple.ts
 git commit -m "test"
 $CHISEL apply


### PR DESCRIPTION
Github hosted runners are struggling with the linters at least, with a
total runtime of 40 minutes per build (!).

We have some beefier self-hosted Github runners so use them instead.