### PR TITLE
Revert "server.rs: Async sleep instad of thread sleep."

### DIFF
--- a/cli/src/server.rs
+++ b/cli/src/server.rs
@@ -5,7 +5,7 @@ use crate::chisel::{StatusRequest, StatusResponse};
 use anyhow::Result;
 use std::future::Future;
 use std::io::ErrorKind;
-
+use std::thread;
 use std::time::Duration;
 use tonic::transport::Channel;
 
@@ -60,7 +60,7 @@ where
                 if total > timeout {
                     anyhow::bail!("Timeout");
                 }
-                tokio::time::sleep(wait_time).await;
+                thread::sleep(wait_time);
                 total += wait_time;
                 wait_time *= 2;
             }


### PR DESCRIPTION
This reverts commit b7dd9fffc3d9b886f1766cc1db1faaf17515351f. It seems
to make 'cargo test' hang on some machines, including the one we use for
CI.