### PR TITLE
server: Enable SO_REUSEPORT for the Tonic server

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -399,11 +399,8 @@ async fn run_shared_state(
     };
 
     let rpc_rx = signal_rx.clone();
-    let shutdown = async move {
-        rpc_rx.recv().await.ok();
-    };
 
-    let rpc_task = crate::rpc::spawn(rpc, opt.rpc_listen_addr, start_wait, shutdown);
+    let rpc_task = crate::rpc::spawn(rpc, opt.rpc_listen_addr, start_wait, rpc_rx);
     debug!("RPC is ready. URL: {}", opt.rpc_listen_addr);
 
     crate::internal::init(


### PR DESCRIPTION
We're seeing the following error that results in `chisel wait` timing
out in CI runs:

```
Error: transport error

 Caused by:
     0: error creating server listener: Address already in use (os error 98)
     1: Address already in use (os error 98)
```

One possible explanation for this bug is that as we recycle port
numbers, we attempt to reuse a port that's still in TIME_WAIT state
(process terminated, but TCP stack not ready to give it back).

Therefore, like we already do for the API server, let's enable
SO_REUSEPORT for the Tonic server too.