### PR TITLE
Fix missing colon in lit tests.

### DIFF
--- a/cli/tests/lit/cli/describe.deno
+++ b/cli/tests/lit/cli/describe.deno
@@ -54,9 +54,9 @@ EOF
 $CHISEL apply --allow-type-deletion
 
 $CHISEL describe
-# CHECK Endpoint: /dev/hello
+# CHECK: Endpoint: /dev/hello
 
 $CHISEL restart
 
 $CHISEL describe
-# CHECK Endpoint: /dev/hello
+# CHECK: Endpoint: /dev/hello

--- a/cli/tests/lit/filter.deno
+++ b/cli/tests/lit/filter.deno
@@ -117,8 +117,8 @@ $CHISEL apply
 $CURL -X POST -o - $CHISELD_HOST/dev/take_filter
 # CHECK: "simple_take": [
 # CHECK: "x",
-# CHECK  1
-# CHECK  ],
+# CHECK: 1
+# CHECK: ],
 # CHECK: "filter_take": [
 # CHECK: "z",
 # CHECK: 3

--- a/cli/tests/lit/find_by.deno
+++ b/cli/tests/lit/find_by.deno
@@ -14,18 +14,18 @@ $CHISEL apply
 # CHECK: End point defined: /dev/ins
 
 $CURL --data '{
-    "first_name":"Glauber", 
-    "last_name":"Costa", 
-    "age": 666, 
-    "human": true, 
+    "first_name":"Glauber",
+    "last_name":"Costa",
+    "age": 666,
+    "human": true,
     "height": 10.01
 }' -o - $CHISELD_HOST/dev/ins
 
 $CURL --data '{
-    "first_name":"Jan", 
-    "last_name":"Plhak", 
-    "age": -666, 
-    "human": true, 
+    "first_name":"Jan",
+    "last_name":"Plhak",
+    "age": -666,
+    "human": true,
     "height": 10.02
 }' -o - $CHISELD_HOST/dev/ins
 
@@ -53,7 +53,7 @@ $CURL --data '{
 }' -o - $CHISELD_HOST/dev/find_by
 
 # CHECK: HTTP/1.1 200 OK
-# CHECK: 
+# CHECK:
 
 $CURL --data '{
     "field_name":"age",
@@ -92,4 +92,4 @@ $CURL --data '{
 }' -o - $CHISELD_HOST/dev/find_by
 
 # CHECK: HTTP/1.1 500 Internal Server Error
-# CHECK Uncaught Error: trying to filter by non-existent field `foo` misspelled_field_name
+# CHECK: Error: expression error: entity 'Person' doesn't have field 'misspelled_field_name'

--- a/cli/tests/lit/out-of-order-models.deno
+++ b/cli/tests/lit/out-of-order-models.deno
@@ -35,6 +35,6 @@ cd "$TEMPDIR"
 
 $CHISEL apply
 
-# CHECK Model defined: A
-# CHECK Model defined: B
-# CHECK Model defined: C
+# CHECK: Model defined: A
+# CHECK: Model defined: B
+# CHECK: Model defined: C

--- a/cli/tests/lit/return.deno
+++ b/cli/tests/lit/return.deno
@@ -34,7 +34,7 @@ $CURL $CHISELD_HOST/dev/return
 
 $CURL $CHISELD_HOST/dev/undefined && echo "UniqueString"
 # CHECK: HTTP/1.1 200 OK
-# CHECK UniqueString
+# CHECK: UniqueString
 
 cat << EOF > "$TEMPDIR/endpoints/return.ts"
 type MyReturn = {


### PR DESCRIPTION
Because the lit framework is a piece of crap, we weren't checking for errors on multiple places.

 `+`  some trailing newlines trimming.