### PR TITLE
Reduce polymorphism in types/mod.rs (from #1618)

### DIFF
--- a/server/src/apply.rs
+++ b/server/src/apply.rs
@@ -127,7 +127,7 @@ or
             };
 
             fields.push(Field::new(
-                NewField::new(&field.name, field_ty, &api_version)?,
+                &NewField::new(&field.name, field_ty, &api_version)?,
                 field.labels,
                 field.default_value,
                 field.is_optional,
@@ -137,7 +137,7 @@ or
         let ty_indexes = indexes.get(&name).cloned().unwrap_or_default();
 
         let ty = Arc::new(ObjectType::new(
-            NewObject::new(&name, &api_version),
+            &NewObject::new(&name, &api_version),
             fields,
             ty_indexes,
         )?);

--- a/server/src/datastore/meta/mod.rs
+++ b/server/src/datastore/meta/mod.rs
@@ -516,7 +516,7 @@ impl MetaService {
                 Ok(fields) => {
                     let indexes = self.load_type_indexes(type_id, backing_table).await?;
 
-                    let ty = ObjectType::new(desc, fields, indexes)?;
+                    let ty = ObjectType::new(&desc, fields, indexes)?;
                     ts.add_custom_type(Entity::Custom(Arc::new(ty)))?;
                 }
                 Err(_) => {
@@ -541,7 +541,7 @@ impl MetaService {
             let fields = self.load_type_fields(&ts, type_id).await?;
             let indexes = self.load_type_indexes(type_id, backing_table).await?;
 
-            let ty = ObjectType::new(desc, fields, indexes)?;
+            let ty = ObjectType::new(&desc, fields, indexes)?;
             ts.add_custom_type(Entity::Custom(Arc::new(ty)))?;
         }
 
@@ -598,7 +598,7 @@ impl MetaService {
                 .map(|r| r.get("label_name"))
                 .collect::<Vec<String>>();
 
-            fields.push(Field::new(desc, labels, field_def, is_optional, is_unique));
+            fields.push(Field::new(&desc, labels, field_def, is_optional, is_unique));
         }
         Ok(fields)
     }

--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -887,12 +887,12 @@ pub mod tests {
 
     pub fn make_entity(name: &str, fields: Vec<Field>) -> Entity {
         let desc = types::NewObject::new(name, VERSION);
-        Entity::Custom(Arc::new(ObjectType::new(desc, fields, vec![]).unwrap()))
+        Entity::Custom(Arc::new(ObjectType::new(&desc, fields, vec![]).unwrap()))
     }
 
     pub fn make_field(name: &str, ty: Type) -> Field {
         let desc = types::NewField::new(name, ty, VERSION).unwrap();
-        Field::new(desc, vec![], None, false, false)
+        Field::new(&desc, vec![], None, false, false)
     }
 
     async fn init_query_engine(db_file: &NamedTempFile) -> QueryEngine {

--- a/server/src/types/builtin.rs
+++ b/server/src/types/builtin.rs
@@ -95,7 +95,7 @@ fn add_auth_entity(
             name: type_name,
             backing_table,
         };
-        Entity::Auth(Arc::new(ObjectType::new(desc, fields, vec![]).unwrap())).into()
+        Entity::Auth(Arc::new(ObjectType::new(&desc, fields, vec![]).unwrap())).into()
     });
 }
 

--- a/server/src/types/mod.rs
+++ b/server/src/types/mod.rs
@@ -243,11 +243,8 @@ impl From<Type> for TypeId {
     }
 }
 
-impl<T> From<T> for TypeId
-where
-    T: FieldDescriptor,
-{
-    fn from(other: T) -> Self {
+impl From<&dyn FieldDescriptor> for TypeId {
+    fn from(other: &dyn FieldDescriptor) -> Self {
         other.ty().into()
     }
 }
@@ -271,8 +268,8 @@ pub struct ObjectType {
 }
 
 impl ObjectType {
-    pub fn new<D: ObjectDescriptor>(
-        desc: D,
+    pub fn new(
+        desc: &dyn ObjectDescriptor,
         fields: Vec<Field>,
         indexes: Vec<DbIndex>,
     ) -> anyhow::Result<Self> {
@@ -548,8 +545,8 @@ pub struct Field {
 }
 
 impl Field {
-    pub fn new<D: FieldDescriptor>(
-        desc: D,
+    pub fn new(
+        desc: &dyn FieldDescriptor,
         labels: Vec<String>,
         default: Option<String>,
         is_optional: bool,


### PR DESCRIPTION
Replacing compile-time polymorphism with `&dyn` reduces the amount of generated code.

This is a spin-off from #1618.