### PR TITLE
CRUD: read object before PUT

### DIFF
--- a/cli/tests/integration_tests/lit_tests/crud.node
+++ b/cli/tests/integration_tests/lit_tests/crud.node
@@ -218,16 +218,28 @@ $CURL -X DELETE "$CHISELD_HOST/dev/persons?all=true"
 # CHECK: HTTP/1.1 200 OK
 # CHECK: Deleted entities matching ?all=true
 
-$CURL -X PUT -d '{"age":98422}' $CHISELD_HOST/dev/persons/cef5d492-d7e3-4c45-9a55-5929b9ab8292
+$CURL -X PUT -d '{"age":98422, "height": 2 }' $CHISELD_HOST/dev/persons/cef5d492-d7e3-4c45-9a55-5929b9ab8292
 # CHECK: HTTP/1.1 200 OK
 # CHECK: "age": 98422
-$CURL -X PUT -d '{"age":2938}' $CHISELD_HOST/dev/persons/cef5d492-d7e3-4c45-9a55-5929b9ab8292 # Repeated PUT of the same id.
+# CHECK: "height": 2
+$CURL -X PUT -d '{"age":2938}' $CHISELD_HOST/dev/persons/cef5d492-d7e3-4c45-9a55-5929b9ab8292 # Repeated PUT of the same id, object is entirely recreated
 # CHECK: HTTP/1.1 200 OK
 # CHECK: "age": 2938
+# CHECK: "height": 1
 echo there is just `$CURL --no-include $CHISELD_HOST/dev/persons | jq '.results | length'` entry
 # CHECK: there is just 1 entry
 $CURL --no-include $CHISELD_HOST/dev/persons | jq '.results | .[] | .age'
 # CHECK: 2938
+$CURL -X PATCH -d '{"height": 4 }' $CHISELD_HOST/dev/persons/cef5d492-d7e3-4c45-9a55-5929b9ab8292 # PATCH on an existing object, only mentioned properties are changed
+# CHECK: HTTP/1.1 200 OK
+# CHECK: "age": 2938
+# CHECK: "height": 4
+
+$CURL -X PATCH -d '{"height": 4 }' $CHISELD_HOST/dev/persons/ # PATCH with no id, 400
+# CHECK: HTTP/1.1 400 Bad Request
+
+$CURL -X PATCH -d '{"height": 4 }' $CHISELD_HOST/dev/persons/0000 # PATCH of a non-existent object, 404
+# CHECK: HTTP/1.1 404 Not Found
 
 $CURL -X PUT -d '{"age":98422}' $CHISELD_HOST/dev/persons/ # PUT without ID.
 # CHECK: 400 Bad Request


### PR DESCRIPTION
This is crucial for objects with non-literal defaults. Consider for
example, the following object:

```
export class Joke extends ChiselEntity {
        createdAt : number = Date.now()
        name : string
        content : string
}
```

because "createdAt" has a default, it is convenient not to specify it
when creating the object. However, if you call a CRUD PUT on an existing
object, the whole object gets recreated and have the default it had
before (in this case, a creation time).

With a PATCH, we can pass just name and content, and createdAt will be
left alone.

Fixes #1213