### PR TITLE
Upgrade sqlx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,10 +1453,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "7e851a83c30366fd01d75b913588e95e74a1705c1ecc5d58b1f8e1a6d556525f"
+dependencies = [
+ "dirs 4.0.0",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -4462,9 +4465,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f82cbe94f41641d6c410ded25bbf5097c240cefdf8e3b06d04198d0a96af6a4"
+checksum = "788841def501aabde58d3666fcea11351ec3962e6ea75dbcd05c84a71d68bcd1"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -4472,9 +4475,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b69bf218860335ddda60d6ce85ee39f6cf6e5630e300e19757d1de15886a093"
+checksum = "8c21d3b5e7cadfe9ba7cdc1295f72cc556c750b4419c27c219c0693198901f8e"
 dependencies = [
  "ahash",
  "atoi",
@@ -4485,6 +4488,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "dirs 4.0.0",
+ "dotenvy",
  "either",
  "event-listener",
  "flume",
@@ -4527,11 +4531,11 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40c63177cf23d356b159b60acd27c54af7423f1736988502e36bae9a712118f"
+checksum = "4adfd2df3557bddd3b91377fc7893e8fa899e9b4061737cbade4e1bb85f1b45c"
 dependencies = [
- "dotenv",
+ "dotenvy",
  "either",
  "heck 0.4.0",
  "once_cell",
@@ -4546,9 +4550,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874e93a365a598dc3dadb197565952cb143ae4aa716f7bcc933a8d836f6bf89f"
+checksum = "7be52fc7c96c136cedea840ed54f7d446ff31ad670c9dea95ebcb998530971a3"
 dependencies = [
  "once_cell",
  "tokio",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -44,7 +44,7 @@ serde_derive = "1.0.137"
 serde_json = "1.0.81"
 sha2 = "0.10.2"
 socket2 = { version = "0.3.18", features = ["unix", "reuseport"] }
-sqlx = { version = "0.6.0", features = [
+sqlx = { version = "0.6.1", features = [
     "any",
     "postgres",
     "sqlite",


### PR DESCRIPTION
If we re-generate `Cargo.lock`, we get the latest sqlx release, which --
unfortunately -- breaks our SQLite code because we never enable WAL
explicitly.

Let's upgrade sqlx in controlled way by first changing our code, and
then bumping the version.