### PR TITLE
rust tests: Pretty print ProcessError.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,7 +639,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
 ]
@@ -678,6 +678,7 @@ dependencies = [
  "swc_ecmascript",
  "tempdir",
  "tempfile",
+ "textwrap 0.15.0",
  "tokio",
  "toml",
  "tonic",
@@ -4328,6 +4329,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "socket2"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5041,6 +5048,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5507,6 +5525,15 @@ name = "unicode-ident"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a52dcaab0c48d931f7cc8ef826fa51690a08e1ea55117ef26f89864f532383f"
+dependencies = [
+ "regex",
+]
 
 [[package]]
 name = "unicode-normalization"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -48,6 +48,7 @@ reqwest = { version = "0.11.11", features = ["blocking", "json"] }
 server = { path = "../server" }
 strip-ansi-escapes = "0.1.1"
 tempdir = "0.3.7"
+textwrap = "0.15.0"
 url = "2.2.2"
 whoami = "1.2.1"
 

--- a/cli/tests/integration_tests/framework.rs
+++ b/cli/tests/integration_tests/framework.rs
@@ -182,7 +182,6 @@ impl ExecutableExt for checked_command::CheckedCommand {
     }
 }
 
-#[derive(Debug)]
 pub struct ProcessError {
     output: MixedTestableOutput,
 }
@@ -201,6 +200,17 @@ impl From<checked_command::Error> for ProcessError {
                 },
             }
         }
+    }
+}
+
+impl std::fmt::Debug for ProcessError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "ProcessError:\nSTDOUT:\n{}\nSTDERR:\n{}",
+            textwrap::indent(&self.stdout().output, "    "),
+            textwrap::indent(&self.stderr().output, "    ")
+        )
     }
 }
 


### PR DESCRIPTION
Quality of life improvement, this ensures that if chisel apply (or similar) fails with ProcessError, we get a nicely formatted message containing STDOUT and STDERR of the process.