### PR TITLE
Use module `proto` to hold protobuf definitions (from #1618)

### DIFF
--- a/cli/src/chisel.rs
+++ b/cli/src/chisel.rs
@@ -1,1 +1,0 @@
-tonic::include_proto!("chisel");

--- a/cli/src/cmd/apply.rs
+++ b/cli/src/cmd/apply.rs
@@ -3,9 +3,9 @@
 pub mod deno;
 pub mod node;
 
-use crate::chisel::chisel_rpc_client::ChiselRpcClient;
-use crate::chisel::{ChiselApplyRequest, IndexCandidate, PolicyUpdateRequest};
 use crate::project::{read_manifest, read_to_string, AutoIndex, Module, Optimize};
+use crate::proto::chisel_rpc_client::ChiselRpcClient;
+use crate::proto::{ChiselApplyRequest, IndexCandidate, PolicyUpdateRequest};
 use anyhow::{anyhow, Context, Result};
 use serde_json::Value;
 use std::collections::HashMap;

--- a/cli/src/cmd/apply/deno.rs
+++ b/cli/src/cmd/apply/deno.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
-use crate::chisel::IndexCandidate;
 use crate::cmd::apply::chiselc_output;
 use crate::cmd::apply::parse_indexes;
 use crate::cmd::apply::SourceMap;
+use crate::proto::IndexCandidate;
 use anyhow::{anyhow, Context, Result};
 use endpoint_tsc::compile_endpoints;
 use std::path::PathBuf;

--- a/cli/src/cmd/apply/node.rs
+++ b/cli/src/cmd/apply/node.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
-use crate::chisel::IndexCandidate;
 use crate::cmd::apply::chiselc_spawn;
 use crate::cmd::apply::parse_indexes;
 use crate::cmd::apply::{SourceMap, TypeChecking};
 use crate::project::read_to_string;
+use crate::proto::IndexCandidate;
 use anyhow::{anyhow, Context, Result};
 use std::env;
 use std::ffi::OsStr;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,12 +5,12 @@ use crate::cmd::dev::cmd_dev;
 use crate::project::{create_project, CreateProjectOptions};
 use crate::server::{start_server, wait, wait_with_cond};
 use anyhow::{anyhow, Result};
-use chisel::chisel_rpc_client::ChiselRpcClient;
-use chisel::{
+use futures::{pin_mut, Future, FutureExt};
+use proto::chisel_rpc_client::ChiselRpcClient;
+use proto::{
     type_msg::TypeEnum, ChiselDeleteRequest, DescribeRequest, PopulateRequest, RestartRequest,
     StatusRequest,
 };
-use futures::{pin_mut, Future, FutureExt};
 use std::env;
 use std::fs;
 use std::io::ErrorKind;
@@ -18,11 +18,14 @@ use std::path::Path;
 use structopt::StructOpt;
 use tokio::process::Child;
 
-mod chisel;
 mod cmd;
 mod project;
 mod server;
 mod ts;
+
+mod proto {
+    tonic::include_proto!("chisel");
+}
 
 fn parse_version(version: &str) -> anyhow::Result<String> {
     anyhow::ensure!(!version.is_empty(), "version name can't be empty");

--- a/cli/src/server.rs
+++ b/cli/src/server.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com>
 
-use crate::chisel::chisel_rpc_client::ChiselRpcClient;
-use crate::chisel::{StatusRequest, StatusResponse};
+use crate::proto::chisel_rpc_client::ChiselRpcClient;
+use crate::proto::{StatusRequest, StatusResponse};
 use anyhow::Result;
 use std::future::Future;
 use std::io::ErrorKind;

--- a/cli/src/ts.rs
+++ b/cli/src/ts.rs
@@ -1,4 +1,4 @@
-use crate::chisel::{type_msg::TypeEnum, AddTypeRequest, ContainerType, FieldDefinition, TypeMsg};
+use crate::proto::{type_msg::TypeEnum, AddTypeRequest, ContainerType, FieldDefinition, TypeMsg};
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use chisel_server::auth::is_auth_entity_name;
 use std::collections::BTreeSet;

--- a/server/src/internal.rs
+++ b/server/src/internal.rs
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com>
 
-use crate::chisel::{chisel_rpc_client::ChiselRpcClient, ChiselApplyRequest};
+use crate::proto::{chisel_rpc_client::ChiselRpcClient, ChiselApplyRequest};
 use anyhow::Result;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request, Response, Server};

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -31,6 +31,6 @@ pub mod server;
 pub(crate) mod types;
 pub(crate) mod vecmap;
 
-pub(crate) mod chisel {
+pub(crate) mod proto {
     tonic::include_proto!("chisel");
 }


### PR DESCRIPTION
Name `chisel` is meaningless.

This is a spin-off from #1618.