### PR TITLE
document non-literal defaults

### DIFF
--- a/docusaurus/docs/InDepth/advanced-data.md
+++ b/docusaurus/docs/InDepth/advanced-data.md
@@ -90,7 +90,7 @@ model evolution without any database migration. While fully arbitrary evolution 
 many cases that we can already handle. You will see that they cover many scenarios, especially if you
 prepare in advance. They are:
 
-* Fields that have a default value can always be added or removed.
+* Fields that have a literal default value can always be added or removed.
 * Fields that are optional can always be added or removed.
 
 Going back ot our `BlogPost` model, notice that if we try to add another field, we will see an error messsage:
@@ -108,7 +108,7 @@ export class BlogPost extends ChiselEntity {
 Our logs will show:
 
 ```
-unsafe to replace type: BlogPost. Reason: Trying to add a new non-optional field (newField) without a default value. Consider adding a default value or making it optional to make the types compatible
+unsafe to replace type: BlogPost. Reason: Trying to add a new non-optional field (newField) without a trivial default value. Consider adding a default value or making it optional to make the types compatible
 ```
 
 It is possible, however, to add:
@@ -135,3 +135,85 @@ export class BlogPost extends ChiselEntity {
     newerField: boolean = false;
 }
 ```
+
+## Non-trivial default values and custom updates
+
+Sometimes we want fields to have defaults that cannot be expressed as simple literals. For example, we may want to include a field
+that represents the creation time of an object.
+
+We would model it like this:
+
+```typescript title="my-backend/models/Custom.ts"
+import { ChiselEntity, unique } from "@chiselstrike/api"
+
+export class Custom extends ChiselEntity {
+    content: string;
+    createdAt: number = Date.now()
+
+    created() : Date {
+        return new Date(this.createdAt)
+    }
+}
+```
+
+Now, when a new object of the type `Custom` is created, it will have its timestamp automatically inserted. Working
+directly with numbers can be inconvenient, so a helper function `created` can be added as well, that returns a [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) object
+
+What if we also want to track the update time? First, let's add the property to the model. Adding it as optional will allow us to evolve
+the model automatically. And similar to `createdAt`, we can add a helper function so that we can extract a `Date` type easily:
+
+```typescript title="my-backend/models/Custom.ts"
+import { ChiselEntity, unique } from "@chiselstrike/api"
+
+export class Custom extends ChiselEntity {
+    content: string;
+    createdAt: number = Date.now()
+    updatedAt?: number
+
+    created() : Date {
+        return new Date(this.createdAt)
+    }
+
+    updated() : Date {
+        return new Date(this.updatedAt)
+    }
+}
+```
+
+But doing that is not enough. The field exists, but we don't want to add
+custom logic into endpoints to handle it. We want to make sure it is always
+updated when we save the model.
+
+To do that, we can override the `save()` method of `ChiselEntity`. That is the method
+that is invoked any time an object, new or existing, is created.
+
+```typescript title="my-backend/models/Custom.ts"
+import { ChiselEntity, unique } from "@chiselstrike/api"
+
+export class Custom extends ChiselEntity {
+    content: string;
+    createdAt: number = Date.now()
+    updatedAt?: number
+
+    created() : Date {
+        return new Date(this.createdAt)
+    }
+
+    updated() : Date {
+        return new Date(this.updatedAt)
+    }
+
+    async save() : Promise<void> {
+        this.updatedAt = Date.now()
+        return super.save()
+    }
+}
+```
+
+:::caution
+A couple of years ago a friend of mine started a swear jar in the office. We all had to add $1 every time we
+had a dangling promise. She now retired rich and has her own private island.
+
+Remember `save` is an async function. Just writing `super.save()` won't do the trick. You either have to `await super.save()`,
+or `return super.save()`
+:::


### PR DESCRIPTION
We merged a patch allowing non-literal defaults but didn't update the
documentation.

As it turns out, I asked myself "what if I want a field that gets
updated when the object is updated?", and guess what: just overriding
save works juuuuuust fine.

So document that too.