### PR TITLE
Containerize Github actions.

### DIFF
--- a/.github/build.Dockerfile
+++ b/.github/build.Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:22.04
+
+# If you need to add dependencies, don't forget to push the image to registry and bump the version
+# in .github/workflows/rust.yml
+RUN apt-get update &&\
+    apt-get upgrade -y &&\
+    apt-get install -y lld git curl jq build-essential pkg-config libssl-dev postgresql-client uuid-runtime zstd &&\
+    apt-get clean -y

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,27 +20,14 @@ env:
 jobs:
   build:
     runs-on: self-hosted
+    container:
+      image: ghcr.io/chiselstrike/rust-build-image:v1.0
+      options: --user 1000
     steps:
-    - name: Kill stray chiseld processes
-      run: "killall -9 -q chiseld || true"
     - name: checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Log in to the Container registry
-      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Make some room available
-      id: makeroom
-      run: "sudo rm -rf /usr/local/lib/android && sudo rm -rf /usr/share/dotnet"
-
-    - name: Install lld
-      id: lld
-      run: "sudo apt-get -y install lld"
 
     - name: Install rust toolchain
       uses: actions-rs/toolchain@v1
@@ -99,6 +86,9 @@ jobs:
 
   postgres-test:
     runs-on: self-hosted
+    container:
+      image: ghcr.io/chiselstrike/rust-build-image:v1.0
+      options: --user 1000
     services:
       postgres:
         image: postgres
@@ -109,19 +99,11 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        ports:
-          - 5432:5432
     steps:
-    - name: Kill stray chiseld processes
-      run: "killall -9 -q chiseld || true"
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
-
-    - name: Install lld
-      id: lld
-      run: "sudo apt-get -y install lld"
 
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
@@ -130,6 +112,11 @@ jobs:
 
     - name: Configure Rust cache
       uses: Swatinem/rust-cache@v1
+
+    - name: Install node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
 
     - name: Configure Node cache
       uses: actions/cache@v2
@@ -147,4 +134,4 @@ jobs:
       timeout-minutes: 20
       with:
           command: test
-          args: -p cli --test integration_tests -- --database postgres --database-user postgres --database-password "$POSTGRES_PASSWORD"
+          args: -p cli --test integration_tests -- --database postgres --database-user postgres --database-password "$POSTGRES_PASSWORD" --database-host postgres


### PR DESCRIPTION
This PR containerizes out pipeline builds to achieve better isolation from Runner's filesystem, stray processes etc.

It's currently based on our Docker image stored in chiselstrike's GH container registry: `ghcr.io/chiselstrike/rust-build-image:v1.0` which was built using `.github/build.Dockerfile`.
The reason why we need to have custom container is that we need to run the tests without root access to test some properties of file access and manipulation. That however doesn't allow us to install the required packages. (I got `sudo not found` error). So we build a container with dependencies and run in it without root. 
 
I wanted to automatically build the image as a pre-step to our build process, but I'm unable to make it push to our registry so I've deferred it to another PR which doesn't even need to go in as I don't expect the dependencies to change very often and we can just push manually...