### PR TITLE
create-chiselstrike-app: gitignore template improvements

### DIFF
--- a/packages/create-chiselstrike-app/template/gitignore
+++ b/packages/create-chiselstrike-app/template/gitignore
@@ -1,1 +1,4 @@
+/.chiseld.db*
+/.gen
+/.vscode
 /node_modules


### PR DESCRIPTION
Add ".vscode" and ".gen" directories and the ChiselStrike local
development database files to .gitignore as suggested by
@ricardodalarme.