### PR TITLE
api: adds the map operator

### DIFF
--- a/cli/tests/lit/map.deno
+++ b/cli/tests/lit/map.deno
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com>
+
+# RUN: sh -e @file
+
+cd "$TEMPDIR"
+
+cat << EOF > "$TEMPDIR/models/types.ts"
+import { ChiselEntity } from "@chiselstrike/api";
+
+export class Person extends ChiselEntity {
+  name: string = "bob";
+  company: string = "ChiselStrike";
+}
+EOF
+
+cat << EOF > "$TEMPDIR/endpoints/store.ts"
+import { Person } from "../models/types.ts";
+
+export default async function chisel() {
+    const person = new Person();
+    await person.save();
+    return "Ok"
+}
+EOF
+
+cat << EOF > "$TEMPDIR/endpoints/maparray.ts"
+import { Person } from "../models/types.ts";
+
+export default async function chisel(): Promise<Array<number>> {
+    return Person.cursor().map(x => x.name.length).toArray()
+}
+EOF
+
+cat << EOF > "$TEMPDIR/endpoints/mapfor.ts"
+import { Person } from "../models/types.ts";
+
+export default async function chisel(): Promise<number> {
+  let count = 0;
+  for await (const e of Person.cursor().map(x => x.name.length)) {
+      count += e;
+  }
+  return count;
+}
+EOF
+
+cat << EOF > "$TEMPDIR/endpoints/doublemap.ts"
+import { Person } from "../models/types.ts";
+
+export default async function chisel(): Promise<Array<number>> {
+  return Person.cursor().map(x => x.name.length).map(x => x + 10).toArray()
+}
+EOF
+
+cat << EOF > "$TEMPDIR/endpoints/maptake.ts"
+import { Person } from "../models/types.ts";
+
+export default async function chisel(): Promise<number> {
+  const a = await Person.cursor().map(x => x.name.length).map(x => x + 10).take(0).toArray()
+  return a.length
+}
+EOF
+
+
+cat << EOF > "$TEMPDIR/endpoints/mapskip.ts"
+import { Person } from "../models/types.ts";
+
+export default async function chisel(): Promise<number> {
+  const a = await Person.cursor().map(x => x.name.length).map(x => x + 10).skip(1).toArray()
+  return a.length
+}
+EOF
+
+cat << EOF > "$TEMPDIR/endpoints/mapfilter.ts"
+import { Person } from "../models/types.ts";
+
+export default async function chisel(): Promise<number> {
+  const a = await Person.cursor().map(x => x.name.length).map(x => x + 10).filter(x => x > 0).toArray()
+  return a.length
+}
+EOF
+
+
+$CHISEL apply
+
+# CHECK: Model defined: Person
+
+$CURL -X POST $CHISELD_HOST/dev/store
+# CHECK: Ok
+
+$CURL $CHISELD_HOST/dev/maparray
+# CHECK: 3
+
+$CURL $CHISELD_HOST/dev/mapfor
+# CHECK: 3
+
+$CURL $CHISELD_HOST/dev/doublemap
+# CHECK: 13
+
+$CURL $CHISELD_HOST/dev/maptake
+# CHECK: 0
+
+$CURL $CHISELD_HOST/dev/mapskip
+# CHECK: 0
+
+$CURL $CHISELD_HOST/dev/mapfilter
+# CHECK: 1

--- a/docusaurus/docs/InDepth/cursors.md
+++ b/docusaurus/docs/InDepth/cursors.md
@@ -46,6 +46,7 @@ The methods provided by `ChiselCursor` are:
 | `sortBy(key, ascending)`| Require the elements to be sorted by a given `key` (field) of the entity. |
 | `minBy(key)`            | Select minimal value over entities' `key` (field) |
 | `maxBy(key)`            | Select maximal value over entities' `key` (field) |
+| `map(function)`         | Returns another cursor with the result of applying `function` to each element of the original cursor |
 | `toArray()`             | Convert this cursor to an array.  |
 
 <!-- FIXME : without examples it's unclear what a restrictions object or a function predicate is, this needs a simpler explanation with examples. -->


### PR DESCRIPTION
map is a classic operation that is provided by Array and frankly many
other primitives.

This simple version executes the code in typescript, but already has
the added advantage of not forcing the full materialization of the array
prior to map, as would be the case with toArray.map().

In the near future we can pass many of these functions to the database.