### PR TITLE
Implement token authentication

### DIFF
--- a/cli/tests/integration_tests/database.rs
+++ b/cli/tests/integration_tests/database.rs
@@ -109,7 +109,7 @@ pub struct SqliteDb {
 
 impl SqliteDb {
     pub fn url(&self) -> String {
-        let path = self.tmp_dir.path().join("chiseld.db");
+        let path = self.tmp_dir.path().join(".chiseld.db");
         format!("sqlite://{}?mode=rwc", path.display())
     }
 }

--- a/cli/tests/integration_tests/framework.rs
+++ b/cli/tests/integration_tests/framework.rs
@@ -1,6 +1,7 @@
 use crate::database::Database;
 use anyhow::Result;
 use bytes::{Bytes, BytesMut};
+use reqwest::header::HeaderMap;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::process::{ExitStatus, Stdio};
@@ -316,6 +317,10 @@ impl Chisel {
         self.exec("wait", &[]).await
     }
 
+    pub async fn restart(&self) -> Result<ProcessOutput, ProcessOutput> {
+        self.exec("restart", &[]).await
+    }
+
     /// Writes given `text` (probably code) into a file on given relative `path`
     /// in ChiselStrike project.
     pub fn write(&self, path: &str, text: &str) {
@@ -353,7 +358,13 @@ impl Chisel {
     /// Sends a HTTP request to a relative `url` on the running `chiseld`, using the given request
     /// `method` and `body`. Does not check that the response is successful. Panics if there was an error while
     /// handling the request.
-    pub async fn request<B>(&self, method: reqwest::Method, url: &str, body: B) -> reqwest::Response
+    pub async fn request_with_headers<B>(
+        &self,
+        method: reqwest::Method,
+        url: &str,
+        body: B,
+        headers: HeaderMap,
+    ) -> reqwest::Response
     where
         B: Into<reqwest::Body>,
     {
@@ -364,10 +375,19 @@ impl Chisel {
         self.client
             .request(method.clone(), full_url)
             .body(body)
+            .headers(headers)
             .timeout(core::time::Duration::from_secs(5))
             .send()
             .await
             .unwrap_or_else(|e| panic!("HTTP error in {} {}: {}", method, url, e))
+    }
+
+    pub async fn request<B>(&self, method: reqwest::Method, url: &str, body: B) -> reqwest::Response
+    where
+        B: Into<reqwest::Body>,
+    {
+        self.request_with_headers(method, url, body, HeaderMap::new())
+            .await
     }
 
     /// Same as `request()`, but reads the response status and body as bytes.
@@ -375,7 +395,23 @@ impl Chisel {
     where
         B: Into<reqwest::Body>,
     {
-        let response = self.request(method.clone(), url, body).await;
+        self.request_body_with_headers(method, url, body, HeaderMap::new())
+            .await
+    }
+
+    pub async fn request_body_with_headers<B>(
+        &self,
+        method: reqwest::Method,
+        url: &str,
+        body: B,
+        headers: HeaderMap,
+    ) -> (u16, Bytes)
+    where
+        B: Into<reqwest::Body>,
+    {
+        let response = self
+            .request_with_headers(method.clone(), url, body, headers)
+            .await;
         let status = response.status().as_u16();
         match response.bytes().await {
             Ok(response_body) => (status, response_body),
@@ -391,7 +427,24 @@ impl Chisel {
     where
         B: Into<reqwest::Body>,
     {
-        let (status, response_body) = self.request_body(method.clone(), url, body).await;
+        self.request_text_with_headers(method, url, body, HeaderMap::new())
+            .await
+    }
+
+    /// Same as `request_text()`, but with headers
+    pub async fn request_text_with_headers<B>(
+        &self,
+        method: reqwest::Method,
+        url: &str,
+        body: B,
+        headers: HeaderMap,
+    ) -> String
+    where
+        B: Into<reqwest::Body>,
+    {
+        let (status, response_body) = self
+            .request_body_with_headers(method.clone(), url, body, headers)
+            .await;
         match str::from_utf8(&response_body) {
             Ok(text) => text.into(),
             Err(err) => panic!(
@@ -426,7 +479,25 @@ impl Chisel {
     where
         B: Into<reqwest::Body>,
     {
-        self.request(method, url, body).await.status().as_u16()
+        self.request_status_with_headers(method, url, body, HeaderMap::new())
+            .await
+    }
+
+    /// Same as `request()`, but returns the response status.
+    pub async fn request_status_with_headers<B>(
+        &self,
+        method: reqwest::Method,
+        url: &str,
+        body: B,
+        headers: HeaderMap,
+    ) -> u16
+    where
+        B: Into<reqwest::Body>,
+    {
+        self.request_with_headers(method, url, body, headers)
+            .await
+            .status()
+            .as_u16()
     }
 
     /*
@@ -446,17 +517,26 @@ impl Chisel {
     }
     */
 
+    /// Same as `request_text_with_headers()`, but sends GET with no request body.
+    pub async fn get_text_with_headers(&self, url: &str, headers: HeaderMap) -> String {
+        self.request_text_with_headers(reqwest::Method::GET, url, "", headers)
+            .await
+    }
+
     /// Same as `request_json()`, but sends GET with no request body.
     pub async fn get_json(&self, url: &str) -> serde_json::Value {
         self.request_json(reqwest::Method::GET, url, "").await
     }
 
-    /*
     /// Same as `request_status()`, but sends GET with no request body.
     pub async fn get_status(&self, url: &str) -> u16 {
-        self.request_status(reqwest::Method::GET, url, "").await
+        self.get_status_with_headers(url, HeaderMap::new()).await
     }
-    */
+
+    pub async fn get_status_with_headers(&self, url: &str, headers: HeaderMap) -> u16 {
+        self.request_status_with_headers(reqwest::Method::GET, url, "", headers)
+            .await
+    }
 
     /// Same as `request()`, but sends POST with JSON request payload.
     pub async fn post_json(&self, url: &str, data: serde_json::Value) -> reqwest::Response {

--- a/cli/tests/integration_tests/framework.rs
+++ b/cli/tests/integration_tests/framework.rs
@@ -584,3 +584,9 @@ pub struct TestContext {
     // before we try to drop the database.
     pub _db: Database,
 }
+
+pub fn header(name: &'static str, value: &str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(name, value.parse().unwrap());
+    headers
+}

--- a/cli/tests/integration_tests/rust.rs
+++ b/cli/tests/integration_tests/rust.rs
@@ -98,20 +98,26 @@ async fn setup_test_context(
 
     let db: Database = match db_config {
         DatabaseConfig::Postgres(config) => Database::Postgres(PostgresDb::new(config)),
-        DatabaseConfig::Sqlite => Database::Sqlite(SqliteDb { tmp_dir }),
+        DatabaseConfig::Sqlite => Database::Sqlite(SqliteDb {
+            tmp_dir: tmp_dir.clone(),
+        }),
     };
 
-    let mut chiseld = GuardedChild::new(tokio::process::Command::new(chiseld()).args([
-        "--webui",
-        "--db-uri",
-        db.url().as_str(),
-        "--api-listen-addr",
-        &chiseld_config.api_address.to_string(),
-        "--internal-routes-listen-addr",
-        &chiseld_config.internal_address.to_string(),
-        "--rpc-listen-addr",
-        &chiseld_config.rpc_address.to_string(),
-    ]));
+    let mut chiseld = GuardedChild::new(
+        tokio::process::Command::new(chiseld())
+            .args([
+                "--webui",
+                "--db-uri",
+                db.url().as_str(),
+                "--api-listen-addr",
+                &chiseld_config.api_address.to_string(),
+                "--internal-routes-listen-addr",
+                &chiseld_config.internal_address.to_string(),
+                "--rpc-listen-addr",
+                &chiseld_config.rpc_address.to_string(),
+            ])
+            .current_dir(tmp_dir.path()),
+    );
 
     tokio::select! {
         exit_status = chiseld.wait() => {

--- a/cli/tests/integration_tests/rust_tests/token_auth.rs
+++ b/cli/tests/integration_tests/rust_tests/token_auth.rs
@@ -1,12 +1,6 @@
-use crate::framework::prelude::*;
-use reqwest::{header::HeaderMap, StatusCode};
+use crate::framework::{header, prelude::*};
+use reqwest::StatusCode;
 use serde_json::json;
-
-fn header(name: &'static str, value: &str) -> HeaderMap {
-    let mut headers = HeaderMap::new();
-    headers.insert(name, value.parse().unwrap());
-    headers
-}
 
 #[chisel_macros::test(modules = Node)]
 pub async fn test(c: TestContext) {

--- a/cli/tests/integration_tests/rust_tests/token_auth.rs
+++ b/cli/tests/integration_tests/rust_tests/token_auth.rs
@@ -1,0 +1,116 @@
+use crate::framework::prelude::*;
+use reqwest::{header::HeaderMap, StatusCode};
+
+fn header(name: &'static str, value: &str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(name, value.parse().unwrap());
+    headers
+}
+
+#[chisel_macros::test(modules = Node)]
+pub async fn test(c: TestContext) {
+    c.chisel.write(
+        "policies/p.yaml",
+        r##"endpoints:
+ - path: /
+   mandatory_header: { name: header33, value: TOKEN33 }"##,
+    );
+    c.chisel.write(".env", r##"{ "TOKEN33" : "s3cr3t" }"##);
+    c.chisel.restart().await.unwrap();
+    c.chisel.apply().await.unwrap();
+
+    // Can't access /dev/hello without the required header.
+    assert_eq!(
+        c.chisel.get_status("/dev/hello").await,
+        StatusCode::FORBIDDEN
+    );
+
+    // But with the right header, you can.
+    assert_eq!(
+        c.chisel
+            .get_text_with_headers("/dev/hello", header("header33", "s3cr3t"))
+            .await,
+        "\"hello world\""
+    );
+
+    // Wrong header value.
+    assert_eq!(
+        c.chisel
+            .get_status_with_headers("/dev/hello", header("header33", "wrong"))
+            .await,
+        StatusCode::FORBIDDEN
+    );
+
+    // Header spec references non-existing secret.
+    c.chisel.write(
+        "policies/p.yaml",
+        r##"endpoints:
+ - path: /
+   mandatory_header: { name: header33, value: WXYZ }"##,
+    );
+    c.chisel.apply().await.unwrap();
+    assert_eq!(
+        c.chisel
+            .get_status_with_headers("/dev/hello", header("header33", "s3cr3t"))
+            .await,
+        StatusCode::FORBIDDEN
+    );
+
+    // Repeated path for header auth.
+    c.chisel.write(
+        "policies/p.yaml",
+        r##"endpoints:
+ - path: /
+   mandatory_header: { name: header33, value: TOKEN33 }
+ - path: /
+   mandatory_header: { name: foo, value: BAR }"##,
+    );
+    c.chisel
+        .apply()
+        .await
+        .expect_err("Didn't catch repeat path")
+        .stderr
+        .peek("Repeated path in header authorization");
+
+    // Unparsable header.
+    c.chisel.write(
+        "policies/p.yaml",
+        r##"endpoints:
+ - path: /
+   mandatory_header: aaabbb"##,
+    );
+    c.chisel
+        .apply()
+        .await
+        .expect_err("Didn't catch wrong header")
+        .stderr
+        .peek("Unparsable header");
+
+    // Header without name.
+    c.chisel.write(
+        "policies/p.yaml",
+        r##"endpoints:
+ - path: /
+   mandatory_header: { value: TOKEN33 }"##,
+    );
+    c.chisel
+        .apply()
+        .await
+        .expect_err("Didn't catch wrong header")
+        .stderr
+        .peek("Header must have string values for keys 'name' and 'value'");
+
+    // Non-string header value.
+    c.chisel.write(
+        "policies/p.yaml",
+        r##"endpoints:
+ - path: /
+   mandatory_header: { name: header33, value: 99 }"##,
+    );
+    c.chisel
+        .apply()
+        .await
+        .expect_err("Didn't catch wrong header")
+        .stderr
+        .peek("Header must have string values for keys 'name' and 'value'");
+}

--- a/cli/tests/integration_tests/rust_tests/token_auth.rs
+++ b/cli/tests/integration_tests/rust_tests/token_auth.rs
@@ -13,7 +13,7 @@ pub async fn test(c: TestContext) {
         "policies/p.yaml",
         r##"endpoints:
  - path: /
-   mandatory_header: { name: header33, value: TOKEN33 }"##,
+   mandatory_header: { name: header33, secret_value_ref: TOKEN33 }"##,
     );
     c.chisel.write(".env", r##"{ "TOKEN33" : "s3cr3t" }"##);
     c.chisel.restart().await.unwrap();
@@ -46,7 +46,7 @@ pub async fn test(c: TestContext) {
         "policies/p.yaml",
         r##"endpoints:
  - path: /
-   mandatory_header: { name: header33, value: WXYZ }"##,
+   mandatory_header: { name: header33, secret_value_ref: WXYZ }"##,
     );
     c.chisel.apply().await.unwrap();
     assert_eq!(
@@ -61,9 +61,9 @@ pub async fn test(c: TestContext) {
         "policies/p.yaml",
         r##"endpoints:
  - path: /
-   mandatory_header: { name: header33, value: TOKEN33 }
+   mandatory_header: { name: header33, secret_value_ref: TOKEN33 }
  - path: /
-   mandatory_header: { name: foo, value: BAR }"##,
+   mandatory_header: { name: foo, secret_value_ref: BAR }"##,
     );
     c.chisel
         .apply()
@@ -91,26 +91,26 @@ pub async fn test(c: TestContext) {
         "policies/p.yaml",
         r##"endpoints:
  - path: /
-   mandatory_header: { value: TOKEN33 }"##,
+   mandatory_header: { secret_value_ref: TOKEN33 }"##,
     );
     c.chisel
         .apply()
         .await
         .expect_err("Didn't catch wrong header")
         .stderr
-        .peek("Header must have string values for keys 'name' and 'value'");
+        .peek("Header must have string values for keys 'name' and 'secret_value_ref'");
 
-    // Non-string header value.
+    // Non-string secret_value_ref.
     c.chisel.write(
         "policies/p.yaml",
         r##"endpoints:
  - path: /
-   mandatory_header: { name: header33, value: 99 }"##,
+   mandatory_header: { name: header33, secret_value_ref: 99 }"##,
     );
     c.chisel
         .apply()
         .await
         .expect_err("Didn't catch wrong header")
         .stderr
-        .peek("Header must have string values for keys 'name' and 'value'");
+        .peek("Header must have string values for keys 'name' and 'secret_value_ref'");
 }

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -59,7 +59,7 @@ use futures::{future, FutureExt};
 use hyper::body::HttpBody;
 use hyper::Method;
 use hyper::Uri;
-use hyper::{header::HeaderValue, HeaderMap, Request, Response, StatusCode};
+use hyper::{Request, Response, StatusCode};
 use log::debug;
 use once_cell::sync::Lazy;
 use once_cell::unsync::OnceCell;
@@ -1070,7 +1070,7 @@ fn is_allowed_by_policy(
     state: &OpState,
     api_version: &str,
     username: Option<String>,
-    headers: &HeaderMap<HeaderValue>,
+    req: &Request<hyper::Body>,
     secrets: &JsonObject,
     path: &std::path::Path,
 ) -> Result<bool> {
@@ -1082,7 +1082,7 @@ fn is_allowed_by_policy(
             path.display()
         )),
         Some(x) => Ok(x.user_authorization.is_allowed(username, path)
-            && x.secret_authorization.is_allowed(headers, secrets, path)),
+            && x.secret_authorization.is_allowed(req, secrets, path)),
     }
 }
 
@@ -1280,7 +1280,7 @@ async fn special_response(
             &state.borrow(),
             rp.api_version(),
             username,
-            req.headers(),
+            req,
             current_secrets(&state.borrow()),
             rp.path().as_ref(),
         )?;

--- a/server/src/policies.rs
+++ b/server/src/policies.rs
@@ -256,7 +256,7 @@ impl VersionPolicy {
                     match header {
                         Yaml::BadValue => {}
                         Yaml::Hash(_) => {
-                            let kv = (&header["name"], &header["value"]);
+                            let kv = (&header["name"], &header["secret_value_ref"]);
                             match kv {
                                 (Yaml::String(name), Yaml::String(value)) => {
                                     policies.secret_authorization.add(path, RequiredHeader {
@@ -265,7 +265,7 @@ impl VersionPolicy {
                                     })?;
                                 }
                                 _ => anyhow::bail!(
-                                    "Header must have string values for keys 'name' and 'value'. Instead got: {header:?}"
+                                    "Header must have string values for keys 'name' and 'secret_value_ref'. Instead got: {header:?}"
                                 ),
                             }
                         }


### PR DESCRIPTION
A new kind of policy lets you forbid endpoint access without a particular HTTP header that contains the correct secret value.