### PR TITLE
granular readiness

### DIFF
--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -8,6 +8,7 @@ use crate::deno::endpoint_path_from_source_path;
 use crate::deno::mutate_policies;
 use crate::deno::remove_type_version;
 use crate::deno::set_type_system;
+use crate::internal::mark_ready;
 use crate::policies::{Policies, VersionPolicy};
 use crate::prefix_map::PrefixMap;
 use crate::runtime;
@@ -765,6 +766,7 @@ pub(crate) fn spawn(
 ) -> tokio::task::JoinHandle<Result<()>> {
     tokio::task::spawn(async move {
         start_wait.await;
+        mark_ready();
 
         let ret = Server::builder()
             .add_service(ChiselRpcServer::new(rpc))

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -10,6 +10,7 @@ use crate::deno::set_query_engine;
 use crate::deno::set_type_system;
 use crate::deno::update_secrets;
 use crate::deno::{activate_endpoint, compile_endpoints};
+use crate::internal::mark_not_ready;
 use crate::rpc::InitState;
 use crate::rpc::{GlobalRpcState, RpcService};
 use crate::runtime;
@@ -368,6 +369,7 @@ async fn run_shared_state(
             _ = sighup.recv().fuse() => { debug!("Got SIGHUP"); DoRepeat::No },
             _ = sigusr1.recv().fuse() => { debug!("Got SIGUSR1"); DoRepeat::Yes },
         };
+        mark_not_ready();
         debug!("Got signal");
         signal_tx.send(()).await?;
         Ok(res)


### PR DESCRIPTION
We always return 200 on the readiness probe, but there are some race
conditions here, due to which it is still possible for the readiness
internal health endpoint to say we are ready to take requests when
in reality we are not.

This increases the granularity and gives us more control over how
we declare whether or not we're ready.