### PR TITLE
policies in typescript

### DIFF
--- a/api/src/endpoint.ts
+++ b/api/src/endpoint.ts
@@ -105,6 +105,13 @@ export async function importEndpoints(endpoints: [Endpoint]) {
     });
 }
 
+export async function importPolicies(endpoints: [Endpoint]) {
+    await toWorker({
+        cmd: "importPolicies",
+        endpoints,
+    });
+}
+
 export async function activateEndpoint(path: string) {
     await toWorker({
         cmd: "activateEndpoint",

--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -95,6 +95,19 @@ async function importEndpointsImpl(endpoints: [Endpoint]) {
     }
 }
 
+function importPolicies(endpoints: [string]) {
+    handleMsg(() => {
+        return importPoliciesImpl(endpoints);
+    });
+}
+
+async function importPoliciesImpl(endpoints: [string]) {
+    for (const pol of endpoints) {
+   	const url = `file:///${pol}`;
+        await import(url);
+    }
+}
+
 function activateEndpoint(path: string) {
     handleMsg(() => {
         handlers[path] = nextHandlers[path];
@@ -273,6 +286,9 @@ onmessage = function (e) {
             break;
         case "importEndpoints":
             importEndpoints(d.endpoints);
+            break;
+        case "importPolicies":
+            importPolicies(d.endpoints);
             break;
         case "activateEndpoint":
             activateEndpoint(d.path);

--- a/proto/chisel.proto
+++ b/proto/chisel.proto
@@ -81,9 +81,15 @@ message PolicyUpdateRequest {
   string policy_config = 1;
 }
 
+message TsPolicyRequest {
+  string file = 1;
+  string code = 2;
+}
+
 message ChiselApplyRequest {
    repeated AddTypeRequest types = 1;
    repeated IndexCandidate index_candidates = 8;
+   repeated TsPolicyRequest ts_policy = 9;
 
    // Location to code map. Includes all modules compiled into JS. The
    // endpoints themselves start with "endpoints/"

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -117,6 +117,9 @@ struct DenoService {
     module_loader: Arc<std::sync::Mutex<ModuleLoaderInner>>,
 
     import_endpoints: v8::Global<v8::Function>,
+
+    import_policies: v8::Global<v8::Function>,
+
     activate_endpoint: v8::Global<v8::Function>,
     call_handler: v8::Global<v8::Function>,
     read_worker_channel: v8::Global<v8::Function>,
@@ -369,6 +372,7 @@ impl DenoService {
 
         let (
             import_endpoints,
+            import_policies,
             activate_endpoint,
             call_handler,
             init_worker,
@@ -385,9 +389,13 @@ impl DenoService {
             let import_endpoints: v8::Local<v8::Function> =
                 get_member(module, scope, "importEndpoints").unwrap();
             let import_endpoints = v8::Global::new(scope, import_endpoints);
+            let import_policies: v8::Local<v8::Function> =
+                get_member(module, scope, "importPolicies").unwrap();
+            let import_policies = v8::Global::new(scope, import_policies);
             let activate_endpoint: v8::Local<v8::Function> =
                 get_member(module, scope, "activateEndpoint").unwrap();
             let activate_endpoint = v8::Global::new(scope, activate_endpoint);
+
             let call_handler: v8::Local<v8::Function> =
                 get_member(module, scope, "callHandler").unwrap();
             let call_handler = v8::Global::new(scope, call_handler);
@@ -403,6 +411,7 @@ impl DenoService {
 
             (
                 import_endpoints,
+                import_policies,
                 activate_endpoint,
                 call_handler,
                 init_worker,
@@ -421,6 +430,7 @@ impl DenoService {
                 _inspector: inspector,
                 module_loader: inner,
                 import_endpoints,
+                import_policies,
                 activate_endpoint,
                 call_handler,
                 to_worker: to_worker_sender,
@@ -1506,6 +1516,38 @@ pub(crate) fn endpoint_path_from_source_path(path: &str) -> String {
     let api_version = iter.nth(1).unwrap();
     let rest = iter.nth(1).unwrap();
     format!("/{}/{}", api_version, without_extension(rest))
+}
+
+pub(crate) async fn compile_policy(ts_policy: Vec<(String, String)>) -> Result<()> {
+    let promise = {
+        let mut service = get();
+        let service: &mut DenoService = &mut service;
+
+        let mut handle = service.module_loader.lock().unwrap();
+        let handle: &mut ModuleLoaderInner = &mut *handle;
+        let code_map = &mut handle.code_map;
+
+        let runtime = &mut service.worker.js_runtime;
+        let scope = &mut runtime.handle_scope();
+        let mut policies: Vec<v8::Local<'_, v8::Value>> = vec![];
+
+        let import_policies = service.import_policies.open(scope);
+        for (path, code) in ts_policy {
+            let url = Url::parse(&format!("file://{}/{}", "/will-be-uuid", path)).unwrap();
+            code_map.insert(url, code);
+
+            let pol = v8::String::new(scope, &format!("will-be-uuid/{}", path)).unwrap();
+            policies.push(pol.into());
+        }
+        let policies = v8::Array::new_with_elements(scope, &policies).into();
+        let undefined = v8::undefined(scope).into();
+
+        let promise = import_policies.call(scope, undefined, &[policies]).unwrap();
+        v8::Global::new(scope, promise)
+    };
+
+    resolve_promise(promise).await?;
+    Ok(())
 }
 
 pub(crate) async fn compile_endpoints(sources: HashMap<String, String>) -> Result<()> {

--- a/server/src/internal.rs
+++ b/server/src/internal.rs
@@ -49,6 +49,7 @@ async fn webapply(body: Body, rpc_addr: &SocketAddr) -> Result<Response<Body>> {
             version: "dev".into(),
             version_tag: "dev".into(),
             app_name: "ChiselStrike WebUI".into(),
+            ts_policy: vec![],
         }))
         .await?;
     response("applied", 200)

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -255,6 +255,13 @@ impl RpcService {
         }
         endpoint_paths.sort_unstable();
 
+        let ts_policy = apply_request
+            .ts_policy
+            .iter()
+            .cloned()
+            .map(|x| (x.file, x.code))
+            .collect();
+
         // Do this before any permanent changes to any of the databases. Otherwise
         // we end up with bad code commited to the meta database and will fail to load
         // chiseld next time, as it tries to replenish the endpoints
@@ -508,6 +515,8 @@ or
                     policies.versions.insert(pol_version, policy);
                 })
                 .await;
+
+                deno::compile_policy(ts_policy).await?;
 
                 let runtime = runtime::get();
                 runtime.api.remove_routes(&prefix);


### PR DESCRIPTION
This PR implements the bare minimum of complex policies in typescript.
In particular:
* policies are not persisted
* only access control works
* only save() is checked
* the audit log is just a console print, this should go into a
  __chiselstrike endpoint and/or kafka
* I don't lint anything to prevent loops or other things we want
  to disallow
* ChiselRequest is not passed

I tested this with the following file:

```
import { Log, ActionResult } from "@chiselstrike/api"
import { User } from "../models/User"

Log(User, {
    GET: () => { return ActionResult.Allow },
    POST: (x) => {
        if (x.name == "Glauber") {
		return ActionResult.Log
	} else {
		return ActionResult.Deny
        }
    }
});
```

This is quite simplistic, and have the Model as the entrypoint. So
it is hard to write policies that take many models into account.
But we have to start somewhere. We may want to make the functions
asynchronous, which would allow us to issue findOnes() to the other
models.

The obvious next step is to pass information about the request,
and then we can check for token in headers, logged in user, etc.

I have the following functions planned for the near future:

```
setLocality(User => {
    if x.country == "eu" {
        return Jurisdiction.EU
    } else {
	return Jurisdiction.Any
    }
})

setEncryption(User, Encryption.Rest)
setEncryption(BlogPost, Encryption.Tls)
```