### PR TITLE
Use "rebase" as Mergify update method

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,6 +11,7 @@ pull_request_rules:
     actions:
       queue:
         name: default
+        update_method: rebase
         method: merge
         commit_message_template: |
             Merge #{{number}} '{{title}}'
@@ -24,4 +25,5 @@ pull_request_rules:
     actions:
       queue:
         name: default
+        update_method: rebase
         method: rebase


### PR DESCRIPTION
Right now, if `main` has changed after tests passed, Mergify will
*merge* `main` and re-run tests. Instead, let's use the `rebase` update
method to get a cleaner git history.