### PR TITLE
add chisel secret vars to opt

### DIFF
--- a/server/src/secrets.rs
+++ b/server/src/secrets.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
+use crate::server::Opt;
 use crate::JsonObject;
 use aes_gcm::aead::{Aead, NewAead};
 use aes_gcm::{Aes256Gcm, Nonce};
@@ -85,10 +86,9 @@ fn get_pkcs8_private_key(pem: &str) -> Result<Option<RsaPrivateKey>> {
     Ok(Some(key))
 }
 
-pub(crate) async fn get_private_key() -> Result<Option<RsaPrivateKey>> {
-    let url = match std::env::var("CHISEL_SECRET_KEY_LOCATION") {
-        Err(_) => return Ok(None),
-        Ok(x) => match Url::parse(&x) {
+pub(crate) async fn get_private_key(opt: &Opt) -> Result<Option<RsaPrivateKey>> {
+    let url = match &opt.chisel_secret_key_location {
+        Some(x) => match Url::parse(x) {
             Ok(o) => Ok(o),
             Err(url::ParseError::RelativeUrlWithoutBase) => {
                 let cwd = std::env::current_dir()?;
@@ -99,6 +99,7 @@ pub(crate) async fn get_private_key() -> Result<Option<RsaPrivateKey>> {
                 anyhow::bail!("Invalid url: {:?}", err);
             }
         },
+        None => return Ok(None),
     }?;
 
     let pem = read_url(&url).await?;
@@ -115,15 +116,15 @@ fn parse_rsa_key(pem: &str) -> Result<Option<RsaPrivateKey>> {
     get_pkcs8_private_key(pem)
 }
 
-pub(crate) async fn get_secrets() -> Result<JsonObject> {
-    let secret_location = match std::env::var("CHISEL_SECRET_LOCATION") {
-        Ok(s) => Url::parse(&s)?,
-        Err(_) => {
+pub(crate) async fn get_secrets(opt: &Opt) -> Result<JsonObject> {
+    let secret_location = match &opt.chisel_secret_location {
+        Some(s) => Url::parse(s)?,
+        None => {
             let cwd = std::env::current_dir()?;
             Url::from_file_path(&cwd.join(".env")).unwrap()
         }
     };
-    let private_key = get_private_key().await?;
+    let private_key = get_private_key(opt).await?;
     let data = read_url(&secret_location).await?;
     let secrets = match private_key {
         None => serde_json::from_str(&data)?,

--- a/server/tests/test_config_file.rs
+++ b/server/tests/test_config_file.rs
@@ -2,6 +2,7 @@ use std::fs::create_dir_all;
 use std::io::Write;
 use std::path::PathBuf;
 
+use serde_json::Value;
 use tempfile::{NamedTempFile, TempDir};
 
 fn chiseld() -> PathBuf {
@@ -60,15 +61,17 @@ executor_threads = 21
 
     let expected = serde_json::json!({
         "api_listen_addr": "localhost:12345",
-        "rpc_listen_addr":"127.0.0.1:50051",
-        "internal_routes_listen_addr":"127.0.0.1:9090",
-        "_metadata_db_uri":"sqlite://chiseld.db?mode=rwc",
-        "_data_db_uri":"sqlite://chiseld-data.db?mode=rwc",
-        "db_uri":"sqlite://.chiseld.db?mode=rwc",
-        "inspect_brk":false,
-        "nr_connections":10,
-        "executor_threads":21,
-        "webui":false
+        "rpc_listen_addr": "127.0.0.1:50051",
+        "internal_routes_listen_addr": "127.0.0.1:9090",
+        "_metadata_db_uri": "sqlite://chiseld.db?mode=rwc",
+        "_data_db_uri": "sqlite://chiseld-data.db?mode=rwc",
+        "db_uri": "sqlite://.chiseld.db?mode=rwc",
+        "inspect_brk": false,
+        "nr_connections": 10,
+        "executor_threads": 21,
+        "webui": false,
+        "chisel_secret_location": Value::Null,
+        "chisel_secret_key_location": Value::Null,
     });
 
     assert_eq!(out, expected);
@@ -94,15 +97,17 @@ executor_threads = 21
 
     let expected = serde_json::json!({
         "api_listen_addr": "localhost:123457",
-        "rpc_listen_addr":"127.0.0.1:50051",
-        "internal_routes_listen_addr":"127.0.0.1:9090",
-        "_metadata_db_uri":"sqlite://chiseld.db?mode=rwc",
-        "_data_db_uri":"sqlite://chiseld-data.db?mode=rwc",
-        "db_uri":"sqlite://.chiseld.db?mode=rwc",
-        "inspect_brk":false,
-        "nr_connections":10,
-        "executor_threads":21,
-        "webui":false
+        "rpc_listen_addr": "127.0.0.1:50051",
+        "internal_routes_listen_addr": "127.0.0.1:9090",
+        "_metadata_db_uri": "sqlite://chiseld.db?mode=rwc",
+        "_data_db_uri": "sqlite://chiseld-data.db?mode=rwc",
+        "db_uri": "sqlite://.chiseld.db?mode=rwc",
+        "inspect_brk": false,
+        "nr_connections": 10,
+        "executor_threads": 21,
+        "webui": false,
+        "chisel_secret_location": Value::Null,
+        "chisel_secret_key_location": Value::Null,
     });
 
     assert_eq!(out, expected);
@@ -126,15 +131,17 @@ executor_threads = 21
 
     let expected = serde_json::json!({
         "api_listen_addr": "localhost:12345",
-        "rpc_listen_addr":"127.0.0.1:50051",
-        "internal_routes_listen_addr":"127.0.0.1:9090",
-        "_metadata_db_uri":"sqlite://chiseld.db?mode=rwc",
-        "_data_db_uri":"sqlite://chiseld-data.db?mode=rwc",
-        "db_uri":"sqlite://.chiseld.db?mode=rwc",
-        "inspect_brk":false,
-        "nr_connections":10,
-        "executor_threads":21,
-        "webui":false
+        "rpc_listen_addr": "127.0.0.1:50051",
+        "internal_routes_listen_addr": "127.0.0.1:9090",
+        "_metadata_db_uri": "sqlite://chiseld.db?mode=rwc",
+        "_data_db_uri": "sqlite://chiseld-data.db?mode=rwc",
+        "db_uri": "sqlite://.chiseld.db?mode=rwc",
+        "inspect_brk": false,
+        "nr_connections": 10,
+        "executor_threads": 21,
+        "webui": false,
+        "chisel_secret_location": Value::Null,
+        "chisel_secret_key_location": Value::Null,
     });
 
     assert_eq!(out, expected);
@@ -176,7 +183,9 @@ executor_threads = 21
         "inspect_brk":false,
         "nr_connections":10,
         "executor_threads":21,
-        "webui":false
+        "webui":false,
+        "chisel_secret_location": Value::Null,
+        "chisel_secret_key_location": Value::Null,
     });
 
     assert_eq!(out, expected);


### PR DESCRIPTION
make chisel secrets env variable part of the options, with fallback to environment variable. This permits setting them in the config file, and through the CLI.
