### PR TITLE
Don't use unnecessary polymorphism (from #1618)

### DIFF
--- a/server/src/introspect.rs
+++ b/server/src/introspect.rs
@@ -83,8 +83,8 @@ async fn introspect(req: Request<hyper::Body>) -> Result<Response<Body>> {
         .unwrap())
 }
 
-pub fn add_introspection<P: AsRef<str>>(api: &ApiService, path: P) {
-    let introspect_route = format!("/{}", path.as_ref());
+pub fn add_introspection(api: &ApiService, path: &str) {
+    let introspect_route = format!("/{}", path);
     api.add_route(
         introspect_route,
         Arc::new(move |req| { introspect(req) }.boxed_local()),

--- a/server/src/policies.rs
+++ b/server/src/policies.rs
@@ -152,9 +152,9 @@ pub struct Policies {
 }
 
 impl Policies {
-    pub fn add_from_yaml<K: ToString, Y: AsRef<str>>(&mut self, version: K, yaml: Y) -> Result<()> {
+    pub fn add_from_yaml(&mut self, version: String, yaml: &str) -> Result<()> {
         let v = VersionPolicy::from_yaml(yaml)?;
-        self.versions.insert(version.to_string(), v);
+        self.versions.insert(version, v);
         Ok(())
     }
 
@@ -196,11 +196,11 @@ impl Policies {
 }
 
 impl VersionPolicy {
-    pub fn from_yaml<S: AsRef<str>>(config: S) -> Result<Self> {
+    pub fn from_yaml(config: &str) -> Result<Self> {
         let mut policies = Self::default();
         let mut labels = vec![];
 
-        let docs = YamlLoader::load_from_str(config.as_ref())?;
+        let docs = YamlLoader::load_from_str(config)?;
         for config in docs.iter() {
             for label in config["labels"].as_vec().get_or_insert(&[].into()).iter() {
                 let name = label["name"].as_str().ok_or_else(|| {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -180,7 +180,7 @@ pub async fn add_endpoints(
                     deno::run_js_event(path.clone(), key, value).boxed_local()
                 }
             });
-            api_service.add_event_handler(path.into(), func);
+            api_service.add_event_handler(path, func);
         } else {
             println!("warning: unrecognized source: {}", path);
         }


### PR DESCRIPTION
`&str` is isomorphic to `T: AsRef<str>`, but does not generate redundant monomorphisations of the same function.

This is a spin-off from #1618.