### PR TITLE
Fix is_unique fields migration.

### DIFF
--- a/cli/tests/lit/unique.deno
+++ b/cli/tests/lit/unique.deno
@@ -66,7 +66,7 @@ export class BlogPost extends ChiselEntity {
 EOF
 
 $CHISEL apply 2>&1 || echo
-# CHECK Error: unsafe to replace type: BlogPost. Reason: adding uniqueness to field content. Incompatible change
+# CHECK: Error: unsafe to replace type: BlogPost. Reason: adding uniqueness to field content. Incompatible change
 
 cat << EOF > "$TEMPDIR/models/post.ts"
 import { ChiselEntity } from "@chiselstrike/api"
@@ -78,4 +78,10 @@ export class BlogPost extends ChiselEntity {
 EOF
 
 $CHISEL apply
-# CHECK Model defined: BlogPost
+# CHECK: Model defined: BlogPost
+
+$CHISEL restart
+describe_output=$($CHISEL describe)
+## Removes newlines
+echo $describe_output
+# CHECK: { relUrl: string; content: string; }

--- a/server/src/datastore/meta/mod.rs
+++ b/server/src/datastore/meta/mod.rs
@@ -95,7 +95,7 @@ async fn update_field_query(
             SET
                 field_type = $1,
                 is_optional = $2::bool,
-                is_unique = $4::bool {default_stmt}
+                is_unique = $3::bool {default_stmt}
             WHERE field_id = $4"#
         );
         let mut query = sqlx::query(&querystr);


### PR DESCRIPTION
Fixes unique field migration in the meta DB. It was likely a typo.