### PR TITLE
Use `pub` instead of `pub(crate)` in server (from #1618)

### DIFF
--- a/cli/src/ts.rs
+++ b/cli/src/ts.rs
@@ -1,6 +1,6 @@
 use crate::chisel::{type_msg::TypeEnum, AddTypeRequest, ContainerType, FieldDefinition, TypeMsg};
 use anyhow::{anyhow, bail, ensure, Context, Result};
-use chisel_server::auth::is_auth_entity_name;
+use chisel_server::is_auth_entity_name;
 use std::collections::BTreeSet;
 use std::fmt;
 use std::path::Path;

--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -13,10 +13,10 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-pub(crate) const AUTH_USER_NAME: &str = "AuthUser";
-pub(crate) const AUTH_SESSION_NAME: &str = "AuthSession";
-pub(crate) const AUTH_TOKEN_NAME: &str = "AuthToken";
-pub(crate) const AUTH_ACCOUNT_NAME: &str = "AuthAccount";
+pub const AUTH_USER_NAME: &str = "AuthUser";
+pub const AUTH_SESSION_NAME: &str = "AuthSession";
+pub const AUTH_TOKEN_NAME: &str = "AuthToken";
+pub const AUTH_ACCOUNT_NAME: &str = "AuthAccount";
 
 const AUTH_ENTITY_NAMES: [&str; 4] = [
     AUTH_USER_NAME,
@@ -55,7 +55,7 @@ export default {type_name}.crud()"#
     crate::server::add_endpoints(sources, api).await
 }
 
-pub(crate) async fn init(api: &mut ApiService) -> Result<()> {
+pub async fn init(api: &mut ApiService) -> Result<()> {
     add_crud_endpoint_for_type(AUTH_USER_NAME, "users", api).await?;
     add_crud_endpoint_for_type(AUTH_SESSION_NAME, "sessions", api).await?;
     add_crud_endpoint_for_type(AUTH_TOKEN_NAME, "tokens", api).await?;
@@ -63,7 +63,7 @@ pub(crate) async fn init(api: &mut ApiService) -> Result<()> {
 }
 
 /// Extracts the username of the logged-in user, or None if there was no login.
-pub(crate) async fn get_username_from_id(
+pub async fn get_username_from_id(
     state: Rc<RefCell<OpState>>,
     userid: Option<String>,
 ) -> Option<String> {

--- a/server/src/datastore/crud.rs
+++ b/server/src/datastore/crud.rs
@@ -12,14 +12,14 @@ use serde_json::json;
 use std::sync::Arc;
 
 #[derive(Clone, Serialize, Deserialize)]
-pub(crate) struct QueryParams {
+pub struct QueryParams {
     #[serde(rename = "typeName")]
     type_name: String,
     url: Url,
 }
 
 /// Parses CRUD `params` and runs the query with provided `query_engine`.
-pub(crate) fn run_query(
+pub fn run_query(
     context: &RequestContext<'_>,
     params: QueryParams,
     query_engine: Arc<QueryEngine>,
@@ -172,7 +172,7 @@ fn make_page_url(url: &Url, host: &Option<String>, cursor: &Cursor) -> Result<Ur
 }
 
 /// Constructs Delete Mutation from CRUD url.
-pub(crate) fn delete_from_url(c: &RequestContext, type_name: &str, url: &str) -> Result<Mutation> {
+pub fn delete_from_url(c: &RequestContext, type_name: &str, url: &str) -> Result<Mutation> {
     let base_entity = match c.ts.lookup_type(type_name, &c.api_version) {
         Ok(Type::Entity(ty)) => ty,
         Ok(ty) => anyhow::bail!("Cannot delete scalar type {type_name} ({})", ty.name()),
@@ -583,7 +583,7 @@ mod tests {
     use serde_json::json;
     use std::collections::HashMap;
 
-    pub(crate) struct FakeField {
+    pub struct FakeField {
         name: &'static str,
         ty: Type,
     }
@@ -603,7 +603,7 @@ mod tests {
         }
     }
 
-    pub(crate) struct FakeObject {
+    pub struct FakeObject {
         name: &'static str,
     }
 

--- a/server/src/datastore/dbconn.rs
+++ b/server/src/datastore/dbconn.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 // in their cdb40b1f8e5f, but that was not released yet. So temporarily wrap
 // around ours. When they release we can remove this.
 #[derive(Debug, Copy, Clone)]
-pub(crate) enum Kind {
+pub enum Kind {
     Postgres,
     Sqlite,
 }
@@ -35,14 +35,14 @@ impl From<AnyKind> for Kind {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct DbConnection {
-    pub(crate) kind: Kind,
-    pub(crate) pool: AnyPool,
-    pub(crate) conn_uri: String,
+pub struct DbConnection {
+    pub kind: Kind,
+    pub pool: AnyPool,
+    pub conn_uri: String,
 }
 
 impl DbConnection {
-    pub(crate) async fn connect(uri: &str, nr_conn: usize) -> Result<Self> {
+    pub async fn connect(uri: &str, nr_conn: usize) -> Result<Self> {
         let opts = AnyConnectOptions::from_str(uri)?;
         let kind: Kind = opts.kind().into();
         let pool = AnyPoolOptions::new()
@@ -68,14 +68,14 @@ impl DbConnection {
         })
     }
 
-    pub(crate) async fn local_connection(&self, nr_conn: usize) -> Result<Self> {
+    pub async fn local_connection(&self, nr_conn: usize) -> Result<Self> {
         match self.kind {
             Kind::Postgres => Self::connect(&self.conn_uri, nr_conn).await,
             Kind::Sqlite => Ok(self.clone()),
         }
     }
 
-    pub(crate) fn get_query_builder(kind: &Kind) -> &dyn SchemaBuilder {
+    pub fn get_query_builder(kind: &Kind) -> &dyn SchemaBuilder {
         match kind {
             Kind::Postgres => &PostgresQueryBuilder,
             Kind::Sqlite => &SqliteQueryBuilder,

--- a/server/src/datastore/engine.rs
+++ b/server/src/datastore/engine.rs
@@ -30,14 +30,14 @@ use std::task::{Context, Poll};
 use uuid::Uuid;
 
 /// A query row is a JSON object that represent the queried entities.
-pub(crate) type ResultRow = JsonObject;
+pub type ResultRow = JsonObject;
 
 /// A query results is a stream of query rows after policies have been applied.
-pub(crate) type QueryResults = BoxStream<'static, Result<ResultRow>>;
+pub type QueryResults = BoxStream<'static, Result<ResultRow>>;
 
-pub(crate) type TransactionStatic = Arc<Mutex<Transaction<'static, Any>>>;
+pub type TransactionStatic = Arc<Mutex<Transaction<'static, Any>>>;
 
-pub(crate) fn extract_transaction(transaction: TransactionStatic) -> Transaction<'static, Any> {
+pub fn extract_transaction(transaction: TransactionStatic) -> Transaction<'static, Any> {
     let transaction = Arc::try_unwrap(transaction).expect("Transaction still has references held!");
     transaction.into_inner()
 }
@@ -72,7 +72,7 @@ async fn make_transactioned_stream(
     }
 }
 
-pub(crate) fn new_query_results(
+pub fn new_query_results(
     raw_query: String,
     tr: TransactionStatic,
 ) -> impl Stream<Item = anyhow::Result<AnyRow>> {
@@ -110,11 +110,11 @@ impl TryFrom<&Field> for ColumnDef {
 /// An SQL string with placeholders, plus its argument values.  Keeps them all alive so they can be fed to
 /// sqlx::Query by reference.
 #[derive(Debug)]
-pub(crate) struct SqlWithArguments {
+pub struct SqlWithArguments {
     /// SQL query text with placeholders $1, $2, ...
-    pub(crate) sql: String,
+    pub sql: String,
     /// Values for $n placeholders.
-    pub(crate) args: Vec<SqlValue>,
+    pub args: Vec<SqlValue>,
 }
 
 impl SqlWithArguments {
@@ -151,8 +151,8 @@ impl SqlWithArguments {
 ///     }
 /// }
 #[derive(Debug, Serialize)]
-pub(crate) struct IdTree {
-    pub(crate) id: String,
+pub struct IdTree {
+    pub id: String,
     children: HashMap<String, IdTree>,
 }
 
@@ -184,7 +184,7 @@ fn id_idx(entity: &QueriedEntity) -> usize {
 /// some parts of a mutation or query need to run through the policy engine,
 /// which is not always offloadable to a database.
 #[derive(Clone)]
-pub(crate) struct QueryEngine {
+pub struct QueryEngine {
     kind: Kind,
     pool: AnyPool,
 }
@@ -194,7 +194,7 @@ impl QueryEngine {
         Self { kind, pool }
     }
 
-    pub(crate) async fn local_connection(conn: &DbConnection, nr_conn: usize) -> Result<Self> {
+    pub async fn local_connection(conn: &DbConnection, nr_conn: usize) -> Result<Self> {
         let local = conn.local_connection(nr_conn).await?;
         Ok(Self::new(local.kind, local.pool))
     }
@@ -206,7 +206,7 @@ impl QueryEngine {
         }
     }
 
-    pub(crate) async fn drop_table(
+    pub async fn drop_table(
         &self,
         transaction: &mut Transaction<'_, Any>,
         ty: &ObjectType,
@@ -223,26 +223,26 @@ impl QueryEngine {
         Ok(())
     }
 
-    pub(crate) async fn start_transaction_static(self: Arc<Self>) -> Result<TransactionStatic> {
+    pub async fn start_transaction_static(self: Arc<Self>) -> Result<TransactionStatic> {
         Ok(Arc::new(Mutex::new(self.pool.begin().await?)))
     }
 
-    pub(crate) async fn start_transaction(&self) -> Result<Transaction<'static, Any>> {
+    pub async fn start_transaction(&self) -> Result<Transaction<'static, Any>> {
         Ok(self.pool.begin().await?)
     }
 
-    pub(crate) async fn commit_transaction(transaction: Transaction<'static, Any>) -> Result<()> {
+    pub async fn commit_transaction(transaction: Transaction<'static, Any>) -> Result<()> {
         transaction.commit().await?;
         Ok(())
     }
 
-    pub(crate) async fn commit_transaction_static(transaction: TransactionStatic) -> Result<()> {
+    pub async fn commit_transaction_static(transaction: TransactionStatic) -> Result<()> {
         let transaction = extract_transaction(transaction);
         transaction.commit().await?;
         Ok(())
     }
 
-    pub(crate) async fn create_table(
+    pub async fn create_table(
         &self,
         transaction: &mut Transaction<'_, Any>,
         ty: &ObjectType,
@@ -265,7 +265,7 @@ impl QueryEngine {
         Ok(())
     }
 
-    pub(crate) async fn alter_table(
+    pub async fn alter_table(
         &self,
         transaction: &mut Transaction<'_, Any>,
         ty: &ObjectType,
@@ -333,7 +333,7 @@ impl QueryEngine {
         Ok(())
     }
 
-    pub(crate) async fn create_indexes(
+    pub async fn create_indexes(
         transaction: &mut Transaction<'_, Any>,
         ty: &ObjectType,
         indexes: &[DbIndex],
@@ -355,7 +355,7 @@ impl QueryEngine {
         Ok(())
     }
 
-    pub(crate) async fn drop_indexes(
+    pub async fn drop_indexes(
         &self,
         transaction: &mut Transaction<'_, Any>,
         ty: &ObjectType,
@@ -476,7 +476,7 @@ impl QueryEngine {
     }
 
     /// Execute the given `query` and return a stream to the results.
-    pub(crate) fn query(
+    pub fn query(
         &self,
         tr: TransactionStatic,
         query_plan: QueryPlan,
@@ -495,7 +495,7 @@ impl QueryEngine {
     ///
     /// Only for testing purposes. For any other purpose, use `mutate_with_transaction`.
     #[cfg(test)]
-    pub(crate) async fn mutate(&self, mutation: Mutation) -> Result<()> {
+    pub async fn mutate(&self, mutation: Mutation) -> Result<()> {
         let mut transaction = self.start_transaction().await?;
         self.mutate_with_transaction(mutation, &mut transaction)
             .await?;
@@ -503,7 +503,7 @@ impl QueryEngine {
         Ok(())
     }
 
-    pub(crate) async fn mutate_with_transaction(
+    pub async fn mutate_with_transaction(
         &self,
         mutation: Mutation,
         transaction: &mut Transaction<'_, Any>,
@@ -524,7 +524,7 @@ impl QueryEngine {
     ///     ...
     /// }
     ///
-    pub(crate) fn add_row<'a>(
+    pub fn add_row<'a>(
         &'a self,
         ty: &ObjectType,
         ty_value: &JsonObject,
@@ -539,7 +539,7 @@ impl QueryEngine {
         }
     }
 
-    pub(crate) async fn add_row_shallow(
+    pub async fn add_row_shallow(
         &self,
         ty: &ObjectType,
         ty_value: &JsonObject,
@@ -549,7 +549,7 @@ impl QueryEngine {
         Ok(())
     }
 
-    pub(crate) async fn fetch_one(&self, q: SqlWithArguments) -> Result<AnyRow> {
+    pub async fn fetch_one(&self, q: SqlWithArguments) -> Result<AnyRow> {
         Ok(q.get_sqlx().fetch_one(&self.pool).await?)
     }
 

--- a/server/src/datastore/engine.rs
+++ b/server/src/datastore/engine.rs
@@ -539,11 +539,7 @@ impl QueryEngine {
         }
     }
 
-    pub async fn add_row_shallow(
-        &self,
-        ty: &ObjectType,
-        ty_value: &JsonObject,
-    ) -> Result<()> {
+    pub async fn add_row_shallow(&self, ty: &ObjectType, ty_value: &JsonObject) -> Result<()> {
         let query = self.prepare_insertion_shallow(ty, ty_value)?;
         self.run_sql_queries(&[query], None).await?;
         Ok(())

--- a/server/src/datastore/expr.rs
+++ b/server/src/datastore/expr.rs
@@ -4,7 +4,7 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg_attr(test, derive(PartialEq))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "exprType")]
-pub(crate) enum Expr {
+pub enum Expr {
     /// A value expression.
     Value { value: Value },
     /// Expression for addressing function parameters of the current expression
@@ -37,7 +37,7 @@ impl From<PropertyAccess> for Expr {
 #[cfg_attr(test, derive(PartialEq))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
-pub(crate) enum Value {
+pub enum Value {
     Bool(bool),
     U64(u64),
     I64(i64),
@@ -94,7 +94,7 @@ impl From<Option<Value>> for Value {
 /// Expression of a property access on an Entity
 #[cfg_attr(test, derive(PartialEq))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct PropertyAccess {
+pub struct PropertyAccess {
     /// Name of a property that will be accessed.
     pub property: String,
     /// Expression whose property will be accessed. The expression
@@ -106,7 +106,7 @@ pub(crate) struct PropertyAccess {
 /// A binary operator.
 #[cfg_attr(test, derive(PartialEq))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) enum BinaryOp {
+pub enum BinaryOp {
     Eq,
     NotEq,
     Lt,
@@ -139,7 +139,7 @@ impl BinaryOp {
 /// A binary expression.
 #[cfg_attr(test, derive(PartialEq))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct BinaryExpr {
+pub struct BinaryExpr {
     pub left: Box<Expr>,
     pub op: BinaryOp,
     pub right: Box<Expr>,
@@ -155,7 +155,7 @@ macro_rules! make_op_method {
 }
 
 impl BinaryExpr {
-    pub(crate) fn new(op: BinaryOp, lhs: Expr, rhs: Expr) -> Self {
+    pub fn new(op: BinaryOp, lhs: Expr, rhs: Expr) -> Self {
         BinaryExpr {
             left: Box::new(lhs),
             op,

--- a/server/src/datastore/meta/mod.rs
+++ b/server/src/datastore/meta/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod schema;
+pub mod schema;
 
 // SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com>
 
@@ -23,7 +23,7 @@ use tokio::fs;
 /// The meta service is responsible for managing metadata such as object
 /// types and labels persistently.
 #[derive(Debug)]
-pub(crate) struct MetaService {
+pub struct MetaService {
     kind: Kind,
     pool: AnyPool,
 }
@@ -218,11 +218,11 @@ async fn insert_field_query(
 }
 
 impl MetaService {
-    pub(crate) fn new(kind: Kind, pool: AnyPool) -> Self {
+    pub fn new(kind: Kind, pool: AnyPool) -> Self {
         Self { kind, pool }
     }
 
-    pub(crate) async fn local_connection(
+    pub async fn local_connection(
         conn: &DbConnection,
         nr_conn: usize,
     ) -> anyhow::Result<Self> {
@@ -253,7 +253,7 @@ impl MetaService {
     /// For Postgres this is a lot more complex because it is not possible to
     /// do cross-database transactions. But this handles the local dev case,
     /// which is what is most relevant at the moment.
-    pub(crate) async fn maybe_migrate_sqlite_database<P: AsRef<Path>, T: AsRef<Path>>(
+    pub async fn maybe_migrate_sqlite_database<P: AsRef<Path>, T: AsRef<Path>>(
         &self,
         sources: &[P],
         to: T,
@@ -374,7 +374,7 @@ impl MetaService {
     }
 
     /// Create the schema of the underlying metadata store.
-    pub(crate) async fn create_schema(&self) -> anyhow::Result<()> {
+    pub async fn create_schema(&self) -> anyhow::Result<()> {
         let query_builder = DbConnection::get_query_builder(&self.kind);
         let tables = schema::tables();
 
@@ -428,7 +428,7 @@ impl MetaService {
     }
 
     /// Load information about the current API versions present in this system
-    pub(crate) async fn load_api_info(&self) -> anyhow::Result<ApiInfoMap> {
+    pub async fn load_api_info(&self) -> anyhow::Result<ApiInfoMap> {
         let query = sqlx::query("SELECT api_version, app_name, version_tag FROM api_info");
         let rows = fetch_all(&self.pool, query).await?;
 
@@ -444,7 +444,7 @@ impl MetaService {
         Ok(info)
     }
 
-    pub(crate) async fn persist_api_info(
+    pub async fn persist_api_info(
         &self,
         transaction: &mut Transaction<'_, Any>,
         api_version: &str,
@@ -465,7 +465,7 @@ impl MetaService {
     }
 
     /// Load the existing endpoints from from metadata store.
-    pub(crate) async fn load_sources<'r>(&self) -> anyhow::Result<PrefixMap<String>> {
+    pub async fn load_sources<'r>(&self) -> anyhow::Result<PrefixMap<String>> {
         let query = sqlx::query("SELECT path, code FROM sources");
         let rows = fetch_all(&self.pool, query).await?;
 
@@ -479,7 +479,7 @@ impl MetaService {
         Ok(sources)
     }
 
-    pub(crate) async fn persist_sources(&self, sources: &PrefixMap<String>) -> anyhow::Result<()> {
+    pub async fn persist_sources(&self, sources: &PrefixMap<String>) -> anyhow::Result<()> {
         let mut transaction = self.pool.begin().await?;
 
         let drop = sqlx::query("DELETE FROM sources");
@@ -497,7 +497,7 @@ impl MetaService {
     }
 
     /// Load the type system from metadata store.
-    pub(crate) async fn load_type_system<'r>(&self) -> anyhow::Result<TypeSystem> {
+    pub async fn load_type_system<'r>(&self) -> anyhow::Result<TypeSystem> {
         let query = sqlx::query(
             r#"
             SELECT
@@ -635,7 +635,7 @@ impl MetaService {
         Ok(indexes)
     }
 
-    pub(crate) async fn remove_type(
+    pub async fn remove_type(
         &self,
         transaction: &mut Transaction<'_, Any>,
         ty: &ObjectType,
@@ -657,7 +657,7 @@ impl MetaService {
         Ok(())
     }
 
-    pub(crate) async fn update_type(
+    pub async fn update_type(
         &self,
         transaction: &mut Transaction<'_, Any>,
         ty: &ObjectType,
@@ -687,11 +687,11 @@ impl MetaService {
         Ok(())
     }
 
-    pub(crate) async fn start_transaction(&self) -> anyhow::Result<Transaction<'_, Any>> {
+    pub async fn start_transaction(&self) -> anyhow::Result<Transaction<'_, Any>> {
         Ok(self.pool.begin().await?)
     }
 
-    pub(crate) async fn commit_transaction(
+    pub async fn commit_transaction(
         transaction: Transaction<'_, Any>,
     ) -> anyhow::Result<()> {
         transaction.commit().await?;
@@ -702,7 +702,7 @@ impl MetaService {
     ///
     /// We don't have a method that persist all policies, for all versions, because
     /// versions are applied independently
-    pub(crate) async fn persist_policy_version(
+    pub async fn persist_policy_version(
         &self,
         transaction: &mut Transaction<'_, Any>,
         version: &str,
@@ -721,7 +721,7 @@ impl MetaService {
         Ok(())
     }
 
-    pub(crate) async fn delete_policy_version(
+    pub async fn delete_policy_version(
         &self,
         transaction: &mut Transaction<'_, Any>,
         version: &str,
@@ -735,7 +735,7 @@ impl MetaService {
     /// Loads all policies, for all versions.
     ///
     /// Useful on startup, when we have to populate our in-memory state from the meta database.
-    pub(crate) async fn load_policies(&self) -> anyhow::Result<Policies> {
+    pub async fn load_policies(&self) -> anyhow::Result<Policies> {
         let get_policy = sqlx::query("SELECT version, policy_str FROM policies");
 
         let rows = fetch_all(&self.pool, get_policy).await?;
@@ -750,7 +750,7 @@ impl MetaService {
         Ok(policies)
     }
 
-    pub(crate) async fn count_rows(
+    pub async fn count_rows(
         &self,
         transaction: &mut Transaction<'_, Any>,
         ty: &ObjectType,
@@ -762,7 +762,7 @@ impl MetaService {
         Ok(cnt)
     }
 
-    pub(crate) async fn insert_type(
+    pub async fn insert_type(
         &self,
         transaction: &mut Transaction<'_, Any>,
         ty: &ObjectType,

--- a/server/src/datastore/meta/mod.rs
+++ b/server/src/datastore/meta/mod.rs
@@ -222,10 +222,7 @@ impl MetaService {
         Self { kind, pool }
     }
 
-    pub async fn local_connection(
-        conn: &DbConnection,
-        nr_conn: usize,
-    ) -> anyhow::Result<Self> {
+    pub async fn local_connection(conn: &DbConnection, nr_conn: usize) -> anyhow::Result<Self> {
         let local = conn.local_connection(nr_conn).await?;
         Ok(Self::new(local.kind, local.pool))
     }
@@ -691,9 +688,7 @@ impl MetaService {
         Ok(self.pool.begin().await?)
     }
 
-    pub async fn commit_transaction(
-        transaction: Transaction<'_, Any>,
-    ) -> anyhow::Result<()> {
+    pub async fn commit_transaction(transaction: Transaction<'_, Any>) -> anyhow::Result<()> {
         transaction.commit().await?;
         Ok(())
     }

--- a/server/src/datastore/meta/schema.rs
+++ b/server/src/datastore/meta/schema.rs
@@ -83,14 +83,14 @@ enum Policies {
     PolicyStr,
 }
 
-pub(crate) static CURRENT_VERSION: &str = "0.7";
+pub static CURRENT_VERSION: &str = "0.7";
 
 // Evolves from a version and returns the new version it evolved to
 //
 // The intention is to evolve from one version to the one immediately following, which is the only
 // way we can keep tests of this sane over the long run. So don't try to be smart and skip
 // versions.
-pub(crate) async fn evolve_from(
+pub async fn evolve_from(
     version: &str,
 ) -> anyhow::Result<(Vec<TableAlterStatement>, String)> {
     match version {
@@ -105,7 +105,7 @@ pub(crate) async fn evolve_from(
     }
 }
 
-pub(crate) fn tables() -> Vec<TableCreateStatement> {
+pub fn tables() -> Vec<TableCreateStatement> {
     let version = Table::create()
         .table(ChiselVersion::Table)
         .if_not_exists()

--- a/server/src/datastore/meta/schema.rs
+++ b/server/src/datastore/meta/schema.rs
@@ -90,9 +90,7 @@ pub static CURRENT_VERSION: &str = "0.7";
 // The intention is to evolve from one version to the one immediately following, which is the only
 // way we can keep tests of this sane over the long run. So don't try to be smart and skip
 // versions.
-pub async fn evolve_from(
-    version: &str,
-) -> anyhow::Result<(Vec<TableAlterStatement>, String)> {
+pub async fn evolve_from(version: &str) -> anyhow::Result<(Vec<TableAlterStatement>, String)> {
     match version {
         "0" => {
             let v = vec![Table::alter()

--- a/server/src/datastore/mod.rs
+++ b/server/src/datastore/mod.rs
@@ -52,14 +52,14 @@
 //! object instead and returns a `QueryResults` object, which represents a
 //! stream of query results with *policies applied*.
 
-pub(crate) mod crud;
+pub mod crud;
 mod dbconn;
-pub(crate) mod engine;
-pub(crate) mod expr;
-pub(crate) mod meta;
-pub(crate) mod query;
+pub mod engine;
+pub mod expr;
+pub mod meta;
+pub mod query;
 
-pub(crate) use dbconn::DbConnection;
-pub(crate) use dbconn::Kind;
-pub(crate) use engine::QueryEngine;
-pub(crate) use meta::MetaService;
+pub use dbconn::DbConnection;
+pub use dbconn::Kind;
+pub use engine::QueryEngine;
+pub use meta::MetaService;

--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -15,7 +15,7 @@ use std::fmt;
 use std::fmt::Write;
 
 #[derive(Debug, Clone, EnumAsInner)]
-pub(crate) enum SqlValue {
+pub enum SqlValue {
     Bool(bool),
     F64(f64),
     String(String),
@@ -29,7 +29,7 @@ impl From<&str> for SqlValue {
 
 /// RequestContext bears a mix of contextual variables used by QueryPlan
 /// and Mutations.
-pub(crate) struct RequestContext<'a> {
+pub struct RequestContext<'a> {
     /// Policies to be applied on the query.
     pub policies: &'a Policies,
     /// Type system to be used of version `api_version`
@@ -54,13 +54,13 @@ impl RequestContext<'_> {
 
 /// Whether a field should be included in or omitted from query result.
 #[derive(Debug, Clone)]
-pub(crate) enum KeepOrOmitField {
+pub enum KeepOrOmitField {
     Keep,
     Omit,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum QueryField {
+pub enum QueryField {
     Scalar {
         /// Name of the original Type field
         name: String,
@@ -92,25 +92,25 @@ pub(crate) enum QueryField {
 /// and so on. The `execute` method of `QueryEngine` executes these queries
 /// using SQL and the policy engine.
 #[derive(Debug, Clone)]
-pub(crate) struct Query {
+pub struct Query {
     /// SQL query text
-    pub(crate) raw_sql: String,
+    pub raw_sql: String,
     /// Entity that is being queried. Contains information necessary to reconstruct
     /// the JSON response.
-    pub(crate) entity: QueriedEntity,
+    pub entity: QueriedEntity,
     /// Entity fields selected by the user. This field is used to post-filter fields that
     /// shall be returned to the user in JSON.
     /// FIXME: The post-filtering is suboptimal solution and selection should happen when
     /// we build the raw_sql query.
-    pub(crate) allowed_fields: Option<HashSet<String>>,
+    pub allowed_fields: Option<HashSet<String>>,
 }
 
 /// QueriedEntity represents queried Entity of type `ty` which is to be aliased as
 /// `table_alias` in the SQL query and joined with nested Entities using `joins`.
 #[derive(Debug, Clone)]
-pub(crate) struct QueriedEntity {
+pub struct QueriedEntity {
     /// Entity fields to be returned in JSON response
-    pub(crate) fields: Vec<QueryField>,
+    pub fields: Vec<QueryField>,
     /// Type of the entity.
     ty: Entity,
     /// Alias name of this entity to be used in SQL query.
@@ -121,7 +121,7 @@ pub(crate) struct QueriedEntity {
 }
 
 impl QueriedEntity {
-    pub(crate) fn get_child_entity<'a>(&'a self, child_name: &str) -> Option<&'a QueriedEntity> {
+    pub fn get_child_entity<'a>(&'a self, child_name: &str) -> Option<&'a QueriedEntity> {
         self.joins.get(child_name).map(|c| &c.entity)
     }
 
@@ -143,7 +143,7 @@ struct Join {
 /// SortKey specifies a `field_name` and ordering in which sorting should be done.
 #[cfg_attr(test, derive(PartialEq))]
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub(crate) struct SortKey {
+pub struct SortKey {
     #[serde(rename = "fieldName")]
     pub field_name: String,
     pub ascending: bool,
@@ -151,14 +151,14 @@ pub(crate) struct SortKey {
 
 #[cfg_attr(test, derive(PartialEq))]
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub(crate) struct SortBy {
+pub struct SortBy {
     pub keys: Vec<SortKey>,
 }
 
 /// Operators used to mutate the result set.
 #[cfg_attr(test, derive(PartialEq))]
 #[derive(Debug, Clone, EnumAsInner)]
-pub(crate) enum QueryOp {
+pub enum QueryOp {
     /// Filters elements by `expression`.
     Filter { expression: Expr },
     /// Projects QueryEntity to a projected Entity containing only `fields`.
@@ -210,7 +210,7 @@ impl fmt::Display for ColumnAlias {
 }
 
 #[derive(Debug, Clone, EnumAsInner)]
-pub(crate) enum TargetDatabase {
+pub enum TargetDatabase {
     Postgres,
     Sqlite,
 }
@@ -221,7 +221,7 @@ pub(crate) enum TargetDatabase {
 /// When we are done with that, `build_query` can be called which creates a `Query`
 /// structure that contains raw SQL query string and additional data necessary for
 /// JSON response reconstruction and filtering.
-pub(crate) struct QueryPlan {
+pub struct QueryPlan {
     /// Columns that will be retrieved from the database in order defined by this vector.
     columns: Vec<Column>,
     /// Entity object representing entity that is being retrieved along with necessary joins
@@ -259,7 +259,7 @@ impl QueryPlan {
     /// Constructs a query builder ready to build an expression querying all fields of a
     /// given type `ty`. This is done in a shallow manner. Columns representing foreign
     /// key are returned as string, not as the related Entity.
-    pub(crate) fn from_type(ty: &Entity) -> Self {
+    pub fn from_type(ty: &Entity) -> Self {
         let mut builder = Self::new(ty.clone());
         for field in ty.all_fields() {
             let mut field = field.clone();
@@ -289,7 +289,7 @@ impl QueryPlan {
 
     /// Constructs QueryPlan from type `ty` and application of given
     /// `operators.
-    pub(crate) fn from_ops(
+    pub fn from_ops(
         c: &RequestContext,
         ty: &Entity,
         operators: Vec<QueryOp>,
@@ -303,7 +303,7 @@ impl QueryPlan {
     /// Constructs a query plan from a query `op_chain` and
     /// additional helper data like `policies`, `api_version`,
     /// `userid` and `path` (url path used for policy evaluation).
-    pub(crate) fn from_op_chain(context: &RequestContext, op_chain: QueryOpChain) -> Result<Self> {
+    pub fn from_op_chain(context: &RequestContext, op_chain: QueryOpChain) -> Result<Self> {
         let (entity_name, operators) = convert_ops(op_chain)?;
         let mut builder = Self::from_entity_name(context, &entity_name)?;
 
@@ -715,7 +715,7 @@ impl QueryPlan {
         Ok(sql_query)
     }
 
-    pub(crate) fn build_query(&self, target: &TargetDatabase) -> Result<Query> {
+    pub fn build_query(&self, target: &TargetDatabase) -> Result<Query> {
         Ok(Query {
             raw_sql: self.make_raw_query(target)?,
             entity: self.entity.clone(),
@@ -745,13 +745,13 @@ fn max_prefix(s: &str, max_len: usize) -> &str {
 
 /// Truncates Database identifier (column/table name) to 63 bytes to make it
 /// Postgres-compatible.
-pub(crate) fn truncate_identifier(s: &str) -> &str {
+pub fn truncate_identifier(s: &str) -> &str {
     max_prefix(s, 63)
 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type")]
-pub(crate) enum QueryOpChain {
+pub enum QueryOpChain {
     BaseEntity {
         name: String,
     },
@@ -803,7 +803,7 @@ fn convert_ops(op: QueryOpChain) -> Result<(String, Vec<QueryOp>)> {
 }
 
 /// `Mutation` represents a statement that mutates the database state.
-pub(crate) struct Mutation {
+pub struct Mutation {
     base_entity: Entity,
     /// Query plan used to build mutation condition.
     filter_query_plan: QueryPlan,
@@ -811,7 +811,7 @@ pub(crate) struct Mutation {
 
 impl Mutation {
     /// Constructs delete from filter expression.
-    pub(crate) fn delete_from_expr(
+    pub fn delete_from_expr(
         c: &RequestContext,
         type_name: &str,
         filter_expr: &Option<Expr>,
@@ -834,7 +834,7 @@ impl Mutation {
         })
     }
 
-    pub(crate) fn build_sql(&self, target: TargetDatabase) -> Result<String> {
+    pub fn build_sql(&self, target: TargetDatabase) -> Result<String> {
         let select_sql = self.filter_query_plan.build_query(&target)?.raw_sql;
         let id_column = ColumnAlias {
             field_name: "id".to_owned(),
@@ -852,7 +852,7 @@ impl Mutation {
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
+pub mod tests {
     use super::*;
     use deno_core::futures;
     use futures::StreamExt;
@@ -866,9 +866,9 @@ pub(crate) mod tests {
     use crate::types;
     use crate::JsonObject;
 
-    pub(crate) const VERSION: &str = "version_1";
+    pub const VERSION: &str = "version_1";
 
-    pub(crate) fn binary(fields: &[&'static str], op: BinaryOp, value: ExprValue) -> Expr {
+    pub fn binary(fields: &[&'static str], op: BinaryOp, value: ExprValue) -> Expr {
         assert!(!fields.len() > 0);
         let mut field_chain = Expr::Parameter { position: 0 };
         for field_name in fields {
@@ -881,7 +881,7 @@ pub(crate) mod tests {
         BinaryExpr::new(op, field_chain, value.into()).into()
     }
 
-    pub(crate) fn make_type_system(entities: &[Entity]) -> TypeSystem {
+    pub fn make_type_system(entities: &[Entity]) -> TypeSystem {
         let mut ts = TypeSystem::default();
         for ty in entities {
             ts.add_custom_type(ty.clone()).unwrap();
@@ -889,12 +889,12 @@ pub(crate) mod tests {
         ts
     }
 
-    pub(crate) fn make_entity(name: &str, fields: Vec<Field>) -> Entity {
+    pub fn make_entity(name: &str, fields: Vec<Field>) -> Entity {
         let desc = types::NewObject::new(name, VERSION);
         Entity::Custom(Arc::new(ObjectType::new(desc, fields, vec![]).unwrap()))
     }
 
-    pub(crate) fn make_field(name: &str, ty: Type) -> Field {
+    pub fn make_field(name: &str, ty: Type) -> Field {
         let desc = types::NewField::new(name, ty, VERSION).unwrap();
         Field::new(desc, vec![], None, false, false)
     }
@@ -914,14 +914,14 @@ pub(crate) mod tests {
         QueryEngine::commit_transaction(tr).await.unwrap();
     }
 
-    pub(crate) async fn setup_clear_db(entities: &[Entity]) -> (QueryEngine, NamedTempFile) {
+    pub async fn setup_clear_db(entities: &[Entity]) -> (QueryEngine, NamedTempFile) {
         let db_file = NamedTempFile::new().unwrap();
         let qe = init_query_engine(&db_file).await;
         init_database(&qe, entities).await;
         (qe, db_file)
     }
 
-    pub(crate) async fn add_row(
+    pub async fn add_row(
         query_engine: &QueryEngine,
         entity: &Entity,
         values: &serde_json::Value,
@@ -944,7 +944,7 @@ pub(crate) mod tests {
         }));
     }
 
-    pub(crate) async fn fetch_rows(qe: &QueryEngine, entity: &Entity) -> Vec<JsonObject> {
+    pub async fn fetch_rows(qe: &QueryEngine, entity: &Entity) -> Vec<JsonObject> {
         let query_plan = QueryPlan::from_type(entity);
         fetch_rows_with_plan(qe, query_plan).await
     }

--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -289,11 +289,7 @@ impl QueryPlan {
 
     /// Constructs QueryPlan from type `ty` and application of given
     /// `operators.
-    pub fn from_ops(
-        c: &RequestContext,
-        ty: &Entity,
-        operators: Vec<QueryOp>,
-    ) -> Result<Self> {
+    pub fn from_ops(c: &RequestContext, ty: &Entity, operators: Vec<QueryOp>) -> Result<Self> {
         let mut query_plan = Self::new(ty.clone());
         query_plan.entity = query_plan.load_entity(c, ty)?;
         query_plan.extend_operators(operators);

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -285,7 +285,7 @@ thread_local! {
 }
 
 impl DenoService {
-    pub(crate) async fn new(inspect: bool, inspect_brk: bool) -> (Self, v8::Global<v8::Function>) {
+    pub async fn new(inspect: bool, inspect_brk: bool) -> (Self, v8::Global<v8::Function>) {
         let web_worker_preload_module_cb =
             Arc::new(|worker| LocalFutureObj::new(Box::new(future::ready(Ok(worker)))));
         let inner = Arc::new(std::sync::Mutex::new(ModuleLoaderInner {
@@ -842,7 +842,7 @@ thread_local! {
     static REJECTED: RefCell<HashSet<v8::Global<v8::Promise>>> = RefCell::new(HashSet::new());
 }
 
-pub(crate) fn shutdown() {
+pub fn shutdown() {
     REJECTED.with(|r| {
         assert!(r.borrow().is_empty());
     });
@@ -870,7 +870,7 @@ extern "C" fn promise_reject_callback(message: v8::PromiseRejectMessage) {
     }
 }
 
-pub(crate) async fn init_deno(
+pub async fn init_deno(
     v8_flags: Vec<String>,
     inspect: bool,
     inspect_brk: bool,
@@ -1107,14 +1107,14 @@ async fn mutate_policies_impl(func: Box<dyn FnOnce(&mut Policies) + Send>) {
     to_worker(WorkerMsg::MutatePolicies(func)).await;
 }
 
-pub(crate) async fn mutate_policies<F>(func: F)
+pub async fn mutate_policies<F>(func: F)
 where
     F: FnOnce(&mut Policies) + Send + 'static,
 {
     mutate_policies_impl(Box::new(func)).await;
 }
 
-pub(crate) async fn set_policies(policies: Policies) {
+pub async fn set_policies(policies: Policies) {
     to_worker(WorkerMsg::SetPolicies(policies)).await;
 }
 
@@ -1139,19 +1139,19 @@ fn current_type_system(st: &OpState) -> &TypeSystem {
     st.borrow()
 }
 
-pub(crate) async fn set_meta(meta: MetaService) {
+pub async fn set_meta(meta: MetaService) {
     to_worker(WorkerMsg::SetMeta(meta)).await;
 }
 
-pub(crate) fn query_engine_arc(st: &OpState) -> Arc<QueryEngine> {
+pub fn query_engine_arc(st: &OpState) -> Arc<QueryEngine> {
     st.borrow::<Arc<QueryEngine>>().clone()
 }
 
-pub(crate) async fn set_query_engine(query_engine: Arc<QueryEngine>) {
+pub async fn set_query_engine(query_engine: Arc<QueryEngine>) {
     to_worker(WorkerMsg::SetQueryEngine(query_engine)).await;
 }
 
-pub(crate) fn lookup_builtin_type(
+pub fn lookup_builtin_type(
     state: &OpState,
     type_name: &str,
 ) -> Result<Type, TypeSystemError> {
@@ -1159,7 +1159,7 @@ pub(crate) fn lookup_builtin_type(
     type_system.lookup_builtin_type(type_name)
 }
 
-pub(crate) async fn remove_type_version(version: &str) {
+pub async fn remove_type_version(version: &str) {
     to_worker(WorkerMsg::RemoveTypeVersion(version.to_string())).await;
 }
 
@@ -1182,11 +1182,11 @@ async fn to_worker(msg: WorkerMsg) {
     resolve_promise(promise).await.unwrap();
 }
 
-pub(crate) async fn set_type_system(type_system: TypeSystem) {
+pub async fn set_type_system(type_system: TypeSystem) {
     to_worker(WorkerMsg::SetTypeSystem(type_system)).await;
 }
 
-pub(crate) async fn update_secrets(secrets: JsonObject) {
+pub async fn update_secrets(secrets: JsonObject) {
     to_worker(WorkerMsg::SetCurrentSecrets(secrets.clone())).await;
 }
 
@@ -1330,7 +1330,7 @@ async fn convert_response(mut res: Response<Body>) -> Result<ResponseParts> {
     })
 }
 
-pub(crate) async fn run_js(path: String, req: Request<hyper::Body>) -> Result<Response<Body>> {
+pub async fn run_js(path: String, req: Request<hyper::Body>) -> Result<Response<Body>> {
     thread_local! {
         static NEXT_REQUEST_ID: Cell<u32> = Cell::new(0);
     }
@@ -1428,7 +1428,7 @@ pub(crate) async fn run_js(path: String, req: Request<hyper::Body>) -> Result<Re
     Ok(body)
 }
 
-pub(crate) async fn run_js_event(
+pub async fn run_js_event(
     path: String,
     key: Option<Vec<u8>>,
     value: Option<Vec<u8>>,
@@ -1578,7 +1578,7 @@ fn get() -> RcMut<DenoService> {
     })
 }
 
-pub(crate) fn endpoint_path_from_source_path(path: &str) -> String {
+pub fn endpoint_path_from_source_path(path: &str) -> String {
     // The source path format is /api_version/endpoints/rest.js. The endpoint is /api_version/rest.
     let mut iter = path.splitn(4, '/');
     let api_version = iter.nth(1).unwrap();
@@ -1586,7 +1586,7 @@ pub(crate) fn endpoint_path_from_source_path(path: &str) -> String {
     format!("/{}/{}", api_version, without_extension(rest))
 }
 
-pub(crate) async fn compile_endpoints(sources: HashMap<String, String>) -> Result<()> {
+pub async fn compile_endpoints(sources: HashMap<String, String>) -> Result<()> {
     let promise = {
         let mut service = get();
         let service: &mut DenoService = &mut service;
@@ -1660,7 +1660,7 @@ pub(crate) async fn compile_endpoints(sources: HashMap<String, String>) -> Resul
     Ok(())
 }
 
-pub(crate) async fn activate_endpoint(path: &str) -> Result<()> {
+pub async fn activate_endpoint(path: &str) -> Result<()> {
     let promise = {
         let mut service = get();
         let service: &mut DenoService = &mut service;
@@ -1676,7 +1676,7 @@ pub(crate) async fn activate_endpoint(path: &str) -> Result<()> {
     Ok(())
 }
 
-pub(crate) async fn activate_event_handler(path: &str) -> Result<()> {
+pub async fn activate_event_handler(path: &str) -> Result<()> {
     let promise = {
         let mut service = get();
         let service: &mut DenoService = &mut service;

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -870,11 +870,7 @@ extern "C" fn promise_reject_callback(message: v8::PromiseRejectMessage) {
     }
 }
 
-pub async fn init_deno(
-    v8_flags: Vec<String>,
-    inspect: bool,
-    inspect_brk: bool,
-) -> Result<()> {
+pub async fn init_deno(v8_flags: Vec<String>, inspect: bool, inspect_brk: bool) -> Result<()> {
     let v8_flags = once("unused_arg0".to_owned())
         .chain(v8_flags.iter().cloned())
         .collect();
@@ -1151,10 +1147,7 @@ pub async fn set_query_engine(query_engine: Arc<QueryEngine>) {
     to_worker(WorkerMsg::SetQueryEngine(query_engine)).await;
 }
 
-pub fn lookup_builtin_type(
-    state: &OpState,
-    type_name: &str,
-) -> Result<Type, TypeSystemError> {
+pub fn lookup_builtin_type(state: &OpState, type_name: &str) -> Result<Type, TypeSystemError> {
     let type_system = current_type_system(state);
     type_system.lookup_builtin_type(type_name)
 }

--- a/server/src/internal.rs
+++ b/server/src/internal.rs
@@ -14,11 +14,11 @@ use std::sync::atomic::{AtomicU16, Ordering};
 static SERVE_WEBUI: OnceCell<SocketAddr> = OnceCell::new();
 static HEALTH_READY: AtomicU16 = AtomicU16::new(404);
 
-pub(crate) fn mark_ready() {
+pub fn mark_ready() {
     HEALTH_READY.store(200, Ordering::Relaxed);
 }
 
-pub(crate) fn mark_not_ready() {
+pub fn mark_not_ready() {
     HEALTH_READY.store(400, Ordering::Relaxed);
 }
 
@@ -78,7 +78,7 @@ async fn route(req: Request<Body>) -> Result<Response<Body>> {
 /// Unlike the API server, it is strictly bound to 127.0.0.1. This is enough
 /// for the Kubernetes checks to work, and it is one less thing for us to secure
 /// and prevent DDoS attacks again - which is why this is a different server
-pub(crate) fn init(addr: SocketAddr, serve_webui: bool, rpc_addr: SocketAddr) {
+pub fn init(addr: SocketAddr, serve_webui: bool, rpc_addr: SocketAddr) {
     if serve_webui {
         SERVE_WEBUI
             .set(rpc_addr)

--- a/server/src/introspect.rs
+++ b/server/src/introspect.rs
@@ -84,7 +84,7 @@ async fn introspect(req: Request<hyper::Body>) -> Result<Response<Body>> {
         .unwrap())
 }
 
-pub(crate) fn add_introspection<P: AsRef<Path>>(api: &ApiService, path: P) {
+pub fn add_introspection<P: AsRef<Path>>(api: &ApiService, path: P) {
     let mut introspect_route = PathBuf::from("/");
     introspect_route.push(&path);
     api.add_route(
@@ -93,7 +93,7 @@ pub(crate) fn add_introspection<P: AsRef<Path>>(api: &ApiService, path: P) {
     );
 }
 
-pub(crate) fn init(api: &ApiService) {
+pub fn init(api: &ApiService) {
     add_introspection(api, "/");
     add_introspection(api, "__chiselstrike");
 }

--- a/server/src/kafka.rs
+++ b/server/src/kafka.rs
@@ -11,7 +11,7 @@ use rskafka::client::{
 use std::rc::Rc;
 use std::sync::Arc;
 
-pub(crate) async fn spawn(
+pub async fn spawn(
     api: Rc<ApiService>,
     connection: String,
     topics: Vec<String>,
@@ -49,8 +49,8 @@ pub(crate) async fn spawn(
     Ok(tasks)
 }
 
-pub(crate) async fn init() -> Result<()> {
+pub async fn init() -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn shutdown() {}
+pub fn shutdown() {}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -3,6 +3,9 @@
 #![cfg_attr(feature = "must_not_suspend", feature(must_not_suspend))]
 #![cfg_attr(feature = "must_not_suspend", deny(must_not_suspend))]
 
+pub use crate::auth::is_auth_entity_name;
+pub use crate::server::{run_all, DoRepeat, Opt};
+
 pub(crate) type JsonObject = serde_json::Map<String, serde_json::Value>;
 
 macro_rules! send_command {
@@ -15,7 +18,7 @@ macro_rules! send_command {
 extern crate log;
 
 pub(crate) mod api;
-pub mod auth;
+pub(crate) mod auth;
 pub(crate) mod datastore;
 pub(crate) mod deno;
 pub(crate) mod internal;
@@ -27,7 +30,7 @@ pub(crate) mod rcmut;
 pub(crate) mod rpc;
 pub(crate) mod runtime;
 pub(crate) mod secrets;
-pub mod server;
+pub(crate) mod server;
 pub(crate) mod types;
 pub(crate) mod vecmap;
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -4,11 +4,10 @@
 extern crate log;
 
 use anyhow::Result;
-use chisel_server::server;
+use chisel_server as server;
 use env_logger::Env;
 use log::LevelFilter;
 use nix::unistd::execv;
-use server::DoRepeat;
 use std::env;
 use std::ffi::CString;
 use std::io::Write;
@@ -58,7 +57,7 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    if let DoRepeat::Yes = server::run_all(opt).await? {
+    if let server::DoRepeat::Yes = server::run_all(opt).await? {
         info!("Restarting");
         execv(&CString::new(exe).unwrap(), &args).unwrap();
     }

--- a/server/src/policies.rs
+++ b/server/src/policies.rs
@@ -12,7 +12,7 @@ use yaml_rust::{Yaml, YamlLoader};
 
 /// Different kinds of policies.
 #[derive(Clone)]
-pub(crate) enum Kind {
+pub enum Kind {
     /// How this policy transforms values read from storage.
     Transform(fn(Value) -> Value),
     /// Field is of AuthUser type and must match the user currently logged in.
@@ -22,30 +22,30 @@ pub(crate) enum Kind {
 }
 
 #[derive(Clone)]
-pub(crate) struct Policy {
-    pub(crate) kind: Kind,
+pub struct Policy {
+    pub kind: Kind,
 
     /// This policy doesn't apply when the request URI matches.
-    pub(crate) except_uri: regex::Regex,
+    pub except_uri: regex::Regex,
 }
 
 /// Maps labels to their applicable policies.
-pub(crate) type LabelPolicies = HashMap<String, Policy>;
+pub type LabelPolicies = HashMap<String, Policy>;
 
 #[derive(Clone, Default, Debug)]
-pub(crate) struct FieldPolicies {
+pub struct FieldPolicies {
     /// Maps a field name to the transformation we apply to that field's values.
-    pub(crate) transforms: HashMap<String, fn(Value) -> Value>,
+    pub transforms: HashMap<String, fn(Value) -> Value>,
     /// Names of fields that must equal the currently logged-in user.
-    pub(crate) match_login: HashSet<String>,
+    pub match_login: HashSet<String>,
     /// ID of the currently logged-in user.
-    pub(crate) current_userid: Option<String>,
+    pub current_userid: Option<String>,
     /// Names of fields which will be excluded from query's resulting json object.
-    pub(crate) omit: HashSet<String>,
+    pub omit: HashSet<String>,
 }
 
 #[derive(Clone, Default, Debug)]
-pub(crate) struct UserAuthorization {
+pub struct UserAuthorization {
     /// A user is authorized to access a path if the username matches the regex for the longest path prefix present
     /// here.
     paths: PrefixMap<regex::Regex>,
@@ -76,7 +76,7 @@ impl UserAuthorization {
 /// Describes secret-based authorization.  An endpoint request will only be allowed if it includes a header
 /// specified in this struct.
 #[derive(Clone, Default, Debug)]
-pub(crate) struct SecretAuthorization {
+pub struct SecretAuthorization {
     /// A request can access an endpoint if it includes a header required by the longest path prefix.
     paths: PrefixMap<RequiredHeader>,
 }
@@ -146,19 +146,19 @@ struct RequiredHeader {
 }
 
 #[derive(Clone, Default)]
-pub(crate) struct VersionPolicy {
-    pub(crate) labels: LabelPolicies,
-    pub(crate) user_authorization: UserAuthorization,
-    pub(crate) secret_authorization: SecretAuthorization,
+pub struct VersionPolicy {
+    pub labels: LabelPolicies,
+    pub user_authorization: UserAuthorization,
+    pub secret_authorization: SecretAuthorization,
 }
 
 #[derive(Clone, Default)]
-pub(crate) struct Policies {
-    pub(crate) versions: HashMap<String, VersionPolicy>,
+pub struct Policies {
+    pub versions: HashMap<String, VersionPolicy>,
 }
 
 impl Policies {
-    pub(crate) fn add_from_yaml<K: ToString, Y: AsRef<str>>(
+    pub fn add_from_yaml<K: ToString, Y: AsRef<str>>(
         &mut self,
         version: K,
         yaml: Y,
@@ -169,7 +169,7 @@ impl Policies {
     }
 
     /// For field of type `ty` creates field policies.
-    pub(crate) fn make_field_policies(
+    pub fn make_field_policies(
         &self,
         user_id: &Option<String>,
         current_path: &str,
@@ -206,7 +206,7 @@ impl Policies {
 }
 
 impl VersionPolicy {
-    pub(crate) fn from_yaml<S: AsRef<str>>(config: S) -> Result<Self> {
+    pub fn from_yaml<S: AsRef<str>>(config: S) -> Result<Self> {
         let mut policies = Self::default();
         let mut labels = vec![];
 
@@ -303,7 +303,7 @@ impl VersionPolicy {
     }
 }
 
-pub(crate) fn anonymize(_: Value) -> Value {
+pub fn anonymize(_: Value) -> Value {
     // TODO: use type-specific anonymization.
     json!("xxxxx")
 }

--- a/server/src/policies.rs
+++ b/server/src/policies.rs
@@ -158,11 +158,7 @@ pub struct Policies {
 }
 
 impl Policies {
-    pub fn add_from_yaml<K: ToString, Y: AsRef<str>>(
-        &mut self,
-        version: K,
-        yaml: Y,
-    ) -> Result<()> {
+    pub fn add_from_yaml<K: ToString, Y: AsRef<str>>(&mut self, version: K, yaml: Y) -> Result<()> {
         let v = VersionPolicy::from_yaml(yaml)?;
         self.versions.insert(version.to_string(), v);
         Ok(())

--- a/server/src/prefix_map.rs
+++ b/server/src/prefix_map.rs
@@ -5,7 +5,7 @@ use std::ops::Bound;
 use std::path::{Path, PathBuf};
 
 #[derive(Clone, Debug)]
-pub(crate) struct PrefixMap<T> {
+pub struct PrefixMap<T> {
     map: BTreeMap<PathBuf, T>,
 }
 
@@ -19,7 +19,7 @@ impl<T> Default for PrefixMap<T> {
 
 impl<T> PrefixMap<T> {
     /// Returns the longest map entry whose key is a prefix of path, if one exists.
-    pub(crate) fn longest_prefix(&self, path: &Path) -> Option<(&Path, &T)> {
+    pub fn longest_prefix(&self, path: &Path) -> Option<(&Path, &T)> {
         let path_range = (Bound::Unbounded, Bound::Included(path));
         let tree_range = self.map.range::<Path, _>(path_range);
         for (p, v) in tree_range.rev() {
@@ -30,15 +30,15 @@ impl<T> PrefixMap<T> {
         None
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&Path, &T)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&Path, &T)> {
         self.map.iter().map(|(k, v)| (k.as_path(), v))
     }
 
-    pub(crate) fn insert(&mut self, k: PathBuf, v: T) -> Option<T> {
+    pub fn insert(&mut self, k: PathBuf, v: T) -> Option<T> {
         self.map.insert(k, v)
     }
 
-    pub(crate) fn remove_prefix(&mut self, prefix: &Path) {
+    pub fn remove_prefix(&mut self, prefix: &Path) {
         self.map.retain(|k, _| !k.starts_with(prefix))
     }
 }

--- a/server/src/rcmut.rs
+++ b/server/src/rcmut.rs
@@ -17,7 +17,7 @@ use std::rc::Rc;
     feature = "must_not_suspend",
     must_not_suspend = "holding a RcMut across suspend"
 )]
-pub(crate) struct RcMut<T: 'static> {
+pub struct RcMut<T: 'static> {
     rc: Rc<RefCell<T>>,
     refmut: MaybeUninit<RefMut<'static, T>>,
 }
@@ -29,7 +29,7 @@ impl<T> Drop for RcMut<T> {
 }
 
 impl<T> RcMut<T> {
-    pub(crate) fn new(rc: Rc<RefCell<T>>) -> Self {
+    pub fn new(rc: Rc<RefCell<T>>) -> Self {
         let mut ret = Self {
             rc,
             refmut: MaybeUninit::uninit(),

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -60,7 +60,7 @@ fn validate_api_version(version: &str) -> Result<()> {
 // types (especially because they may error out in different ways due to ordering).
 //
 // Policies and endpoints are stateless so we don't need a global copy.
-pub(crate) struct GlobalRpcState {
+pub struct GlobalRpcState {
     /// Unique UUID identifying this RPC runtime.
     id: Uuid,
     type_system: TypeSystem,
@@ -73,14 +73,14 @@ pub(crate) struct GlobalRpcState {
 }
 
 #[derive(Clone)]
-pub(crate) struct InitState {
+pub struct InitState {
     pub sources: PrefixMap<String>,
     pub policies: Policies,
     pub type_system: TypeSystem,
 }
 
 impl GlobalRpcState {
-    pub(crate) async fn new(
+    pub async fn new(
         meta: MetaService,
         init: InitState,
         query_engine: QueryEngine,
@@ -129,12 +129,12 @@ impl GlobalRpcState {
 /// The RPC service provides a Protobuf-based interface for Chisel control
 /// plane. For example, the service has RPC calls for managing types and
 /// endpoints. The user-generated data plane endpoints are serviced with REST.
-pub(crate) struct RpcService {
+pub struct RpcService {
     state: Arc<Mutex<GlobalRpcState>>,
 }
 
 impl RpcService {
-    pub(crate) fn new(state: Arc<Mutex<GlobalRpcState>>) -> Self {
+    pub fn new(state: Arc<Mutex<GlobalRpcState>>) -> Self {
         Self { state }
     }
 
@@ -806,7 +806,7 @@ impl ChiselRpc for RpcService {
     }
 }
 
-pub(crate) fn spawn(
+pub fn spawn(
     rpc: RpcService,
     addr: SocketAddr,
     start_wait: impl core::future::Future<Output = ()> + Send + 'static,

--- a/server/src/runtime.rs
+++ b/server/src/runtime.rs
@@ -8,13 +8,13 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 #[derive(new)]
-pub(crate) struct Runtime {
-    pub(crate) api: Rc<ApiService>,
+pub struct Runtime {
+    pub api: Rc<ApiService>,
 }
 
 thread_local!(static RUNTIME: OnceCell<Rc<RefCell<Runtime>>> = OnceCell::new());
 
-pub(crate) fn set(rt: Runtime) {
+pub fn set(rt: Runtime) {
     RUNTIME.with(|x| {
         x.set(Rc::new(RefCell::new(rt)))
             .map_err(|_| ())
@@ -22,7 +22,7 @@ pub(crate) fn set(rt: Runtime) {
     })
 }
 
-pub(crate) fn get() -> RcMut<Runtime> {
+pub fn get() -> RcMut<Runtime> {
     RUNTIME.with(|x| {
         let rc = x.get().expect("Runtime is not yet initialized.").clone();
         RcMut::new(rc)

--- a/server/src/secrets.rs
+++ b/server/src/secrets.rs
@@ -86,7 +86,7 @@ fn get_pkcs8_private_key(pem: &str) -> Result<Option<RsaPrivateKey>> {
     Ok(Some(key))
 }
 
-pub(crate) async fn get_private_key(opt: &Opt) -> Result<Option<RsaPrivateKey>> {
+pub async fn get_private_key(opt: &Opt) -> Result<Option<RsaPrivateKey>> {
     let url = match &opt.chisel_secret_key_location {
         Some(x) => match Url::parse(x) {
             Ok(o) => Ok(o),
@@ -116,7 +116,7 @@ fn parse_rsa_key(pem: &str) -> Result<Option<RsaPrivateKey>> {
     get_pkcs8_private_key(pem)
 }
 
-pub(crate) async fn get_secrets(opt: &Opt) -> Result<JsonObject> {
+pub async fn get_secrets(opt: &Opt) -> Result<JsonObject> {
     let secret_location = match &opt.chisel_secret_location {
         Some(s) => Url::parse(s)?,
         None => {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -116,7 +116,7 @@ pub enum DoRepeat {
     No,
 }
 
-pub(crate) trait CommandTrait:
+pub trait CommandTrait:
     (FnOnce() -> LocalBoxFuture<'static, Result<()>>) + Send + 'static
 {
 }
@@ -156,7 +156,7 @@ impl SharedTasks {
     }
 }
 
-pub(crate) async fn add_endpoints(
+pub async fn add_endpoints(
     sources: HashMap<String, String>,
     api_service: &ApiService,
 ) -> Result<()> {
@@ -324,7 +324,7 @@ struct ExecutorChannel {
 
 // Sends commands, receives results.
 #[derive(Clone)]
-pub(crate) struct CoordinatorChannel {
+pub struct CoordinatorChannel {
     pub tx: async_channel::Sender<Command>,
     pub rx: async_channel::Receiver<CommandResult>,
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -116,10 +116,7 @@ pub enum DoRepeat {
     No,
 }
 
-pub trait CommandTrait:
-    (FnOnce() -> LocalBoxFuture<'static, Result<()>>) + Send + 'static
-{
-}
+pub trait CommandTrait: (FnOnce() -> LocalBoxFuture<'static, Result<()>>) + Send + 'static {}
 
 impl<T> CommandTrait for T where
     T: (FnOnce() -> LocalBoxFuture<'static, Result<()>>) + Send + 'static

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 #[derive(thiserror::Error, Debug)]
-pub(crate) enum TypeSystemError {
+pub enum TypeSystemError {
     #[error["type already exists"]]
     CustomTypeExists(Entity),
     #[error["no such type: {0}"]]
@@ -31,19 +31,19 @@ pub(crate) enum TypeSystemError {
 }
 
 #[derive(Debug, Default, Clone, new)]
-pub(crate) struct VersionTypes {
+pub struct VersionTypes {
     #[new(default)]
-    pub(crate) custom_types: HashMap<String, Entity>,
+    pub custom_types: HashMap<String, Entity>,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct TypeSystem {
-    pub(crate) versions: HashMap<String, VersionTypes>,
+pub struct TypeSystem {
+    pub versions: HashMap<String, VersionTypes>,
     builtin_types: HashMap<String, Type>,
 }
 
 impl VersionTypes {
-    pub(crate) fn lookup_custom_type(&self, type_name: &str) -> Result<Entity, TypeSystemError> {
+    pub fn lookup_custom_type(&self, type_name: &str) -> Result<Entity, TypeSystemError> {
         match self.custom_types.get(type_name) {
             Some(ty) => Ok(ty.to_owned()),
             None => Err(TypeSystemError::NoSuchType(type_name.to_owned())),
@@ -161,7 +161,7 @@ impl Default for TypeSystem {
 }
 
 impl TypeSystem {
-    pub(crate) async fn create_builtin_backing_tables(
+    pub async fn create_builtin_backing_tables(
         &self,
         query_engine: &QueryEngine,
     ) -> anyhow::Result<()> {
@@ -178,7 +178,7 @@ impl TypeSystem {
     /// Returns a mutable reference to all types from a specific version.
     ///
     /// If there are no types for this version, the version is created.
-    pub(crate) fn get_version_mut(&mut self, api_version: &str) -> &mut VersionTypes {
+    pub fn get_version_mut(&mut self, api_version: &str) -> &mut VersionTypes {
         self.versions
             .entry(api_version.to_string())
             .or_insert_with(VersionTypes::default)
@@ -187,7 +187,7 @@ impl TypeSystem {
     /// Returns a read-only reference to all types from a specific version.
     ///
     /// If there are no types for this version, an error is returned
-    pub(crate) fn get_version(&self, api_version: &str) -> Result<&VersionTypes, TypeSystemError> {
+    pub fn get_version(&self, api_version: &str) -> Result<&VersionTypes, TypeSystemError> {
         self.versions
             .get(api_version)
             .ok_or_else(|| TypeSystemError::NoSuchVersion(api_version.to_owned()))
@@ -203,13 +203,13 @@ impl TypeSystem {
     ///
     /// If type `ty` already exists in the type system isn't Entity::Custom type,
     /// the function returns `TypeSystemError`.
-    pub(crate) fn add_custom_type(&mut self, ty: Entity) -> Result<(), TypeSystemError> {
+    pub fn add_custom_type(&mut self, ty: Entity) -> Result<(), TypeSystemError> {
         let version = self.get_version_mut(&ty.api_version);
         version.add_custom_type(ty)
     }
 
     /// Generate an [`ObjectDelta`] with the necessary information to evolve a specific type.
-    pub(crate) fn generate_type_delta(
+    pub fn generate_type_delta(
         old_type: &ObjectType,
         new_type: Arc<ObjectType>,
         ts: &TypeSystem,
@@ -362,7 +362,7 @@ impl TypeSystem {
     /// # Errors
     ///
     /// If the looked up type does not exists, the function returns a `TypeSystemError`.
-    pub(crate) fn lookup_custom_type(
+    pub fn lookup_custom_type(
         &self,
         type_name: &str,
         api_version: &str,
@@ -372,7 +372,7 @@ impl TypeSystem {
     }
 
     /// Looks up a builtin type with name `type_name`.
-    pub(crate) fn lookup_builtin_type(&self, type_name: &str) -> Result<Type, TypeSystemError> {
+    pub fn lookup_builtin_type(&self, type_name: &str) -> Result<Type, TypeSystemError> {
         if let Some(element_type_str) = type_name.strip_prefix("Array<") {
             if let Some(element_type_str) = element_type_str.strip_suffix('>') {
                 let element_type = self.lookup_builtin_type(element_type_str)?;
@@ -390,7 +390,7 @@ impl TypeSystem {
     /// # Errors
     ///
     /// If the looked up type does not exists, the function returns a `NoSuchType`.
-    pub(crate) fn lookup_type(
+    pub fn lookup_type(
         &self,
         type_name: &str,
         api_version: &str,
@@ -414,7 +414,7 @@ impl TypeSystem {
     /// # Errors
     ///
     /// If the looked up type does not exists, the function returns a `NoSuchType`.
-    pub(crate) fn lookup_entity(
+    pub fn lookup_entity(
         &self,
         type_name: &str,
         api_version: &str,
@@ -428,7 +428,7 @@ impl TypeSystem {
         }
     }
 
-    pub(crate) async fn populate_types<T: AsRef<str>, F: AsRef<str>>(
+    pub async fn populate_types<T: AsRef<str>, F: AsRef<str>>(
         &self,
         engine: Arc<QueryEngine>,
         api_version_to: T,
@@ -494,7 +494,7 @@ impl TypeSystem {
         });
     }
 
-    pub(crate) fn get(&self, ty: &TypeId) -> Result<Type, TypeSystemError> {
+    pub fn get(&self, ty: &TypeId) -> Result<Type, TypeSystemError> {
         match ty {
             TypeId::String | TypeId::Float | TypeId::Boolean | TypeId::Id | TypeId::Array(_) => {
                 self.lookup_builtin_type(&ty.name())
@@ -507,7 +507,7 @@ impl TypeSystem {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum Type {
+pub enum Type {
     String,
     Float,
     Boolean,
@@ -516,7 +516,7 @@ pub(crate) enum Type {
 }
 
 impl Type {
-    pub(crate) fn name(&self) -> String {
+    pub fn name(&self) -> String {
         match self {
             Type::Float => "number".to_string(),
             Type::String => "string".to_string(),
@@ -534,7 +534,7 @@ impl From<Entity> for Type {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum Entity {
+pub enum Entity {
     /// User defined Custom entity.
     Custom(Arc<ObjectType>),
     /// Built-in Auth entity.
@@ -543,7 +543,7 @@ pub(crate) enum Entity {
 
 impl Entity {
     /// Checks whether `Entity` is Auth builtin type.
-    pub(crate) fn is_auth(&self) -> bool {
+    pub fn is_auth(&self) -> bool {
         matches!(self, Entity::Auth(_))
     }
 }
@@ -584,14 +584,14 @@ impl Deref for Entity {
 /// reload the type system after changes are made to the database.
 ///
 /// This may become a problem if a user has many types, but it is simple, robust, and elegant.
-pub(crate) trait ObjectDescriptor {
+pub trait ObjectDescriptor {
     fn name(&self) -> String;
     fn id(&self) -> Option<i32>;
     fn backing_table(&self) -> String;
     fn api_version(&self) -> String;
 }
 
-pub(crate) struct InternalObject {
+pub struct InternalObject {
     name: &'static str,
     backing_table: &'static str,
 }
@@ -614,7 +614,7 @@ impl ObjectDescriptor for InternalObject {
     }
 }
 
-pub(crate) struct ExistingObject<'a> {
+pub struct ExistingObject<'a> {
     name: String,
     api_version: String,
     backing_table: &'a str,
@@ -622,7 +622,7 @@ pub(crate) struct ExistingObject<'a> {
 }
 
 impl<'a> ExistingObject<'a> {
-    pub(crate) fn new(name: &str, backing_table: &'a str, id: i32) -> anyhow::Result<Self> {
+    pub fn new(name: &str, backing_table: &'a str, id: i32) -> anyhow::Result<Self> {
         let split: Vec<&str> = name.split('.').collect();
 
         anyhow::ensure!(
@@ -660,14 +660,14 @@ impl<'a> ObjectDescriptor for ExistingObject<'a> {
     }
 }
 
-pub(crate) struct NewObject<'a> {
+pub struct NewObject<'a> {
     name: &'a str,
     backing_table: String, // store at object creation time so consecutive calls to backing_table() return the same value
     api_version: &'a str,
 }
 
 impl<'a> NewObject<'a> {
-    pub(crate) fn new(name: &'a str, api_version: &'a str) -> Self {
+    pub fn new(name: &'a str, api_version: &'a str) -> Self {
         let mut buf = Uuid::encode_buffer();
         let uuid = Uuid::new_v4();
         let backing_table = format!("ty_{}_{}", name, uuid.to_simple().encode_upper(&mut buf));
@@ -699,7 +699,7 @@ impl<'a> ObjectDescriptor for NewObject<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum TypeId {
+pub enum TypeId {
     String,
     Float,
     Boolean,
@@ -709,7 +709,7 @@ pub(crate) enum TypeId {
 }
 
 impl TypeId {
-    pub(crate) fn name(&self) -> String {
+    pub fn name(&self) -> String {
         match self {
             TypeId::Id | TypeId::String => "string".to_string(),
             TypeId::Float => "number".to_string(),
@@ -748,9 +748,9 @@ where
 }
 
 #[derive(Debug)]
-pub(crate) struct ObjectType {
+pub struct ObjectType {
     /// id of this object in the meta-database. Will be None for objects that are not persisted yet
-    pub(crate) meta_id: Option<i32>,
+    pub meta_id: Option<i32>,
     /// Name of this type.
     name: String,
     /// Fields of this type.
@@ -762,11 +762,11 @@ pub(crate) struct ObjectType {
     /// Name of the backing table for this type.
     backing_table: String,
 
-    pub(crate) api_version: String,
+    pub api_version: String,
 }
 
 impl ObjectType {
-    pub(crate) fn new<D: ObjectDescriptor>(
+    pub fn new<D: ObjectDescriptor>(
         desc: D,
         fields: Vec<Field>,
         indexes: Vec<DbIndex>,
@@ -818,31 +818,31 @@ impl ObjectType {
         })
     }
 
-    pub(crate) fn user_fields(&self) -> impl Iterator<Item = &Field> {
+    pub fn user_fields(&self) -> impl Iterator<Item = &Field> {
         self.fields.iter()
     }
 
-    pub(crate) fn all_fields(&self) -> impl Iterator<Item = &Field> {
+    pub fn all_fields(&self) -> impl Iterator<Item = &Field> {
         std::iter::once(&self.chisel_id).chain(self.fields.iter())
     }
 
-    pub(crate) fn has_field(&self, field_name: &str) -> bool {
+    pub fn has_field(&self, field_name: &str) -> bool {
         self.all_fields().any(|f| f.name == field_name)
     }
 
-    pub(crate) fn get_field(&self, field_name: &str) -> Option<&Field> {
+    pub fn get_field(&self, field_name: &str) -> Option<&Field> {
         self.all_fields().find(|f| f.name == field_name)
     }
 
-    pub(crate) fn backing_table(&self) -> &str {
+    pub fn backing_table(&self) -> &str {
         &self.backing_table
     }
 
-    pub(crate) fn name(&self) -> &str {
+    pub fn name(&self) -> &str {
         &self.name
     }
 
-    pub(crate) fn persisted_name(&self) -> String {
+    pub fn persisted_name(&self) -> String {
         format!("{}.{}", self.api_version, self.name)
     }
 
@@ -852,7 +852,7 @@ impl ObjectType {
         to_map.check_populate_from(&source_map)
     }
 
-    pub(crate) fn indexes(&self) -> &Vec<DbIndex> {
+    pub fn indexes(&self) -> &Vec<DbIndex> {
         &self.indexes
     }
 }
@@ -864,16 +864,16 @@ impl PartialEq for ObjectType {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct DbIndex {
+pub struct DbIndex {
     /// Id of this index in the meta database. Before it's creation, it will be None.
-    pub(crate) meta_id: Option<i32>,
+    pub meta_id: Option<i32>,
     /// Name of the index in database. Before it's creation, it will be None.
     backing_table: Option<String>,
-    pub(crate) fields: Vec<String>,
+    pub fields: Vec<String>,
 }
 
 impl DbIndex {
-    pub(crate) fn new(meta_id: i32, backing_table: String, fields: Vec<String>) -> Self {
+    pub fn new(meta_id: i32, backing_table: String, fields: Vec<String>) -> Self {
         Self {
             meta_id: Some(meta_id),
             backing_table: Some(backing_table),
@@ -881,7 +881,7 @@ impl DbIndex {
         }
     }
 
-    pub(crate) fn new_from_fields(fields: Vec<String>) -> Self {
+    pub fn new_from_fields(fields: Vec<String>) -> Self {
         Self {
             meta_id: None,
             backing_table: None,
@@ -889,7 +889,7 @@ impl DbIndex {
         }
     }
 
-    pub(crate) fn name(&self) -> Option<String> {
+    pub fn name(&self) -> Option<String> {
         self.meta_id.map(|id| {
             let name = format!(
                 "index_{id}_{}__{}",
@@ -948,14 +948,14 @@ impl<'a> FieldMap<'a> {
 ///
 /// See the [`ObjectDescriptor`] trait for details.
 /// Situations where a new versus existing field are created are similar.
-pub(crate) trait FieldDescriptor {
+pub trait FieldDescriptor {
     fn name(&self) -> String;
     fn id(&self) -> Option<i32>;
     fn ty(&self) -> Type;
     fn api_version(&self) -> String;
 }
 
-pub(crate) struct ExistingField {
+pub struct ExistingField {
     name: String,
     ty_: Type,
     id: i32,
@@ -963,7 +963,7 @@ pub(crate) struct ExistingField {
 }
 
 impl ExistingField {
-    pub(crate) fn new(name: &str, ty_: Type, id: i32, version: &str) -> Self {
+    pub fn new(name: &str, ty_: Type, id: i32, version: &str) -> Self {
         Self {
             name: name.to_owned(),
             ty_,
@@ -991,14 +991,14 @@ impl FieldDescriptor for ExistingField {
     }
 }
 
-pub(crate) struct NewField<'a> {
+pub struct NewField<'a> {
     name: &'a str,
     ty_: Type,
     version: &'a str,
 }
 
 impl<'a> NewField<'a> {
-    pub(crate) fn new(name: &'a str, ty_: Type, version: &'a str) -> anyhow::Result<Self> {
+    pub fn new(name: &'a str, ty_: Type, version: &'a str) -> anyhow::Result<Self> {
         Ok(Self { name, ty_, version })
     }
 }
@@ -1022,13 +1022,13 @@ impl<'a> FieldDescriptor for NewField<'a> {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct Field {
-    pub(crate) id: Option<i32>,
-    pub(crate) name: String,
-    pub(crate) type_id: TypeId,
-    pub(crate) labels: Vec<String>,
-    pub(crate) is_optional: bool,
-    pub(crate) is_unique: bool,
+pub struct Field {
+    pub id: Option<i32>,
+    pub name: String,
+    pub type_id: TypeId,
+    pub labels: Vec<String>,
+    pub is_optional: bool,
+    pub is_unique: bool,
     // We want to keep the default the user gave us so we can
     // return it in `chisel describe`. That's the default that is
     // valid in typescriptland.
@@ -1043,7 +1043,7 @@ pub(crate) struct Field {
 }
 
 impl Field {
-    pub(crate) fn new<D: FieldDescriptor>(
+    pub fn new<D: FieldDescriptor>(
         desc: D,
         labels: Vec<String>,
         default: Option<String>,
@@ -1072,22 +1072,22 @@ impl Field {
         }
     }
 
-    pub(crate) fn user_provided_default(&self) -> &Option<String> {
+    pub fn user_provided_default(&self) -> &Option<String> {
         &self.default
     }
 
-    pub(crate) fn default_value(&self) -> &Option<String> {
+    pub fn default_value(&self) -> &Option<String> {
         &self.effective_default
     }
 
-    pub(crate) fn generate_value(&self) -> Option<String> {
+    pub fn generate_value(&self) -> Option<String> {
         match self.type_id {
             TypeId::Id => Some(Uuid::new_v4().to_string()),
             _ => self.default.clone(),
         }
     }
 
-    pub(crate) fn persisted_name(&self, parent_type_name: &ObjectType) -> String {
+    pub fn persisted_name(&self, parent_type_name: &ObjectType) -> String {
         format!(
             "{}.{}.{}",
             self.api_version,
@@ -1098,25 +1098,25 @@ impl Field {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct FieldAttrDelta {
-    pub(crate) type_id: TypeId,
-    pub(crate) default: Option<String>,
-    pub(crate) is_optional: bool,
-    pub(crate) is_unique: bool,
+pub struct FieldAttrDelta {
+    pub type_id: TypeId,
+    pub default: Option<String>,
+    pub is_optional: bool,
+    pub is_unique: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct FieldDelta {
-    pub(crate) id: i32,
-    pub(crate) attrs: Option<FieldAttrDelta>,
-    pub(crate) labels: Option<Vec<String>>,
+pub struct FieldDelta {
+    pub id: i32,
+    pub attrs: Option<FieldAttrDelta>,
+    pub labels: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct ObjectDelta {
-    pub(crate) added_fields: Vec<Field>,
-    pub(crate) removed_fields: Vec<Field>,
-    pub(crate) updated_fields: Vec<FieldDelta>,
-    pub(crate) added_indexes: Vec<DbIndex>,
-    pub(crate) removed_indexes: Vec<DbIndex>,
+pub struct ObjectDelta {
+    pub added_fields: Vec<Field>,
+    pub removed_fields: Vec<Field>,
+    pub updated_fields: Vec<FieldDelta>,
+    pub added_indexes: Vec<DbIndex>,
+    pub removed_indexes: Vec<DbIndex>,
 }

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -390,11 +390,7 @@ impl TypeSystem {
     /// # Errors
     ///
     /// If the looked up type does not exists, the function returns a `NoSuchType`.
-    pub fn lookup_type(
-        &self,
-        type_name: &str,
-        api_version: &str,
-    ) -> Result<Type, TypeSystemError> {
+    pub fn lookup_type(&self, type_name: &str, api_version: &str) -> Result<Type, TypeSystemError> {
         if let Ok(ty) = self.lookup_builtin_type(type_name) {
             Ok(ty)
         } else {

--- a/server/src/vecmap.rs
+++ b/server/src/vecmap.rs
@@ -4,22 +4,22 @@
 // function. We should switch to vec-map if they accept a PR adding
 // push.
 
-pub(crate) struct VecMap<V> {
+pub struct VecMap<V> {
     vec: Vec<Option<V>>,
 }
 
 impl<V> VecMap<V> {
-    pub(crate) fn push(&mut self, v: V) -> usize {
+    pub fn push(&mut self, v: V) -> usize {
         let ret = self.vec.len();
         self.vec.push(Some(v));
         ret
     }
 
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self { vec: vec![] }
     }
 
-    pub(crate) fn remove(&mut self, key: usize) -> Option<V> {
+    pub fn remove(&mut self, key: usize) -> Option<V> {
         if key >= self.vec.len() {
             return None;
         }


### PR DESCRIPTION
We don't have to use `pub(crate)` everywhere, it is sufficient if we apply `pub(crate)` only at the crate root and use just `pub` in modules.

In particular, this does not affect warnings about dead code.

This is a spin-off from #1618.