### PR TITLE
Use tokio::select!() to avoid having to fuse()

### DIFF
--- a/cli/src/cmd/dev.rs
+++ b/cli/src/cmd/dev.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use deno_core::futures;
 use endpoint_tsc::tsc_compile;
 use futures::channel::mpsc::channel;
-use futures::{FutureExt, SinkExt, StreamExt};
+use futures::{SinkExt, StreamExt};
 use notify::{event::ModifyKind, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::HashSet;
 use std::panic;
@@ -28,10 +28,10 @@ pub(crate) async fn cmd_dev(
     let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
     let mut sighup = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())?;
     let sig_task: JoinHandle<Result<()>> = tokio::task::spawn(async move {
-        futures::select! {
-            _ = sigterm.recv().fuse() => { },
-            _ = sigint.recv().fuse() => { },
-            _ = sighup.recv().fuse() => { },
+        tokio::select! {
+            _ = sigterm.recv() => { },
+            _ = sigint.recv() => { },
+            _ = sighup.recv() => { },
         };
         signal_tx.send(()).await?;
         Ok(())
@@ -67,11 +67,11 @@ pub(crate) async fn cmd_dev(
     apply_watcher.watch(&cwd, RecursiveMode::Recursive)?;
 
     loop {
-        futures::select! {
-            _ = signal_rx.next().fuse() => {
+        tokio::select! {
+            _ = signal_rx.next() => {
                 break;
             }
-            res = watcher_rx.next().fuse() => {
+            res = watcher_rx.next() => {
                 let res = res.unwrap();
                 match res {
                     Ok(Event {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -363,11 +363,11 @@ async fn run_shared_state(
     let mut sigusr1 =
         tokio::signal::unix::signal(tokio::signal::unix::SignalKind::user_defined1())?;
     let sig_task = tokio::task::spawn(async move {
-        let res = futures::select! {
-            _ = sigterm.recv().fuse() => { debug!("Got SIGTERM"); DoRepeat::No },
-            _ = sigint.recv().fuse() => { debug!("Got SIGINT"); DoRepeat::No },
-            _ = sighup.recv().fuse() => { debug!("Got SIGHUP"); DoRepeat::No },
-            _ = sigusr1.recv().fuse() => { debug!("Got SIGUSR1"); DoRepeat::Yes },
+        let res = tokio::select! {
+            _ = sigterm.recv() => { debug!("Got SIGTERM"); DoRepeat::No },
+            _ = sigint.recv() => { debug!("Got SIGINT"); DoRepeat::No },
+            _ = sighup.recv() => { debug!("Got SIGHUP"); DoRepeat::No },
+            _ = sigusr1.recv() => { debug!("Got SIGUSR1"); DoRepeat::Yes },
         };
         mark_not_ready();
         debug!("Got signal");
@@ -382,9 +382,9 @@ async fn run_shared_state(
     let opt_clone = opt.clone();
     let _secret_reader = tokio::task::spawn(async move {
         loop {
-            futures::select! {
-                _ = sleep(Duration::from_millis(1000)).fuse() => {},
-                _ = secret_shutdown.recv().fuse() => {
+            tokio::select! {
+                _ = sleep(Duration::from_millis(1000)) => {},
+                _ = secret_shutdown.recv() => {
                     break;
                 }
             };


### PR DESCRIPTION
Suggested by Jan Špaček.