### PR TITLE
remove rustfmt as build dependency in tonic_build

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,7 +29,7 @@ utils = { path = "../utils" }
 
 [build-dependencies]
 anyhow = "1.0"
-tonic-build = "0.5.2"
+tonic-build = { version = "0.5.2", default-features = false, features = ["prost", "transport"] }
 vergen = { version = "6", default-features = false, features = ["git"] }
 
 [dev-dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -70,7 +70,7 @@ tempfile = "3.2.0"
 anyhow = { version = "1.0", features = ["backtrace"] }
 libc = { version = "0.2.99", features = ["extra_traits", "align"] }
 log = { version = "0.4.14", features = ["std"] }
-tonic-build = "0.5.2"
+tonic-build = { version = "0.5.2", default-features = false, features = ["prost", "transport"] }
 tracing = { version = "0.1.30", features = ["log"] }
 vergen = { version = "6", default-features = false, features = ["git"] }
 


### PR DESCRIPTION
As I was trying to build chisel in a container, I realized that tonic_build had rustfmt feature enabled by default. This needlessly complicates the build process, and newer versions of tonic do not require that anymore.

For now, I have only removed the feature, but it may be desirable to bump tonic later on.
