### PR TITLE
allow arbitrary defaults

### DIFF
--- a/cli/tests/lit/type-evolve.deno
+++ b/cli/tests/lit/type-evolve.deno
@@ -167,3 +167,87 @@ rm $TEMPDIR/endpoints/test_indexes.ts
 
 $CHISEL apply --allow-type-deletion
 # CHECK: Model defined: Evolving
+
+### get / set helpers for the tests below
+cat << EOF > "$TEMPDIR/endpoints/get.ts"
+import { Defaults } from "../models/defaults.ts";
+
+export default async function chisel(req: Request) {
+    return Defaults.findAll()
+}
+EOF
+
+cat << EOF > "$TEMPDIR/endpoints/set.ts"
+import { Defaults } from "../models/defaults.ts";
+
+export default async function chisel(req: Request) {
+    const x = Defaults.build();
+    await x.save();
+}
+EOF
+
+## Test able to use fields with complex defaults...
+cat << EOF > "$TEMPDIR/models/defaults.ts"
+import { ChiselEntity } from "@chiselstrike/api";
+
+export class Defaults extends ChiselEntity {
+    a: number  = "string".length
+}
+EOF
+
+$CHISEL apply
+# CHECK: Model defined: Defaults
+
+$CURL -d '{}' $CHISELD_HOST/dev/set
+# CHECK: HTTP/1.1 200 OK
+
+$CURL  $CHISELD_HOST/dev/get
+# CHECK: "a": 6
+
+## But not able to add other complex fields ...
+cat << EOF > "$TEMPDIR/models/defaults.ts"
+import { ChiselEntity } from "@chiselstrike/api";
+
+export class Defaults extends ChiselEntity {
+    a: number = "string".length
+    b: string = JSON.stringify({a: "test2"});
+}
+EOF
+
+$CHISEL apply 2>&1 || true
+# CHECK: Error: unsafe to replace type
+
+## ... unless they are optional!
+## Also check that defaults can be whatever, including other models
+cat << EOF > "$TEMPDIR/models/defaults.ts"
+import { ChiselEntity } from "@chiselstrike/api";
+
+export class Aux extends ChiselEntity {
+    aux: string = "aux"
+}
+
+function myFunction() : string {
+	return "funcreturn"
+}
+
+export class Defaults extends ChiselEntity {
+    a: number = "string".length
+    b?: string = JSON.stringify({a: "test2"});
+    c?: string = myFunction()
+    d?: Aux = new Aux()
+}
+EOF
+
+$CHISEL apply
+# CHECK: Model defined: Aux
+# CHECK: Model defined: Defaults
+
+$CURL -d '{}' $CHISELD_HOST/dev/set
+# CHECK: HTTP/1.1 200 OK
+
+$CURL  $CHISELD_HOST/dev/get
+# CHECK: "a": 6
+# CHECK: "b": "{\"a\":\"test2\"}"
+# CHECK: "c": "funcreturn"
+# CHECK: "d": {
+# CHECK: "aux": "aux"

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -232,7 +232,6 @@ impl TypeSystem {
         let mut updated_fields = Vec::new();
 
         for (name, field) in new_fields.map.iter() {
-            let field_ty = ts.get(&field.type_id)?;
             match old_fields.map.remove(name) {
                 None => {
                     if field.default.is_none() && !field.is_optional {
@@ -241,6 +240,11 @@ impl TypeSystem {
                     added_fields.push(field.to_owned().clone());
                 }
                 Some(old) => {
+                    // Important: we can only issue this get() here, after we know this model is
+                    // pre-existing. Otherwise this breaks in the case where we're adding a
+                    // property that is itself a custom model.
+                    let field_ty = ts.get(&field.type_id)?;
+
                     let old_ty = ts.get(&old.type_id)?;
                     if field_ty != old_ty {
                         // FIXME: it should be almost always possible to evolve things into

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -235,7 +235,7 @@ impl TypeSystem {
             match old_fields.map.remove(name) {
                 None => {
                     if field.default.is_none() && !field.is_optional {
-                        return Err(TypeSystemError::UnsafeReplacement(new_type.name.clone(), format!("Trying to add a new non-optional field ({}) without a default value. Consider adding a default value or making it optional to make the types compatible", field.name)));
+                        return Err(TypeSystemError::UnsafeReplacement(new_type.name.clone(), format!("Trying to add a new non-optional field ({}) without a trivial default value. Consider adding a default value or making it optional to make the types compatible", field.name)));
                     }
                     added_fields.push(field.to_owned().clone());
                 }
@@ -920,7 +920,7 @@ impl<'a> FieldMap<'a> {
             } else {
                 anyhow::ensure!(
                     field.default.is_none(),
-                    "Adding field {} without a default, which is not supported yet",
+                    "Adding field {} without a trivial default, which is not supported yet",
                     name
                 );
             }


### PR DESCRIPTION
This PR allow us to write things like:

  a: number = Date.now()

in defaults.

We need surprisingly little to make this work, which makes me very
happy. Essentially, Entity.build() will already execute those functions,
so it works just fine.

We just need to make sure that the schema evolution works, which also
happen to work just fine: for complex expressions, we just treat them
as "no defaults". That makes sense, because if you have something like
"Date.now()", the behavior the user expects for things that didn't
exist before is not to retrofill with the current date...

So we allow adding mandatory types with literals and change the error
messages accordingly. Complex expressions behave like no-default.

We do miss the opportunity to allow things like "string".length and "1 +
2", which are not literals, but are pure and could be executed compile
time. However this is good for now, and we could in the future expand
chiselc to allow for those expressions to be parsed as literal defaults.