### PR TITLE
docs: Switch to JSON-based streaming example

### DIFF
--- a/docusaurus/docs/Intro/streaming.md
+++ b/docusaurus/docs/Intro/streaming.md
@@ -11,11 +11,12 @@ For example, to consume events from a `hello` topic, create a `events/hello.ts` 
 ```typescript title="my-backend/events/hello.ts"
 import { ChiselEvent } from "@chiselstrike/api";
 
+function toJSON(buffer: ArrayBuffer) {
+    return JSON.parse(String.fromCharCode.apply(null, new Uint8Array(buffer)));
+}
+
 export default async function (event: ChiselEvent) {
-    const utf8 = new TextDecoder();
-    const key = event.key ? utf8.decode(event.key) : undefined;
-    const value = event.value ? utf8.decode(event.value) : undefined;
-    console.log("Event => key = " + key + ", value = " + value);
+    console.log(toJSON(event.value));
 }
 ```
 


### PR DESCRIPTION
The StringDecoder thing is just ugly and nobody will use that in
real-life code. Switch to equally ugly, yet useful, example with JSON.