### PR TITLE
cli/dev: Track changes in event handlers

### DIFF
--- a/cli/src/cmd/dev.rs
+++ b/cli/src/cmd/dev.rs
@@ -64,6 +64,13 @@ pub(crate) async fn cmd_dev(
         let dir = cwd.join(dir);
         tracked.insert(dir);
     }
+
+    if let Some(events) = &manifest.events {
+        for dir in events {
+            let dir = cwd.join(dir);
+            tracked.insert(dir);
+        }
+    }
     apply_watcher.watch(&cwd, RecursiveMode::Recursive)?;
 
     loop {


### PR DESCRIPTION
Let's teach "chisel dev" about the event handler directory so that
changes are hot-reloaded.