### PR TITLE
allow deletion of empty models

### DIFF
--- a/cli/tests/lit/cli/describe.deno
+++ b/cli/tests/lit/cli/describe.deno
@@ -51,7 +51,7 @@ export default async function chisel(req: Request) {
     return new Response('ok');
 }
 EOF
-$CHISEL apply --allow-type-deletion
+$CHISEL apply
 
 $CHISEL describe
 # CHECK: Endpoint: /dev/hello

--- a/cli/tests/lit/cli/reapply.deno
+++ b/cli/tests/lit/cli/reapply.deno
@@ -90,12 +90,12 @@ $CHISEL apply 2>&1 || echo # (swallow the apply abort)
 
 ## Redefining elemental types is not OK.
 echo 'export class number extends ChiselEntity { a: number}' > "$TEMPDIR/models/foo.ts"
-$CHISEL apply --allow-type-deletion 2>&1 || echo # (swallow the apply abort)
+$CHISEL apply 2>&1 || echo # (swallow the apply abort)
 # CHECK: custom type expected, got `number` instead
 
 ## Redefining AuthUser is not OK.
 echo 'export class AuthUser extends ChiselEntity { a: number}' > "$TEMPDIR/models/foo.ts"
-$CHISEL apply --allow-type-deletion 2>&1 ||:
+$CHISEL apply 2>&1 ||:
 # CHECK: custom type expected, got `AuthUser` instead
 
 ### Removing fields is not OK if they didn't have a default
@@ -105,7 +105,7 @@ export class Bar extends ChiselEntity {
   b: number;
 }
 EOF
-$CHISEL apply --allow-type-deletion 2>&1 || echo # (swallow the apply abort)
+$CHISEL apply 2>&1 || echo # (swallow the apply abort)
 # CHECK: Model defined: Bar
 #
 cat << EOF > "$TEMPDIR/models/foo.ts"

--- a/cli/tests/lit/delete-type.deno
+++ b/cli/tests/lit/delete-type.deno
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com>
+
+# RUN: sh -e @file
+
+cd "$TEMPDIR"
+
+cat << EOF > "$TEMPDIR/models/user.ts"
+import { ChiselEntity } from "@chiselstrike/api";
+
+export class User extends ChiselEntity {
+    username: string;
+    email: string;
+}
+EOF
+
+cat << EOF > "$TEMPDIR/endpoints/user.ts"
+import { User } from "../models/user.ts";
+export default User.crud();
+EOF
+
+$CHISEL apply
+# CHECK: Model defined: User
+# CHECK: End point defined: /dev/user
+
+$CURL -X POST -d '{"username": "alice", "email": "alice@example.org"}' $CHISELD_HOST/dev/user
+# CHECK: "alice"
+
+rm models/user.ts
+rm endpoints/user.ts
+
+## can't remove the type because it has data
+$CHISEL apply 2>&1 || true
+# CHECK: Error
+
+# After deleting, apply will succeed
+$CURL -X DELETE $CHISELD_HOST/dev/user?all=true
+$CHISEL apply

--- a/cli/tests/lit/pol-anon.deno
+++ b/cli/tests/lit/pol-anon.deno
@@ -51,7 +51,7 @@ export class Person extends Chisel.ChiselEntity {
   height: number;
 }
 EOF
-$CHISEL apply --allow-type-deletion
+$CHISEL apply
 
 cat << EOF > "$TEMPDIR/policies/pol.yaml"
 labels:

--- a/cli/tests/lit/type-evolve.deno
+++ b/cli/tests/lit/type-evolve.deno
@@ -165,5 +165,5 @@ EOF
 
 rm $TEMPDIR/endpoints/test_indexes.ts
 
-$CHISEL apply --allow-type-deletion
+$CHISEL apply
 # CHECK: Model defined: Evolving

--- a/cli/tests/lit/types.deno
+++ b/cli/tests/lit/types.deno
@@ -34,7 +34,7 @@ cat << EOF > "$TEMPDIR/models/types.ts"
 export class Zed extends ChiselEntity { a: string; a: string; }
 EOF
 set +e
-$CHISEL apply --allow-type-deletion 2>&1
+$CHISEL apply 2>&1
 set -e
 
 # CHECK: [[(UNIQUE constraint failed|unique constraint)]]
@@ -43,7 +43,7 @@ cat << EOF > "$TEMPDIR/models/types.ts"
 export class Bad extends ChiselEntity { a: SomeType; }
 EOF
 set +e
-$CHISEL apply --allow-type-deletion 2>&1
+$CHISEL apply 2>&1
 set -e
 
 # CHECK: Error: field 'a' in class 'Bad' is of unknown entity type 'SomeType'
@@ -51,11 +51,11 @@ set -e
 cat << EOF > "$TEMPDIR/models/types.ts"
 export class Malformed extends ChiselEntity { name: string(); }
 EOF
-$CHISEL apply --allow-type-deletion 2>&1 || echo
+$CHISEL apply 2>&1 || echo
 # CHECK: 1 | export class Malformed extends ChiselEntity { name: string(); }
 
 cat << EOF > "$TEMPDIR/models/types.ts"
 export class Malformed extends ChiselEntity { name; }
 EOF
-$CHISEL apply --allow-type-deletion 2>&1 || echo
+$CHISEL apply 2>&1 || echo
 # CHECK: 1 | export class Malformed extends ChiselEntity { name; }

--- a/server/src/datastore/meta/mod.rs
+++ b/server/src/datastore/meta/mod.rs
@@ -721,6 +721,18 @@ impl MetaService {
         Ok(policies)
     }
 
+    pub(crate) async fn count_rows(
+        &self,
+        transaction: &mut Transaction<'_, Any>,
+        ty: &ObjectType,
+    ) -> anyhow::Result<i64> {
+        let query = format!("SELECT COUNT(*) as count from \"{}\"", ty.backing_table());
+        let count = sqlx::query(&query);
+        let row = fetch_one(transaction, count).await?;
+        let cnt: i64 = row.get("count");
+        Ok(cnt)
+    }
+
     pub(crate) async fn insert_type(
         &self,
         transaction: &mut Transaction<'_, Any>,


### PR DESCRIPTION
Currently we disallow models to be removed from files at all, because
that can destroy data in the database. Deletion has to happen with
an apply flag.

This is very inconvenient, though, for both local development, where a
user may be just experimenting with types, or hosted chiseltrike, where
apply is automatically done through git, so there is no way to pass
flags.

We should be more tolerant, and allow models to be deleted if they are
empty.