### PR TITLE
Rename Expr::Literal to Expr::Value.

### DIFF
--- a/api/src/chisel.ts
+++ b/api/src/chisel.ts
@@ -1099,7 +1099,7 @@ function restrictionsToFilterExpr<T extends ChiselEntity>(
             },
             op: "Eq",
             right: {
-                exprType: "Literal",
+                exprType: "Value",
                 value: restrictions[key],
             },
         };

--- a/chiselc/docs/query-expr.md
+++ b/chiselc/docs/query-expr.md
@@ -21,7 +21,7 @@ BlogPost.cursor().filter({
     property: { exprType: "Identifier", value: "name" },
   },
   op: "=",
-  right: { exprType: "Literal", value: "Glauber" },
+  right: { exprType: "Value", value: "Glauber" },
 });
 ```
 
@@ -44,10 +44,10 @@ The `exprType` of an identifier expression is `Identifier`.
 
 An identifier expression has a property `ident`, which is a string representing the identifier symbol.
 
-### Literal
+### Value
 
-The `exprType` of a literal is `Literal`.
-A literal has a `value` property, which can be a `string` or a `number`.
+The `exprType` of a value is `Value`.
+A value has a `value` property, which can be a `string` or a `number`.
 
 ### Parameter
 

--- a/chiselc/src/query.rs
+++ b/chiselc/src/query.rs
@@ -16,8 +16,8 @@ pub enum Expr {
     PropertyAccess(PropertyAccessExpr),
     /// An identifier expression.
     Identifier(String),
-    /// A literal expression.
-    Literal(Literal),
+    /// A value expression.
+    Value(Value),
 }
 
 /// A binary expression.
@@ -48,9 +48,9 @@ pub enum BinaryOp {
     Or,
 }
 
-/// A literal expression
+/// A value expression
 #[derive(Debug)]
-pub enum Literal {
+pub enum Value {
     Bool(bool),
     Num(f64),
     Str(String),

--- a/chiselc/src/transforms/filter/emit.rs
+++ b/chiselc/src/transforms/filter/emit.rs
@@ -15,9 +15,9 @@ use crate::query::BinaryExpr as QBinaryExpr;
 use crate::query::BinaryOp as QBinaryOp;
 use crate::query::Expr as QExpr;
 use crate::query::Filter;
-use crate::query::Literal as QLiteral;
 use crate::query::Operator;
 use crate::query::PropertyAccessExpr;
+use crate::query::Value as QValue;
 use swc_atoms::JsWord;
 use swc_common::Span;
 use swc_ecmascript::ast::Number;
@@ -106,7 +106,7 @@ fn expr_to_ts(expr: &QExpr, params: &[String], span: Span) -> Expr {
             property_access_to_ts(property_access_expr, params, span)
         }
         QExpr::Identifier(ident) => identifier_to_ts(ident, params, span),
-        QExpr::Literal(lit) => literal_to_ts(lit, span),
+        QExpr::Value(val) => value_to_ts(val, span),
     }
 }
 
@@ -214,12 +214,12 @@ fn identifier_to_ts(ident: &str, params: &[String], span: Span) -> Expr {
     Expr::Object(ObjectLit { span, props })
 }
 
-fn literal_to_ts(lit: &QLiteral, span: Span) -> Expr {
-    let mut props = vec![make_expr_type("Literal", span)];
+fn value_to_ts(lit: &QValue, span: Span) -> Expr {
+    let mut props = vec![make_expr_type("Value", span)];
     let lit = match lit {
-        QLiteral::Bool(v) => make_bool_lit(*v, span),
-        QLiteral::Str(s) => make_str_lit(s, span),
-        QLiteral::Num(n) => make_num_lit(n, span),
+        QValue::Bool(v) => make_bool_lit(*v, span),
+        QValue::Str(s) => make_str_lit(s, span),
+        QValue::Num(n) => make_num_lit(n, span),
     };
     let lit = PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
         key: PropName::Ident(Ident {

--- a/chiselc/src/transforms/utils.rs
+++ b/chiselc/src/transforms/utils.rs
@@ -3,10 +3,10 @@ use crate::query::BinaryExpr as QBinaryExpr;
 use crate::query::BinaryOp as QBinaryOp;
 use crate::query::Expr as QExpr;
 use crate::query::Filter as QFilter;
-use crate::query::Literal as QLiteral;
 use crate::query::Operator as QOperator;
 use crate::query::PropertyAccessExpr as QPropertyAccessExpr;
 use crate::query::Scan as QScan;
+use crate::query::Value as QValue;
 use crate::transforms::filter::splitting::{rewrite_filter_arrow, split_and_convert_expr};
 use crate::utils::pat_to_string;
 use anyhow::Result;
@@ -112,7 +112,7 @@ pub fn extract_filter(
 pub fn convert_filter_expr(expr: &Expr) -> Option<QExpr> {
     match expr {
         Expr::Bin(bin_expr) => convert_bin_expr(bin_expr),
-        Expr::Lit(Lit::Bool(value)) => Some(QExpr::Literal(QLiteral::Bool(value.value))),
+        Expr::Lit(Lit::Bool(value)) => Some(QExpr::Value(QValue::Bool(value.value))),
         _ => None,
     }
 }
@@ -136,8 +136,8 @@ fn convert_expr(expr: &Expr) -> Option<QExpr> {
     match expr {
         Expr::Bin(bin_expr) => convert_bin_expr(bin_expr),
         Expr::Paren(paren_expr) => convert_expr(&*paren_expr.expr),
-        Expr::Lit(Lit::Num(number)) => Some(QExpr::Literal(QLiteral::Num(number.value))),
-        Expr::Lit(Lit::Str(s)) => Some(QExpr::Literal(QLiteral::Str(format!("{}", s.value)))),
+        Expr::Lit(Lit::Num(number)) => Some(QExpr::Value(QValue::Num(number.value))),
+        Expr::Lit(Lit::Str(s)) => Some(QExpr::Value(QValue::Str(format!("{}", s.value)))),
         Expr::Member(member_expr) => {
             let obj = convert_expr(&member_expr.obj)?;
             let prop = match &member_expr.prop {

--- a/chiselc/tests/lit/filter_splitting/filter-with-side-effects-return.lit
+++ b/chiselc/tests/lit/filter_splitting/filter-with-side-effects-return.lit
@@ -17,7 +17,7 @@ Person.cursor().filter(person => { return person.age > 40 && fetch("foobar"); })
 // CHECK:     },
 // CHECK:     op: "Gt",
 // CHECK:     right: {
-// CHECK:         exprType: "Literal",
+// CHECK:         exprType: "Value",
 // CHECK:         value: 40
 // CHECK:     }
 // CHECK: }, (person)=>{

--- a/chiselc/tests/lit/filter_splitting/filter-with-side-effects.lit
+++ b/chiselc/tests/lit/filter_splitting/filter-with-side-effects.lit
@@ -16,7 +16,7 @@ Person.cursor().filter(person => person.age > 40 && fetch("foobar"))
 // CHECK:     },
 // CHECK:     op: "Gt",
 // CHECK:     right: {
-// CHECK:         exprType: "Literal",
+// CHECK:         exprType: "Value",
 // CHECK:         value: 40
 // CHECK:     }
 // CHECK: }, (person)=>fetch("foobar")
@@ -39,7 +39,7 @@ Person.cursor().filter(person => person.name == "Glauber Costa" && person.age > 
 // CHECK:         },
 // CHECK:         op: "Eq",
 // CHECK:         right: {
-// CHECK:             exprType: "Literal",
+// CHECK:             exprType: "Value",
 // CHECK:             value: "Glauber Costa"
 // CHECK:         }
 // CHECK:     },
@@ -56,7 +56,7 @@ Person.cursor().filter(person => person.name == "Glauber Costa" && person.age > 
 // CHECK:         },
 // CHECK:         op: "Gt",
 // CHECK:         right: {
-// CHECK:             exprType: "Literal",
+// CHECK:             exprType: "Value",
 // CHECK:             value: 40
 // CHECK:         }
 // CHECK:     }

--- a/chiselc/tests/lit/filter_splitting/findone.ts
+++ b/chiselc/tests/lit/filter_splitting/findone.ts
@@ -16,7 +16,7 @@ Person.findOne(person => person.name == "Glauber Costa" && validate(person));
 // CHECK:     },
 // CHECK:     op: "Eq",
 // CHECK:     right: {
-// CHECK:         exprType: "Literal",
+// CHECK:         exprType: "Value",
 // CHECK:         value: "Glauber Costa"
 // CHECK:     }
 // CHECK: }, (person)=>validate(person)

--- a/chiselc/tests/lit/transform-filter.lit
+++ b/chiselc/tests/lit/transform-filter.lit
@@ -28,7 +28,7 @@ const main = async () => {
 // CHECK:         },
 // CHECK:         op: "Gt",
 // CHECK:         right: {
-// CHECK:             exprType: "Literal",
+// CHECK:             exprType: "Value",
 // CHECK:             value: 4
 // CHECK:         }
 // CHECK:     }).toArray();
@@ -52,7 +52,7 @@ const people = await Person.cursor()
 // CHECK:     },
 // CHECK:     op: "Gt",
 // CHECK:     right: {
-// CHECK:         exprType: "Literal",
+// CHECK:         exprType: "Value",
 // CHECK:         value: 4
 // CHECK:     }
 // CHECK: }).toArray();
@@ -81,7 +81,7 @@ await Person.cursor().filter((p) => { return p.age < 4 });
 // CHECK:    },
 // CHECK:    op: "Lt",
 // CHECK:    right: {
-// CHECK:        exprType: "Literal",
+// CHECK:        exprType: "Value",
 // CHECK:        value: 4
 // CHECK:    }
 // CHECK: });
@@ -101,7 +101,7 @@ await Person.cursor().filter((p) => { return p.age > 4 });
 // CHECK:     },
 // CHECK:     op: "Gt",
 // CHECK:     right: {
-// CHECK:         exprType: "Literal",
+// CHECK:         exprType: "Value",
 // CHECK:         value: 4
 // CHECK:     }
 // CHECK: });
@@ -121,7 +121,7 @@ await Person.cursor().filter((p) => { return p.age <= 4 });
 // CHECK:     },
 // CHECK:     op: "LtEq",
 // CHECK:     right: {
-// CHECK:         exprType: "Literal",
+// CHECK:         exprType: "Value",
 // CHECK:         value: 4
 // CHECK:     }
 // CHECK: });
@@ -141,7 +141,7 @@ await Person.cursor().filter((p) => { return p.age != 4 });
 // CHECK:     },
 // CHECK:     op: "NotEq",
 // CHECK:     right: {
-// CHECK:         exprType: "Literal",
+// CHECK:         exprType: "Value",
 // CHECK:         value: 4
 // CHECK:     }
 // CHECK: });
@@ -160,7 +160,7 @@ await Person.cursor().filter((p) => p.age < 4);
 // CHECK:     },
 // CHECK:     op: "Lt",
 // CHECK:     right: {
-// CHECK:         exprType: "Literal",
+// CHECK:         exprType: "Value",
 // CHECK:         value: 4
 // CHECK:     }
 // CHECK: });
@@ -182,7 +182,7 @@ await Person.cursor().filter((p) => { return p.age < 4 || (p.age > 10 && p.age !
 // CHECK:         },
 // CHECK:         op: "Lt",
 // CHECK:         right: {
-// CHECK:             exprType: "Literal",
+// CHECK:             exprType: "Value",
 // CHECK:             value: 4
 // CHECK:         }
 // CHECK:     },
@@ -201,7 +201,7 @@ await Person.cursor().filter((p) => { return p.age < 4 || (p.age > 10 && p.age !
 // CHECK:             },
 // CHECK:             op: "Gt",
 // CHECK:             right: {
-// CHECK:                 exprType: "Literal",
+// CHECK:                 exprType: "Value",
 // CHECK:                 value: 10
 // CHECK:             }
 // CHECK:         },
@@ -218,7 +218,7 @@ await Person.cursor().filter((p) => { return p.age < 4 || (p.age > 10 && p.age !
 // CHECK:             },
 // CHECK:             op: "NotEq",
 // CHECK:             right: {
-// CHECK:                 exprType: "Literal",
+// CHECK:                 exprType: "Value",
 // CHECK:                 value: 12
 // CHECK:             }
 // CHECK:         }
@@ -240,7 +240,7 @@ await Person.cursor().filter((p) => { return p.name == 'Alice' })
 // CHECK:     },
 // CHECK:     op: "Eq",
 // CHECK:     right: {
-// CHECK:         exprType: "Literal",
+// CHECK:         exprType: "Value",
 // CHECK:         value: "Alice"
 // CHECK:     }
 // CHECK: });
@@ -260,14 +260,14 @@ await Person.cursor().filter(p => { return true; });
 // CHECK: await Person.cursor().__filter((p)=>{
 // CHECK:     return true;
 // CHECK: }, {
-// CHECK:     exprType: "Literal",
+// CHECK:     exprType: "Value",
 // CHECK:     value: true
 // CHECK: });
 
 await Person.cursor().filter(p => true);
 // CHECK: await Person.cursor().__filter((p)=>true
 // CHECK: , {
-// CHECK:     exprType: "Literal",
+// CHECK:     exprType: "Value",
 // CHECK:     value: true
 // CHECK: });
 

--- a/cli/tests/lit/filter-with-predicate.deno
+++ b/cli/tests/lit/filter-with-predicate.deno
@@ -301,7 +301,7 @@ export default async function chisel(req: Request) {
             },
             op: "Eq",
             right: {
-              exprType: "Literal",
+              exprType: "Value",
               value: 89
             }
         });
@@ -343,7 +343,7 @@ export default async function chisel(req: Request) {
             },
             op: "Eq",
             right: {
-              exprType: "Literal",
+              exprType: "Value",
               value: "The importance of being erinaceous"
             }
         });
@@ -381,7 +381,7 @@ export default async function chisel(req: Request) {
             },
             op: "Eq",
             right: {
-              exprType: "Literal",
+              exprType: "Value",
               value: 89
             }
         });
@@ -423,7 +423,7 @@ export default async function chisel(req: Request) {
             },
             op: "Eq",
             right: {
-              exprType: "Literal",
+              exprType: "Value",
               value: "The importance of being erinaceous"
             }
         });
@@ -453,7 +453,7 @@ export default async function chisel(req: Request) {
         .__filter((p) => {
             return all;
         }, {
-            exprType: "Literal",
+            exprType: "Value",
             value: all
         });
 

--- a/cli/tests/lit/find.deno
+++ b/cli/tests/lit/find.deno
@@ -34,7 +34,7 @@ export default async function chisel(req: ChiselRequest) {
                 },
                 op: "Eq",
                 right: {
-                  exprType: "Literal",
+                  exprType: "Value",
                   value: first_name
                 }
             },
@@ -79,7 +79,7 @@ export default async function chisel(req: ChiselRequest) {
                 },
                 op: "Eq",
                 right: {
-                  exprType: "Literal",
+                  exprType: "Value",
                   value: first_name
                 }
             }

--- a/server/src/datastore/expr.rs
+++ b/server/src/datastore/expr.rs
@@ -5,8 +5,8 @@ use serde_derive::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "exprType")]
 pub(crate) enum Expr {
-    /// A literal expression.
-    Literal { value: Literal },
+    /// A value expression.
+    Value { value: Value },
     /// Expression for addressing function parameters of the current expression
     Parameter { position: usize },
     /// Expression for addressing entity property
@@ -15,9 +15,9 @@ pub(crate) enum Expr {
     Binary(BinaryExpr),
 }
 
-impl From<Literal> for Expr {
-    fn from(literal: Literal) -> Self {
-        Expr::Literal { value: literal }
+impl From<Value> for Expr {
+    fn from(value: Value) -> Self {
+        Expr::Value { value }
     }
 }
 
@@ -33,11 +33,11 @@ impl From<PropertyAccess> for Expr {
     }
 }
 
-/// Various literals.
+/// Various Values.
 #[cfg_attr(test, derive(PartialEq))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
-pub(crate) enum Literal {
+pub(crate) enum Value {
     Bool(bool),
     U64(u64),
     I64(i64),
@@ -46,47 +46,47 @@ pub(crate) enum Literal {
     Null,
 }
 
-impl From<bool> for Literal {
+impl From<bool> for Value {
     fn from(val: bool) -> Self {
-        Literal::Bool(val)
+        Value::Bool(val)
     }
 }
 
-impl From<u64> for Literal {
+impl From<u64> for Value {
     fn from(val: u64) -> Self {
-        Literal::U64(val)
+        Value::U64(val)
     }
 }
 
-impl From<i64> for Literal {
+impl From<i64> for Value {
     fn from(val: i64) -> Self {
-        Literal::I64(val)
+        Value::I64(val)
     }
 }
 
-impl From<f64> for Literal {
+impl From<f64> for Value {
     fn from(val: f64) -> Self {
-        Literal::F64(val)
+        Value::F64(val)
     }
 }
 
-impl From<String> for Literal {
+impl From<String> for Value {
     fn from(val: String) -> Self {
-        Literal::String(val)
+        Value::String(val)
     }
 }
 
-impl From<&str> for Literal {
+impl From<&str> for Value {
     fn from(val: &str) -> Self {
-        Literal::String(val.to_owned())
+        Value::String(val.to_owned())
     }
 }
 
-impl From<Option<Literal>> for Literal {
-    fn from(opt: Option<Literal>) -> Literal {
+impl From<Option<Value>> for Value {
+    fn from(opt: Option<Value>) -> Value {
         match opt {
-            Some(literal) => literal,
-            None => Literal::Null,
+            Some(val) => val,
+            None => Value::Null,
         }
     }
 }
@@ -180,10 +180,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_literal_parsing_bool() {
+    fn test_value_parsing_bool() {
         let expr: Expr = serde_json::from_str(
             r#"{
-            "exprType": "Literal",
+            "exprType": "Value",
             "value": true
         }"#,
         )
@@ -191,17 +191,17 @@ mod tests {
 
         assert!(matches!(
             expr,
-            Expr::Literal {
-                value: Literal::Bool(true)
+            Expr::Value {
+                value: Value::Bool(true)
             }
         ));
     }
 
     #[test]
-    fn test_literal_parsing_u64() {
+    fn test_value_parsing_u64() {
         let expr = serde_json::from_str(
             r#"{
-            "exprType": "Literal",
+            "exprType": "Value",
             "value": 42
         }"#,
         )
@@ -209,17 +209,17 @@ mod tests {
 
         assert!(matches!(
             expr,
-            Expr::Literal {
-                value: Literal::U64(42)
+            Expr::Value {
+                value: Value::U64(42)
             }
         ));
     }
 
     #[test]
-    fn test_literal_parsing_i64() {
+    fn test_value_parsing_i64() {
         let expr = serde_json::from_str(
             r#"{
-            "exprType": "Literal",
+            "exprType": "Value",
             "value": -42
         }"#,
         )
@@ -227,17 +227,17 @@ mod tests {
 
         assert!(matches!(
             expr,
-            Expr::Literal {
-                value: Literal::I64(-42)
+            Expr::Value {
+                value: Value::I64(-42)
             }
         ));
     }
 
     #[test]
-    fn test_literal_parsing_f64() {
+    fn test_value_parsing_f64() {
         let expr = serde_json::from_str(
             r#"{
-            "exprType": "Literal",
+            "exprType": "Value",
             "value": 42.0
         }"#,
         )
@@ -245,70 +245,65 @@ mod tests {
 
         assert!(matches!(
             expr,
-            Expr::Literal {
-                value: Literal::F64(_)
+            Expr::Value {
+                value: Value::F64(_)
             }
         ));
-        if let Expr::Literal {
-            value: Literal::F64(v),
+        if let Expr::Value {
+            value: Value::F64(v),
         } = expr
         {
             assert_eq!(v, 42.0);
         } else {
-            panic!("failed to match the literal");
+            panic!("failed to match the value");
         }
     }
 
     #[test]
-    fn test_literal_parsing_string() {
+    fn test_value_parsing_string() {
         let expr: Expr = serde_json::from_str(
             r#"{
-            "exprType": "Literal",
-            "value": "I'm the best literal"
+            "exprType": "Value",
+            "value": "I'm the best value"
         }"#,
         )
         .unwrap();
 
         assert!(matches!(
             expr,
-            Expr::Literal {
-                value: Literal::String(_)
+            Expr::Value {
+                value: Value::String(_)
             }
         ));
-        if let Expr::Literal {
-            value: Literal::String(v),
+        if let Expr::Value {
+            value: Value::String(v),
         } = expr
         {
-            assert_eq!(v, "I'm the best literal");
+            assert_eq!(v, "I'm the best value");
         } else {
-            panic!("failed to match the literal");
+            panic!("failed to match the value");
         }
     }
 
     #[test]
-    fn test_literal_parsing_null() {
+    fn test_value_parsing_null() {
         let expr = serde_json::from_str(
             r#"{
-            "exprType": "Literal",
+            "exprType": "Value",
             "value": null
         }"#,
         )
         .unwrap();
 
-        assert!(matches!(
-            expr,
-            Expr::Literal {
-                value: Literal::Null
-            }
-        ));
+        assert!(matches!(expr, Expr::Value { value: Value::Null }));
     }
 
     #[test]
     #[should_panic(expected = "missing field `value`")]
-    fn test_literal_parsing_value_missing_panic() {
+    fn test_value_parsing_value_missing_panic() {
         let _expr: Expr = serde_json::from_str(
             r#"{
-            "exprType": "Literal"
+            "exprType": "Value"
         }"#,
         )
         .unwrap();


### PR DESCRIPTION
As agreed ... somewhere with @penberg , I've renamed `Expr::Literal` to `Expr::Value` as it's more fitting and will allow us to compile filtering lambdas that use variables.