### PR TITLE
Don't print "End point defined" from `chisel apply` (from #1618)

### DIFF
--- a/cli/src/cmd/apply.rs
+++ b/cli/src/cmd/apply.rs
@@ -178,21 +178,11 @@ pub(crate) async fn apply(
 
     let msg = execute!(client.apply(tonic::Request::new(req)).await);
 
-    for ty in msg.types {
-        println!("Model defined: {}", ty);
-    }
-
-    for end in msg.endpoints {
-        println!("End point defined: {}", end);
-    }
-
-    for end in msg.event_handlers {
-        println!("Event handler defined: {}", end);
-    }
-
-    for lbl in msg.labels {
-        println!("Policy defined for label {}", lbl);
-    }
+    println!("Code was applied to the ChiselStrike server. It contained:");
+    println!("  - models: {}", msg.types.len());
+    println!("  - endpoints: {}", msg.endpoints.len());
+    println!("  - event handlers: {}", msg.event_handlers.len());
+    println!("  - labels: {}", msg.labels.len());
 
     Ok(())
 }

--- a/cli/tests/integration_tests/lit_tests/access-origin.deno
+++ b/cli/tests/integration_tests/lit_tests/access-origin.deno
@@ -16,7 +16,7 @@ EOF
 cd "$TEMPDIR"
 $CHISEL apply
 
-# CHECK: End point defined: /dev/foo
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/foo
 

--- a/cli/tests/integration_tests/lit_tests/aggregations.deno
+++ b/cli/tests/integration_tests/lit_tests/aggregations.deno
@@ -86,8 +86,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/compute_aggregations
+# CHECK: Code was applied
 
 $CURL -X POST -o - $CHISELD_HOST/dev/store
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/api-policy.deno
+++ b/cli/tests/integration_tests/lit_tests/api-policy.deno
@@ -27,10 +27,7 @@ EOF
 cd "$TEMPDIR"
 $CHISEL apply
 
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/query
-# CHECK: End point defined: /dev/store
-# CHECK: Policy defined for label pii
+# CHECK: Code was applied
 
 $CURL --data '{
     "first_name":"Glauber",

--- a/cli/tests/integration_tests/lit_tests/auth-header.node
+++ b/cli/tests/integration_tests/lit_tests/auth-header.node
@@ -4,7 +4,7 @@
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: End point defined: /dev/hello
+# CHECK: Code was applied
 
 $CURL $CHISELD_HOST/__chiselstrike/auth/users
 # CHECK: HTTP/1.1 403 Forbidden

--- a/cli/tests/integration_tests/lit_tests/body-resource.deno
+++ b/cli/tests/integration_tests/lit_tests/body-resource.deno
@@ -44,8 +44,7 @@ EOF
 cd "$TEMPDIR"
 $CHISEL apply
 
-# CHECK: End point defined: /dev/test1
-# CHECK: End point defined: /dev/test2
+# CHECK: Code was applied
 
 $CURL --data foobar -o - $CHISELD_HOST/dev/test1
 

--- a/cli/tests/integration_tests/lit_tests/build-entity.deno
+++ b/cli/tests/integration_tests/lit_tests/build-entity.deno
@@ -26,8 +26,7 @@ export default async function (req: Request): Promise<Response> {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: User
-# CHECK: End point defined: /dev/user
+# CHECK: Code was applied
 
 $CURL -d '{"username": "penberg"}' $CHISELD_HOST/dev/user
 # CHECK: penbergPekka

--- a/cli/tests/integration_tests/lit_tests/build-without-default.deno
+++ b/cli/tests/integration_tests/lit_tests/build-without-default.deno
@@ -25,7 +25,7 @@ cd "$TEMPDIR"
 # FIXME, We should detect this error at compile time.
 $CHISEL apply
 
-# CHECK: End point defined: /dev/build
+# CHECK: Code was applied
 
 $CURL -X POST $CHISELD_HOST/dev/build
 

--- a/cli/tests/integration_tests/lit_tests/cli/chisel-apply-ignores.deno
+++ b/cli/tests/integration_tests/lit_tests/cli/chisel-apply-ignores.deno
@@ -21,4 +21,4 @@ cp "$TEMPDIR/endpoints/hello.ts" "$TEMPDIR/endpoints/#hello.ts#"
 
 $CHISEL apply
 
-# CHECK: End point defined: /dev/hello
+# CHECK: Code was applied

--- a/cli/tests/integration_tests/lit_tests/cli/describe.deno
+++ b/cli/tests/integration_tests/lit_tests/cli/describe.deno
@@ -26,9 +26,7 @@ EOF
 
 $CHISEL apply
 
-# CHECK: Model defined: Foo
-# CHECK: Model defined: Bar
-# CHECK: End point defined: /dev/hello
+# CHECK: Code was applied
 
 $CHISEL describe
 

--- a/cli/tests/integration_tests/lit_tests/cli/reapply.deno
+++ b/cli/tests/integration_tests/lit_tests/cli/reapply.deno
@@ -11,11 +11,11 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Model defined: Foo
+# CHECK: Code was applied
 
 ## Identical definition is OK.
 $CHISEL apply
-# CHECK: Model defined: Foo
+# CHECK: Code was applied
 
 ## Changing labels is OK.
 cat << EOF > "$TEMPDIR/models/foo.ts"
@@ -25,7 +25,7 @@ export class Foo extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Model defined: Foo
+# CHECK: Code was applied
 
 # Adding default values is OK.
 cat << EOF > "$TEMPDIR/models/foo.ts"
@@ -35,7 +35,7 @@ export class Foo extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Model defined: Foo
+# CHECK: Code was applied
 
 ## Two compatible definitions in different files are rejected.
 cat << EOF > "$TEMPDIR/models/fooNoteADifferentFilenameHere.ts"
@@ -57,7 +57,7 @@ export class Foo extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Model defined: Foo
+# CHECK: Code was applied
 
 ## Go back to the basics, and add some data
 cat << EOF > "$TEMPDIR/models/foo.ts"
@@ -77,7 +77,7 @@ export default async function seed() {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: Foo
+# CHECK: Code was applied
 
 $CURL -X POST $CHISELD_HOST/dev/seed
 rm "$TEMPDIR/endpoints/seed.ts"
@@ -111,7 +111,7 @@ export class Foo extends ChiselEntity {
 }
 EOF
 $CHISEL apply 2>&1 || echo # (swallow the apply abort)
-# CHECK: Model defined: Foo
+# CHECK: Code was applied
 
 ## Removing fields is OK if they previously had a default
 cat << EOF > "$TEMPDIR/models/foo.ts"
@@ -120,7 +120,7 @@ export class Foo extends ChiselEntity {
 }
 EOF
 $CHISEL apply 2>&1 || echo # (swallow the apply abort)
-# CHECK: Model defined: Foo
+# CHECK: Code was applied
 
 ## clean up data.
 rm "$TEMPDIR/models/foo.ts"

--- a/cli/tests/integration_tests/lit_tests/concurrency.deno
+++ b/cli/tests/integration_tests/lit_tests/concurrency.deno
@@ -17,9 +17,7 @@ EOF
 cd "$TEMPDIR"
 
 $CHISEL apply
-
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/store
+# CHECK: Code was applied
 
 NUM=100
 for i in $(seq 1 $NUM); do

--- a/cli/tests/integration_tests/lit_tests/create.deno
+++ b/cli/tests/integration_tests/lit_tests/create.deno
@@ -24,8 +24,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/new
+# CHECK: Code was applied
 
 $CURL -X POST $CHISELD_HOST/dev/new
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/crud-custom.node
+++ b/cli/tests/integration_tests/lit_tests/crud-custom.node
@@ -87,8 +87,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/persons
+# CHECK: Code was applied
 
 $CURL -d '{"first_name":"Alice","last_name":"Anderson","age":30,"human":true,"height":10}' $CHISELD_HOST/dev/persons
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/crud.node
+++ b/cli/tests/integration_tests/lit_tests/crud.node
@@ -11,8 +11,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/persons
+# CHECK: Code was applied
 
 $CURL -d '{"first_name":"Alice","last_name":"Anderson","age":30,"human":true,"height":10}' $CHISELD_HOST/dev/persons
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/csv.deno
+++ b/cli/tests/integration_tests/lit_tests/csv.deno
@@ -7,10 +7,7 @@ cp examples/csv.ts examples/find.ts "$TEMPDIR/endpoints"
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/csv
-# CHECK: End point defined: /dev/find
+# CHECK: Code was applied
 
 $CURL --data '
 adam,smith

--- a/cli/tests/integration_tests/lit_tests/db-api.deno
+++ b/cli/tests/integration_tests/lit_tests/db-api.deno
@@ -48,10 +48,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/query
-# CHECK: End point defined: /dev/store
+# CHECK: Code was applied
 
 $CURL --data '{
     "first_name":"Glauber",

--- a/cli/tests/integration_tests/lit_tests/defaults.deno
+++ b/cli/tests/integration_tests/lit_tests/defaults.deno
@@ -8,8 +8,7 @@ cat << EOF > "$TEMPDIR/models/types.ts"
 export class Unary extends ChiselEntity { a: number = +1; b: number = 0; c: number = -1 ;}
 EOF
 $CHISEL apply
-
-# CHECK: Model defined: Unary
+# CHECK: Code was applied
 
 $CHISEL restart
 $CHISEL describe
@@ -107,8 +106,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: End point defined: /dev/crud_foo
-# CHECK: End point defined: /dev/readold
+# CHECK: Code was applied
 
 
 $CURL -o - $CHISELD_HOST/dev/readold
@@ -171,7 +169,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: End point defined: /dev/find_many
+# CHECK: Code was applied
 
 $CURL -o - "$CHISELD_HOST/dev/find_many?key=a&value=xaxa" | count_results
 # CHECK: Number of results: 0

--- a/cli/tests/integration_tests/lit_tests/delete-type.deno
+++ b/cli/tests/integration_tests/lit_tests/delete-type.deno
@@ -19,8 +19,7 @@ export default User.crud();
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: User
-# CHECK: End point defined: /dev/user
+# CHECK: Code was applied
 
 $CURL -X POST -d '{"username": "alice", "email": "alice@example.org"}' $CHISELD_HOST/dev/user
 # CHECK: "alice"

--- a/cli/tests/integration_tests/lit_tests/delete.deno
+++ b/cli/tests/integration_tests/lit_tests/delete.deno
@@ -36,8 +36,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: User
-# CHECK: End point defined: /dev/user
+# CHECK: Code was applied
 
 $CURL -X POST -d '{"username": "alice", "email": "alice@example.org"}' $CHISELD_HOST/dev/user
 # CHECK: "alice"

--- a/cli/tests/integration_tests/lit_tests/echo-endpoint.deno
+++ b/cli/tests/integration_tests/lit_tests/echo-endpoint.deno
@@ -29,8 +29,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: End point defined: /dev/echo
+# CHECK: Code was applied
 
 $CURL --data foobar -o - $CHISELD_HOST/dev/echo
 

--- a/cli/tests/integration_tests/lit_tests/endpoint-error.deno
+++ b/cli/tests/integration_tests/lit_tests/endpoint-error.deno
@@ -30,8 +30,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-
-# CHECK: End point defined: /dev/test
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/test
 

--- a/cli/tests/integration_tests/lit_tests/entity-findone-filter.deno
+++ b/cli/tests/integration_tests/lit_tests/entity-findone-filter.deno
@@ -26,8 +26,7 @@ export default async function (req: Request): Promise<Response> {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: User
-# CHECK: End point defined: /dev/entity-methods
+# CHECK: Code was applied
 
 $CURL -X POST $CHISELD_HOST/dev/entity-methods
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/entity-methods.deno
+++ b/cli/tests/integration_tests/lit_tests/entity-methods.deno
@@ -28,8 +28,7 @@ export default async function (req: Request): Promise<Response> {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: User
-# CHECK: End point defined: /dev/entity-methods
+# CHECK: Code was applied
 
 $CURL -X POST $CHISELD_HOST/dev/entity-methods
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/escape-string.deno
+++ b/cli/tests/integration_tests/lit_tests/escape-string.deno
@@ -20,10 +20,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/query
-# CHECK: End point defined: /dev/store
+# CHECK: Code was applied
 
 $CURL --data '{
     "first_name":"Bob'\''",

--- a/cli/tests/integration_tests/lit_tests/filter-with-predicate.deno
+++ b/cli/tests/integration_tests/lit_tests/filter-with-predicate.deno
@@ -97,9 +97,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/findall
+# CHECK: Code was applied
 
 $CHISEL apply
 $CURL -X POST -o - $CHISELD_HOST/dev/store

--- a/cli/tests/integration_tests/lit_tests/filter.deno
+++ b/cli/tests/integration_tests/lit_tests/filter.deno
@@ -7,9 +7,7 @@ cp examples/store.ts "$TEMPDIR/endpoints"
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/store
+# CHECK: Code was applied
 
 $CURL --data '{
     "first_name":"Glauber",
@@ -111,8 +109,7 @@ export default async (req: Request) => {
 }
 EOF
 $CHISEL apply
-# CHECK: Model defined: Post
-# CHECK: End point defined: /dev/take_filter
+# CHECK: Code was applied
 
 $CURL -X POST -o - $CHISELD_HOST/dev/take_filter
 # CHECK: "simple_take": [
@@ -170,9 +167,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: Model defined: TestingEntity
-# CHECK: End point defined: /dev/findall
+# CHECK: Code was applied
 
 $CURL -X POST -o - $CHISELD_HOST/dev/store_testing_entity
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/foreach.deno
+++ b/cli/tests/integration_tests/lit_tests/foreach.deno
@@ -36,9 +36,7 @@ EOF
 
 
 $CHISEL apply
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/foreach
-# CHECK: End point defined: /dev/store
+# CHECK: Code was applied
 
 $CURL -X POST $CHISELD_HOST/dev/store
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/headers.deno
+++ b/cli/tests/integration_tests/lit_tests/headers.deno
@@ -10,7 +10,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: End point defined: /dev/foo
+# CHECK: Code was applied
 
 num=$($CURL $CHISELD_HOST/dev/foo | grep ChiselUID | wc -l)
 echo Found $num copies

--- a/cli/tests/integration_tests/lit_tests/id.deno
+++ b/cli/tests/integration_tests/lit_tests/id.deno
@@ -78,14 +78,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/bad_id
-# CHECK: End point defined: /dev/count_glaubers
-# CHECK: End point defined: /dev/find_by_id
-# CHECK: End point defined: /dev/store_no_id
-# CHECK: End point defined: /dev/store_with_id
-# CHECK: End point defined: /dev/update_by_id
+# CHECK: Code was applied
 
 $CURL -X POST $CHISELD_HOST/dev/bad_id  2>&1 || echo
 # CHECK: invalid ID 'badid'

--- a/cli/tests/integration_tests/lit_tests/ignore-policy-field.deno
+++ b/cli/tests/integration_tests/lit_tests/ignore-policy-field.deno
@@ -26,11 +26,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/query
-# CHECK: End point defined: /dev/store
-# CHECK: Policy defined for label pii
+# CHECK: Code was applied
 
 $CURL --data '{
     "first_name":"Glauber",

--- a/cli/tests/integration_tests/lit_tests/introspect.node
+++ b/cli/tests/integration_tests/lit_tests/introspect.node
@@ -17,7 +17,7 @@ cd "$TEMPDIR"
 mv package.json pkg.json
 
 $CHISEL apply
-# CHECK: End point defined: /dev/simple
+# CHECK: Code was applied
 
 $CURL $CHISELD_HOST/__chiselstrike/
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/join.lit.disabled
+++ b/cli/tests/integration_tests/lit_tests/join.lit.disabled
@@ -47,13 +47,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: Model defined: Nickname
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/query
-# CHECK: End point defined: /dev/store
-# CHECK: End point defined: /dev/store_nick
-# CHECK: Policy defined for label pii
+# CHECK: Code was applied
 
 $CURL --data '{
     "first_name":"Glauber",

--- a/cli/tests/integration_tests/lit_tests/map.deno
+++ b/cli/tests/integration_tests/lit_tests/map.deno
@@ -81,8 +81,7 @@ EOF
 
 
 $CHISEL apply
-
-# CHECK: Model defined: Person
+# CHECK: Code was applied
 
 $CURL -X POST $CHISELD_HOST/dev/store
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/missing-await.deno
+++ b/cli/tests/integration_tests/lit_tests/missing-await.deno
@@ -21,9 +21,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: Model defined: User
-# CHECK: End point defined: /dev/find
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/find
 

--- a/cli/tests/integration_tests/lit_tests/multiple-endpoints.deno
+++ b/cli/tests/integration_tests/lit_tests/multiple-endpoints.deno
@@ -19,9 +19,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: End point defined: /dev/bar
-# CHECK: End point defined: /dev/foo
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/foo
 
@@ -43,9 +41,7 @@ EOF
 
 npm i
 $CHISEL apply
-
-# CHECK: End point defined: /dev/bar
-# CHECK: End point defined: /dev/foo
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/foo
 

--- a/cli/tests/integration_tests/lit_tests/optional-field.deno
+++ b/cli/tests/integration_tests/lit_tests/optional-field.deno
@@ -39,9 +39,7 @@ export default async function (_: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: Bar
-# CHECK: Model defined: Foo
-# CHECK: End point defined: /dev/save
+# CHECK: Code was applied
 
 ## Accept payload without optional values:
 $CURL -d '{}' $CHISELD_HOST/dev/save
@@ -86,16 +84,11 @@ export class Foo extends ChiselEntity {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: Bar
-# CHECK: Model defined: Foo
-# CHECK: End point defined: /dev/save
+# CHECK: Code was applied
 
 ## Correctly populate from optional fields
 $CHISEL apply --version=v2
-# CHECK: Model defined: Bar
-# CHECK: Model defined: Foo
-# CHECK: End point defined: /v2/save
-# CHECK: End point defined: /v2/sum
+# CHECK: Code was applied
 $CHISEL populate --version=v2 --from=dev
 $CURL $CHISELD_HOST/v2/sum
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/out-of-order-models.deno
+++ b/cli/tests/integration_tests/lit_tests/out-of-order-models.deno
@@ -34,7 +34,4 @@ EOF
 cd "$TEMPDIR"
 
 $CHISEL apply
-
-# CHECK: Model defined: A
-# CHECK: Model defined: B
-# CHECK: Model defined: C
+# CHECK: Code was applied

--- a/cli/tests/integration_tests/lit_tests/permissions.deno
+++ b/cli/tests/integration_tests/lit_tests/permissions.deno
@@ -16,8 +16,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: End point defined: /dev/mischief
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/mischief
 

--- a/cli/tests/integration_tests/lit_tests/pol-loggedin.deno
+++ b/cli/tests/integration_tests/lit_tests/pol-loggedin.deno
@@ -105,8 +105,7 @@ export default async function (req: Request) {
 EOF
 
 $CHISEL apply --allow-type-deletion
-# CHECK: Model defined: Post
-# CHECK: End point defined: /dev/po
+# CHECK: Code was applied
 
 $CURL -H ChiselUID\:$id_al -d '{"text": "first post by al"}' $CHISELD_HOST/dev/po
 # CHECK: HTTP/1.1 200 OK
@@ -154,7 +153,7 @@ EOF
 
 rm "$TEMPDIR/policies/pol.yaml"
 $CHISEL apply
-# CHECK: End point defined: /dev/blogs
+# CHECK: Code was applied
 
 $CURL -d '{"text": "first post by al"}' $CHISELD_HOST/dev/po
 # CHECK:  HTTP/1.1 401 Unauthorized
@@ -194,7 +193,7 @@ labels:
     transform: match_login
 EOF
 $CHISEL apply
-# CHECK:Policy defined for label protect
+# CHECK: Code was applied
 
 count=$($CURL -H ChiselUID\:$id_al $CHISELD_HOST/dev/blogs | grep 'blog post by' | wc -l | tr -d '[:space:]')
 echo "result count:$count"

--- a/cli/tests/integration_tests/lit_tests/populate.deno
+++ b/cli/tests/integration_tests/lit_tests/populate.deno
@@ -19,9 +19,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/count
-# CHECK: End point defined: /dev/ins
+# CHECK: Code was applied
 
 $CURL --data '{
     "first_name":"Glauber",
@@ -38,9 +36,7 @@ $CURL $CHISELD_HOST/dev/count
 # CHECK: 1
 
 $CHISEL apply --version staging
-# CHECK: Model defined: Person
-# CHECK: End point defined: /staging/count
-# CHECK: End point defined: /staging/ins
+# CHECK: Code was applied
 
 $CURL $CHISELD_HOST/staging/count
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/prefix.deno
+++ b/cli/tests/integration_tests/lit_tests/prefix.deno
@@ -17,9 +17,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: End point defined: /dev/foo
-# CHECK: End point defined: /dev/foo/bar
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/foo
 

--- a/cli/tests/integration_tests/lit_tests/reject-without-handler.deno
+++ b/cli/tests/integration_tests/lit_tests/reject-without-handler.deno
@@ -15,8 +15,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: End point defined: /dev/err
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/err
 

--- a/cli/tests/integration_tests/lit_tests/remove-endpoints.deno
+++ b/cli/tests/integration_tests/lit_tests/remove-endpoints.deno
@@ -24,9 +24,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: End point defined: /dev/end
-# CHECK: End point defined: /dev/endpo
-# CHECK: End point defined: /dev/endpoint
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/end
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/restart-js.deno
+++ b/cli/tests/integration_tests/lit_tests/restart-js.deno
@@ -18,8 +18,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: End point defined: /dev/test1
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/test1
 # CHECK: HTTP/1.1 200 OK
@@ -37,8 +36,7 @@ export default async function chisel(req) {
 }
 EOF
 $CHISEL apply
-
-# CHECK: End point defined: /dev/test2
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/test2
 

--- a/cli/tests/integration_tests/lit_tests/savemany.deno
+++ b/cli/tests/integration_tests/lit_tests/savemany.deno
@@ -30,8 +30,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/savemany
+# CHECK: Code was applied
 
 $CURL -X POST $CHISELD_HOST/dev/savemany
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/savewrong.deno
+++ b/cli/tests/integration_tests/lit_tests/savewrong.deno
@@ -36,8 +36,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-
-# CHECK: End point defined: /dev/store
+# CHECK: Code was applied
 
 $CURL $CHISELD_HOST/dev/store
 
@@ -53,7 +52,7 @@ import { AuthUser } from '@chiselstrike/api';
 export default AuthUser.crud();
 EOF
 $CHISEL apply
-# CHECK: End point defined: /dev/store
+# CHECK: Code was applied
 
 $CURL -d '{"name":"Foo", "email":"foo@t.co"}' $CHISELD_HOST/dev/store
 # CHECK: Error: Cannot save into type AuthUser.
@@ -75,8 +74,7 @@ export default Post.crud();
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: Post
-# CHECK: End point defined: /dev/store
+# CHECK: Code was applied
 
 $CURL -d '{"author":{"email": "foo@t.co"}}' $CHISELD_HOST/dev/store
 # CHECK: Error: Cannot save into type AuthUser.

--- a/cli/tests/integration_tests/lit_tests/select-order-with-pol.deno
+++ b/cli/tests/integration_tests/lit_tests/select-order-with-pol.deno
@@ -30,10 +30,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/query
-# CHECK: End point defined: /dev/store
+# CHECK: Code was applied
 
 $CURL --data '{
     "first_name":"Glauber",

--- a/cli/tests/integration_tests/lit_tests/select-order.deno
+++ b/cli/tests/integration_tests/lit_tests/select-order.deno
@@ -24,10 +24,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/query
-# CHECK: End point defined: /dev/store
+# CHECK: Code was applied
 
 $CURL --data '{
     "first_name":"Glauber",

--- a/cli/tests/integration_tests/lit_tests/simple-module.node
+++ b/cli/tests/integration_tests/lit_tests/simple-module.node
@@ -16,8 +16,7 @@ EOF
 cd "$TEMPDIR"
 npm i handlebars
 $CHISEL apply
-
-# CHECK: End point defined: /dev/pad
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/pad
 

--- a/cli/tests/integration_tests/lit_tests/sort.deno
+++ b/cli/tests/integration_tests/lit_tests/sort.deno
@@ -56,9 +56,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/get_sorted_by
-# CHECK: End point defined: /dev/store
+# CHECK: Code was applied
 
 $CURL -X POST -o - $CHISELD_HOST/dev/store
 # CHECK: Ok
@@ -92,7 +90,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: End point defined: /dev/get_sorted
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/get_sorted
 # CHECK: [Glauber, Jan, Pekka]
@@ -117,7 +115,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: End point defined: /dev/get_sorted
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/get_sorted
 # CHECK: [Pekka]
@@ -140,7 +138,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: End point defined: /dev/get_sorted
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/get_sorted
 # CHECK: [Glauber, Pekka]
@@ -161,7 +159,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: End point defined: /dev/get_sorted
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/get_sorted
 # CHECK: Error: entity 'Person' has no field named 'invalid_field'
@@ -187,7 +185,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: End point defined: /dev/get_sorted
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/get_sorted
 # CHECK: [Glauber, Jan, Pekka]

--- a/cli/tests/integration_tests/lit_tests/store-nested-type.deno
+++ b/cli/tests/integration_tests/lit_tests/store-nested-type.deno
@@ -81,12 +81,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-
-# CHECK: Model defined: Person
-# CHECK: Model defined: Company
-# CHECK: End point defined: /dev/query_companies
-# CHECK: End point defined: /dev/query_people
-# CHECK: End point defined: /dev/store_adalbrecht
+# CHECK: Code was applied
 
 $CURL -X POST $CHISELD_HOST/dev/store_adalbrecht
 # CHECK: Successfully stored data

--- a/cli/tests/integration_tests/lit_tests/take-skip.deno
+++ b/cli/tests/integration_tests/lit_tests/take-skip.deno
@@ -112,15 +112,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/findall
-# CHECK: End point defined: /dev/findfilter
-# CHECK: End point defined: /dev/findtake
-# CHECK: End point defined: /dev/store
-# CHECK: End point defined: /dev/takecopies
-# CHECK: End point defined: /dev/taketwice
-# CHECK: End point defined: /dev/taketwicereverse
+# CHECK: Code was applied
 
 $CURL -X POST $CHISELD_HOST/dev/store
 # CHECK: Ok
@@ -249,13 +241,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/filter_skip
-# CHECK: End point defined: /dev/predicate_filter_skip
-# CHECK: End point defined: /dev/skip1
-# CHECK: End point defined: /dev/sort_skip_sort
-# CHECK: End point defined: /dev/two_skips
+# CHECK: Code was applied
 
 $CURL $CHISELD_HOST/dev/skip1
 # CHECK: [Jan, Pekka]

--- a/cli/tests/integration_tests/lit_tests/toarray.deno
+++ b/cli/tests/integration_tests/lit_tests/toarray.deno
@@ -34,9 +34,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/store
-# CHECK: End point defined: /dev/toarray
+# CHECK: Code was applied
 
 $CURL -X POST $CHISELD_HOST/dev/store
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/type-evolve.deno
+++ b/cli/tests/integration_tests/lit_tests/type-evolve.deno
@@ -11,7 +11,7 @@ export class Evolving extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Model defined: Evolving
+# CHECK: Code was applied
 
 cat << EOF > "$TEMPDIR/models/types.ts"
 import { ChiselEntity } from "@chiselstrike/api";
@@ -22,7 +22,7 @@ export class Evolving extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Model defined: Evolving
+# CHECK: Code was applied
 
 cat << EOF > "$TEMPDIR/endpoints/store.js"
 import { Evolving } from "../models/types.ts";
@@ -51,9 +51,7 @@ export default async function chisel(req) {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: Evolving
-# CHECK: End point defined: /dev/find
-# CHECK: End point defined: /dev/store
+# CHECK: Code was applied
 
 $CURL -X POST $CHISELD_HOST/dev/store
 # CHECK: HTTP/1.1 200 OK
@@ -72,7 +70,7 @@ export class Evolving extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Model defined: Evolving
+# CHECK: Code was applied
 
 $CURL $CHISELD_HOST/dev/find
 # CHECK: HTTP/1.1 200 OK
@@ -87,7 +85,7 @@ export class Evolving extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Model defined: Evolving
+# CHECK: Code was applied
 
 $CURL $CHISELD_HOST/dev/find
 # CHECK: HTTP/1.1 200 OK
@@ -102,7 +100,7 @@ export class Evolving extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Model defined: Evolving
+# CHECK: Code was applied
 
 $CURL $CHISELD_HOST/dev/find
 # CHECK: HTTP/1.1 200 OK
@@ -118,7 +116,7 @@ export class Evolving extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Model defined: Evolving
+# CHECK: Code was applied
 
 cat << EOF > "$TEMPDIR/models/types.ts"
 import { ChiselEntity } from "@chiselstrike/api";
@@ -129,7 +127,7 @@ export class Evolving extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Model defined: Evolving
+# CHECK: Code was applied
 
 $CURL $CHISELD_HOST/dev/find
 # CHECK: HTTP/1.1 200 OK
@@ -152,7 +150,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: End point defined: /dev/test_indexes
+# CHECK: Code was applied
 
 
 cat << EOF > "$TEMPDIR/models/types.ts"
@@ -166,7 +164,7 @@ EOF
 rm $TEMPDIR/endpoints/test_indexes.ts
 
 $CHISEL apply
-# CHECK: Model defined: Evolving
+# CHECK: Code was applied
 
 ### get / set helpers for the tests below
 cat << EOF > "$TEMPDIR/endpoints/get.ts"
@@ -196,7 +194,7 @@ export class Defaults extends ChiselEntity {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: Defaults
+# CHECK: Code was applied
 
 $CURL -d '{}' $CHISELD_HOST/dev/set
 # CHECK: HTTP/1.1 200 OK
@@ -239,8 +237,7 @@ export class Defaults extends ChiselEntity {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: Aux
-# CHECK: Model defined: Defaults
+# CHECK: Code was applied
 
 $CURL -d '{}' $CHISELD_HOST/dev/set
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/types.deno
+++ b/cli/tests/integration_tests/lit_tests/types.deno
@@ -9,9 +9,7 @@ export class Foo extends ChiselEntity { a?: string; }
 export class Bar extends ChiselEntity { a: string = "default"; }
 EOF
 $CHISEL apply
-
-# CHECK: Model defined: Foo
-# CHECK: Model defined: Bar
+# CHECK: Code was applied
 
 $CHISEL restart
 $CHISEL describe

--- a/cli/tests/integration_tests/lit_tests/unique.deno
+++ b/cli/tests/integration_tests/lit_tests/unique.deno
@@ -78,7 +78,7 @@ export class BlogPost extends ChiselEntity {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: BlogPost
+# CHECK: Code was applied
 
 $CHISEL restart
 describe_output=$($CHISEL describe)

--- a/cli/tests/integration_tests/lit_tests/upsert.deno
+++ b/cli/tests/integration_tests/lit_tests/upsert.deno
@@ -33,8 +33,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Model defined: Person
-# CHECK: End point defined: /dev/upsert
+# CHECK: Code was applied
 
 $CURL -X POST $CHISELD_HOST/dev/upsert
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/url-query.deno
+++ b/cli/tests/integration_tests/lit_tests/url-query.deno
@@ -16,8 +16,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: End point defined: /dev/title
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/title?name=glauber
 

--- a/cli/tests/integration_tests/lit_tests/use-module.deno
+++ b/cli/tests/integration_tests/lit_tests/use-module.deno
@@ -12,8 +12,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: End point defined: /dev/pad
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/pad
 

--- a/cli/tests/integration_tests/lit_tests/use-ts-moduled.deno
+++ b/cli/tests/integration_tests/lit_tests/use-ts-moduled.deno
@@ -12,8 +12,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: End point defined: /dev/pad
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/pad
 

--- a/cli/tests/integration_tests/lit_tests/versions.deno
+++ b/cli/tests/integration_tests/lit_tests/versions.deno
@@ -28,18 +28,10 @@ $CHISEL apply --version string-# 2>&1 || echo
 # CHECK: Error
 
 $CHISEL apply --version v0
-# CHECK: Model defined: Person
-# CHECK: Model defined: Position
-# CHECK: End point defined: /v0/csv
-# CHECK: End point defined: /v0/find
-# CHECK: End point defined: /v0/foo
+# CHECK: Code was applied
 
 $CHISEL apply --version v0-_
-# CHECK: Model defined: Person
-# CHECK: Model defined: Position
-# CHECK: End point defined: /v0-_/csv
-# CHECK: End point defined: /v0-_/find
-# CHECK: End point defined: /v0-_/foo
+# CHECK: Code was applied
 
 
 cat << EOF > "endpoints/foo.js"
@@ -49,11 +41,7 @@ export default async function my_req_func(req) {
 EOF
 
 $CHISEL apply --version v1
-# CHECK: Model defined: Person
-# CHECK: Model defined: Position
-# CHECK: End point defined: /v1/csv
-# CHECK: End point defined: /v1/find
-# CHECK: End point defined: /v1/foo
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/v0/foo
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/worker.deno
+++ b/cli/tests/integration_tests/lit_tests/worker.deno
@@ -11,8 +11,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-
-# CHECK: End point defined: /dev/worker
+# CHECK: Code was applied
 
 $CURL -o - $CHISELD_HOST/dev/worker
 

--- a/cli/tests/integration_tests/rust_tests/find.rs
+++ b/cli/tests/integration_tests/rust_tests/find.rs
@@ -91,8 +91,7 @@ pub async fn find_many(c: TestContext) {
     "##,
     );
 
-    let r = c.chisel.apply_ok().await;
-    r.stdout.peek("Model defined: Person");
+    c.chisel.apply_ok().await;
 
     store_people(&c.chisel).await;
 
@@ -173,8 +172,7 @@ pub async fn find_one(c: TestContext) {
     "##,
     );
 
-    let r = c.chisel.apply_ok().await;
-    r.stdout.peek("Model defined: Person");
+    c.chisel.apply_ok().await;
 
     store_people(&c.chisel).await;
 
@@ -208,8 +206,7 @@ pub async fn find_by(mut c: TestContext) {
     c.chisel.copy_to_dir("examples/find_by.ts", "endpoints");
     c.chisel.copy_to_dir("examples/store.ts", "endpoints");
 
-    let r = c.chisel.apply_ok().await;
-    r.stdout.peek("Model defined: Person");
+    c.chisel.apply_ok().await;
 
     store_people(&c.chisel).await;
 

--- a/cli/tests/integration_tests/rust_tests/policies.rs
+++ b/cli/tests/integration_tests/rust_tests/policies.rs
@@ -25,9 +25,7 @@ pub async fn policies(c: TestContext) {
         }
     "##,
     );
-
-    let mut r = c.chisel.apply_ok().await;
-    r.stdout.read("Model defined: Person");
+    c.chisel.apply_ok().await;
 
     let pekka = json!({
         "first_name":"Pekka",

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -298,7 +298,7 @@ async fn run(state: SharedState, init: InitState, mut cmd: ExecutorChannel) -> R
     state.readiness_tx.send(()).await?;
 
     info!(
-        "ChiselStrike is ready 🚀 - URL: http://{} ",
+        "ChiselStrike server is ready 🚀 - URL: http://{} ",
         state.opt.api_listen_addr
     );
 


### PR DESCRIPTION
With the new routing API, we will be unable to print these messages, so let's remove them now.

This is a spin-off from #1618.