### PR TITLE
Return strings verbatim, without conversion to JSON (from #1618)

### DIFF
--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -259,7 +259,11 @@ async function callHandlerImpl(
     // this instead of materializing a full response. Probably
     // a bit faster but this is a lot simpler for now.
     if (res?.constructor.name != "Response") {
-        res = Chisel.responseFromJson(res);
+        if (typeof res === "string") {
+            res = new Response(res);
+        } else {
+            res = Chisel.responseFromJson(res);
+        }
     }
 
     for (const h of res.headers) {

--- a/cli/tests/integration_tests/framework.rs
+++ b/cli/tests/integration_tests/framework.rs
@@ -511,12 +511,12 @@ impl Chisel {
     pub async fn get_body(&self, url: &str) -> (u16, Bytes) {
         self.request_body(reqwest::Method::GET, url, "").await
     }
+    */
 
     /// Same as `request_text()`, but sends GET with no request body.
     pub async fn get_text(&self, url: &str) -> String {
         self.request_text(reqwest::Method::GET, url, "").await
     }
-    */
 
     /// Same as `request_text_with_headers()`, but sends GET with no request body.
     pub async fn get_text_with_headers(&self, url: &str, headers: HeaderMap) -> String {

--- a/cli/tests/integration_tests/rust_tests/find.rs
+++ b/cli/tests/integration_tests/rust_tests/find.rs
@@ -181,23 +181,23 @@ pub async fn find_one(c: TestContext) {
     for name in ["Glauber", "Jan", "Pekka"] {
         assert_eq!(
             c.chisel
-                .get_json(&format!("/dev/find_one?first_name={name}"))
+                .get_text(&format!("/dev/find_one?first_name={name}"))
                 .await,
-            json!(name)
+            name,
         );
         assert_eq!(
             c.chisel
-                .get_json(&format!(
+                .get_text(&format!(
                     "/dev/find_one?first_name={name}&use_predicate=true"
                 ))
                 .await,
-            json!(name)
+            name,
         );
         assert_eq!(
             c.chisel
-                .get_json(&format!("/dev/find_one?first_name={name}&use_expr=true"))
+                .get_text(&format!("/dev/find_one?first_name={name}&use_expr=true"))
                 .await,
-            json!(name)
+            name,
         );
     }
 }

--- a/cli/tests/integration_tests/rust_tests/token_auth.rs
+++ b/cli/tests/integration_tests/rust_tests/token_auth.rs
@@ -25,7 +25,7 @@ pub async fn test(c: TestContext) {
         c.chisel
             .get_text_with_headers("/dev/hello", header("header33", "s3cr3t"))
             .await,
-        "\"hello world\""
+        "hello world"
     );
 
     // Wrong header value.
@@ -125,10 +125,10 @@ pub async fn test(c: TestContext) {
         c.chisel
             .get_text_with_headers("/dev/hello", header("header33", "s3cr3t"))
             .await,
-        "\"hello world\""
+        "hello world"
     );
     assert_eq!(
         c.chisel.post_json_text("/dev/hello", json!(122333)).await,
-        "\"122333\""
+        "122333"
     );
 }


### PR DESCRIPTION
When the user returns a plain string from the request handler, it will be serialized as JSON. This is very confusing and also incorrect, because a valid JSON document must be an array or an object.

This is a spin-off from #1618.