### PR TITLE
Use "begin transaction", not "start transaction" (from #1618)

### DIFF
--- a/server/src/datastore/crud.rs
+++ b/server/src/datastore/crud.rs
@@ -772,7 +772,7 @@ mod tests {
         headers: HashMap<String, String>,
     ) -> Result<JsonObject> {
         let qe = Arc::new(qe.clone());
-        let tr = qe.clone().start_transaction_static().await.unwrap();
+        let tr = qe.clone().begin_transaction_static().await.unwrap();
         super::run_query(
             &RequestContext {
                 policies: &Policies::default(),

--- a/server/src/datastore/engine.rs
+++ b/server/src/datastore/engine.rs
@@ -223,11 +223,11 @@ impl QueryEngine {
         Ok(())
     }
 
-    pub async fn start_transaction_static(self: Arc<Self>) -> Result<TransactionStatic> {
+    pub async fn begin_transaction_static(self: Arc<Self>) -> Result<TransactionStatic> {
         Ok(Arc::new(Mutex::new(self.pool.begin().await?)))
     }
 
-    pub async fn start_transaction(&self) -> Result<Transaction<'static, Any>> {
+    pub async fn begin_transaction(&self) -> Result<Transaction<'static, Any>> {
         Ok(self.pool.begin().await?)
     }
 
@@ -496,7 +496,7 @@ impl QueryEngine {
     /// Only for testing purposes. For any other purpose, use `mutate_with_transaction`.
     #[cfg(test)]
     pub async fn mutate(&self, mutation: Mutation) -> Result<()> {
-        let mut transaction = self.start_transaction().await?;
+        let mut transaction = self.begin_transaction().await?;
         self.mutate_with_transaction(mutation, &mut transaction)
             .await?;
         QueryEngine::commit_transaction(transaction).await?;
@@ -559,7 +559,7 @@ impl QueryEngine {
                 transaction.execute(q.get_sqlx()).await?;
             }
         } else {
-            let mut transaction = self.start_transaction().await?;
+            let mut transaction = self.begin_transaction().await?;
             for q in queries {
                 transaction.execute(q.get_sqlx()).await?;
             }

--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -903,7 +903,7 @@ pub mod tests {
     }
 
     async fn init_database(query_engine: &QueryEngine, entities: &[Entity]) {
-        let mut tr = query_engine.start_transaction().await.unwrap();
+        let mut tr = query_engine.begin_transaction().await.unwrap();
         for entity in entities {
             query_engine.create_table(&mut tr, entity).await.unwrap();
         }
@@ -947,7 +947,7 @@ pub mod tests {
 
     async fn fetch_rows_with_plan(qe: &QueryEngine, query_plan: QueryPlan) -> Vec<JsonObject> {
         let qe = Arc::new(qe.clone());
-        let tr = qe.clone().start_transaction_static().await.unwrap();
+        let tr = qe.clone().begin_transaction_static().await.unwrap();
         let row_streams = qe.query(tr, query_plan).unwrap();
 
         row_streams

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -660,7 +660,7 @@ async fn op_chisel_crud_delete(
         query_engine_arc(&state).clone()
     };
 
-    let transaction = query_engine.clone().start_transaction_static().await?;
+    let transaction = query_engine.clone().begin_transaction_static().await?;
 
     let mut guard = transaction.lock().await;
     query_engine
@@ -1206,7 +1206,7 @@ fn op_chisel_rollback_transaction(state: &mut OpState) -> Result<()> {
 #[op]
 async fn op_chisel_create_transaction(state: Rc<RefCell<OpState>>) -> Result<()> {
     let qe = query_engine_arc(&state.borrow());
-    let transaction = qe.start_transaction_static().await?;
+    let transaction = qe.begin_transaction_static().await?;
     set_current_transaction(&mut state.borrow_mut(), transaction);
     Ok(())
 }

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -157,7 +157,7 @@ impl RpcService {
         let to_remove: Vec<&Entity> = version_types.custom_types.iter().map(|x| x.1).collect();
 
         let meta = &state.meta;
-        let mut transaction = meta.start_transaction().await?;
+        let mut transaction = meta.begin_transaction().await?;
 
         meta.delete_policy_version(&mut transaction, &api_version)
             .await?;
@@ -169,7 +169,7 @@ impl RpcService {
         MetaService::commit_transaction(transaction).await?;
 
         let query_engine = &state.query_engine;
-        let mut transaction = query_engine.start_transaction().await?;
+        let mut transaction = query_engine.begin_transaction().await?;
         for ty in to_remove.into_iter() {
             query_engine.drop_table(&mut transaction, ty).await?;
         }
@@ -300,7 +300,7 @@ impl RpcService {
         let version_types = state.type_system.get_version(&api_version)?; // End mutable state borrow from above.
 
         let meta = &state.meta;
-        let mut transaction = meta.start_transaction().await?;
+        let mut transaction = meta.begin_transaction().await?;
 
         for (existing, removed) in version_types.custom_types.iter() {
             if type_names.get(existing).is_none() {
@@ -474,7 +474,7 @@ or
             .collect::<Result<Vec<_>, _>>()?;
 
         let query_engine = &state.query_engine;
-        let mut transaction = query_engine.start_transaction().await?;
+        let mut transaction = query_engine.begin_transaction().await?;
         for ty in to_insert.into_iter() {
             query_engine.create_table(&mut transaction, &ty).await?;
         }

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -165,7 +165,7 @@ impl TypeSystem {
         &self,
         query_engine: &QueryEngine,
     ) -> anyhow::Result<()> {
-        let mut transaction = query_engine.start_transaction().await?;
+        let mut transaction = query_engine.begin_transaction().await?;
         for ty in self.builtin_types.values() {
             if let Type::Entity(ty) = ty {
                 query_engine.create_table(&mut transaction, ty).await?;
@@ -458,7 +458,7 @@ impl TypeSystem {
                         )
                     })?;
 
-                let tr = engine.clone().start_transaction_static().await?;
+                let tr = engine.clone().begin_transaction_static().await?;
                 let query_plan = QueryPlan::from_type(ty_obj);
                 let mut row_streams = engine.query(tr.clone(), query_plan)?;
 


### PR DESCRIPTION
In SQL, the statement is `BEGIN TRANSACTION`, there is no need to introduce custom terminology.

This is a spin-off from #1618.