### PR TITLE
Remove references to "metadata-db-uri" option

### DIFF
--- a/docusaurus/docs/InDepth/chisel-cli.md
+++ b/docusaurus/docs/InDepth/chisel-cli.md
@@ -155,10 +155,6 @@ The number of executor threads the ChiselStrike server uses.
 
 The internal routes listen address of the server. This is the address that serves healthcheck for things like k8s.
 
-#### `--metadata-db-uri [URI]`
-
-The metadata database URI to connect to.
-
 #### `--rpc-listen-addr [ADDR]`
 
 The RPC listen address of the server. This is the address that the ChiselStrike CLI connects to to interact with the server.

--- a/server/docs/manual.md
+++ b/server/docs/manual.md
@@ -2,36 +2,6 @@
 
 This document is the user manual for the ChiselStrike server, `chiseld`.
 
-## Options
-
-### `--metadata-db-uri [URI]`
-
-The `--metadata-db-uri` option specifies the URI of the database that is
-used to store ChiselStrike server metadata such as type system
-definition.
-
-**Examples:**
-
-Connect to a PostgreSQL database with username `postgres`, password
-`password`, on host `localhost`, and database `chiseld`:
-
-```
-chiseld --metadata-db-uri postgres://postgres:password@localhost/chiseld
-```
-
-Connect to a file-backed SQLite database with the filename `chiseld.db`:
-
-```
-chiseld --metadata-db-uri sqlite://chiseld.db
-```
-
-Connect to an in-memory SQLite database:
-
-```
-chiseld --metadata-db-uri sqlite://:memory:
-```
-
-
 ### Docker/Podman containers:
 
 


### PR DESCRIPTION
Commit f9bf50bebdc8236eb2e2386961015fd40cbf4837 ("merge meta and query
dbs") deprecated the option so let's remove references to it from
documentation.

Fixes #1369