### PR TITLE
Add timeout to test pipelines.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,6 +93,7 @@ jobs:
 
     - name: run unit tests
       uses: actions-rs/cargo@v1
+      timeout-minutes: 20
       with:
           command: test
 
@@ -143,6 +144,7 @@ jobs:
 
     - name: Run integration tests against Postgres
       uses: actions-rs/cargo@v1
+      timeout-minutes: 20
       with:
           command: test
           args: -p cli --test integration_tests -- --database postgres --database-user postgres --database-password "$POSTGRES_PASSWORD"


### PR DESCRIPTION
Tests got stuck in the past, this PR adds a timeout of 20 minutes to test steps in the CI pipeline to limit the impact of stuck tests.