### PR TITLE
Use our forked version of lit in chiselc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,7 +572,7 @@ version = "0.12.0-dev.0"
 dependencies = [
  "anyhow",
  "indexmap",
- "lit 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lit",
  "serde",
  "serde_json",
  "structopt",
@@ -639,7 +639,7 @@ dependencies = [
  "glob",
  "handlebars",
  "itertools 0.10.3",
- "lit 1.0.4 (git+https://github.com/chiselstrike/lit?rev=607b0b9)",
+ "lit",
  "nix 0.22.3",
  "notify",
  "once_cell",
@@ -2599,23 +2599,6 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "lit"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d656b480f604e908333274aaed8ff1d2dc1b52f2a285c2003c560a400d0b39c5"
-dependencies = [
- "clap",
- "error-chain",
- "itertools 0.9.0",
- "lazy_static",
- "log",
- "regex",
- "tempfile",
- "term",
- "walkdir",
-]
 
 [[package]]
 name = "lit"

--- a/chiselc/Cargo.toml
+++ b/chiselc/Cargo.toml
@@ -18,4 +18,4 @@ swc_ecma_codegen_macros = "=0.7.0"
 swc_ecmascript = { version = "0.143.0", features = ["codegen", "parser", "visit", "transforms", "typescript"] }
 
 [dev-dependencies]
-lit = "1.0.4"
+lit = { git = "https://github.com/chiselstrike/lit", rev = "607b0b9" }

--- a/chiselc/tests/integration_test.rs
+++ b/chiselc/tests/integration_test.rs
@@ -25,6 +25,7 @@ mod tests {
             config.add_extension("lit");
             config.constants.insert("chiselc".to_owned(), chiselc());
             config.truncate_output_context_to_number_of_lines = Some(80);
+            config.always_show_stdout = false;
         })
         .expect("Lit tests failed");
     }


### PR DESCRIPTION
Uses our forked version of lit crate in chiselc, adds convenience `config.always_show_stdout = false;` line.