### PR TITLE
Remove the word "endpoint" from public interfaces (from #1618)

### DIFF
--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -91,7 +91,7 @@ async function importEndpointsImpl(
         // Modules are never unloaded, so we need to create an unique
         // path. This will not be a problem once we publish the entire app
         // at once, since then we can create a new isolate for it.
-        const url = `file:///${apiVersion}/endpoints${path}`;
+        const url = `file:///${apiVersion}/routes${path}`;
         const mod = await import(url);
         const handler = mod.default;
         if (typeof handler !== "function") {

--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -88,11 +88,19 @@ async function importEndpointsImpl(
         requestContext.path = path;
         const fullPath = "/" + apiVersion + path;
 
-        // Modules are never unloaded, so we need to create an unique
-        // path. This will not be a problem once we publish the entire app
-        // at once, since then we can create a new isolate for it.
-        const url = `file:///${apiVersion}/routes${path}`;
-        const mod = await import(url);
+        const backCompatUrl = `file:///${apiVersion}/endpoints${path}`;
+        let mod;
+        try {
+            mod = await import(backCompatUrl);
+        } catch {
+            // ignore
+        }
+
+        if (mod === undefined) {
+            const url = `file:///${apiVersion}/routes${path}`;
+            mod = await import(url);
+        }
+
         const handler = mod.default;
         if (typeof handler !== "function") {
             throw new Error(

--- a/cli/src/cmd/apply.rs
+++ b/cli/src/cmd/apply.rs
@@ -66,7 +66,7 @@ impl From<bool> for TypeChecking {
 ///
 /// The apply phase performs bunch of processing on the source files. This
 /// map contains the final processed source files with the full path name
-/// to be shipped to the server. For example, endpoints have a `endpoints/`
+/// to be shipped to the server. For example, endpoints have a `routes/`
 /// prefix in the path for the server in cases the server needs to do
 /// something special depending on the source file type.
 pub(crate) type SourceMap = HashMap<String, String>;

--- a/cli/src/cmd/apply.rs
+++ b/cli/src/cmd/apply.rs
@@ -180,7 +180,7 @@ pub(crate) async fn apply(
 
     println!("Code was applied to the ChiselStrike server. It contained:");
     println!("  - models: {}", msg.types.len());
-    println!("  - endpoints: {}", msg.endpoints.len());
+    println!("  - routes: {}", msg.endpoints.len());
     println!("  - event handlers: {}", msg.event_handlers.len());
     println!("  - labels: {}", msg.labels.len());
 

--- a/cli/src/cmd/apply/deno.rs
+++ b/cli/src/cmd/apply/deno.rs
@@ -23,7 +23,7 @@ pub(crate) async fn apply(
         .collect();
     let mut output = compile_endpoints(&paths?)
         .await
-        .context("could not compile endpoints (using deno-style modules)")?;
+        .context("Could not compile routes (using deno-style modules)")?;
     for f in modules {
         let path = f.to_str().unwrap();
         let orig = output.get_mut(path).unwrap();

--- a/cli/src/cmd/apply/node.rs
+++ b/cli/src/cmd/apply/node.rs
@@ -142,7 +142,7 @@ pub(crate) async fn apply(
         let out = String::from_utf8(res.stdout).expect("command output not utf-8");
         let err = String::from_utf8(res.stderr).expect("command output not utf-8");
         return Err(anyhow!("{}\n{}", out, err))
-            .context("could not bundle endpoints with esbuild (using node-style modules)");
+            .context("Could not bundle routes with esbuild (using node-style modules)");
     }
 
     for bundler_info in bundler_file_mapping.iter() {

--- a/cli/src/cmd/dev.rs
+++ b/cli/src/cmd/dev.rs
@@ -60,7 +60,7 @@ pub(crate) async fn cmd_dev(
         tracked.insert(dir);
     }
 
-    for dir in &manifest.endpoints {
+    for dir in &manifest.routes {
         let dir = cwd.join(dir);
         tracked.insert(dir);
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -250,9 +250,6 @@ async fn main() -> Result<()> {
                     }
                     println!("  }}");
                 }
-                for def in &version_def.endpoint_defs {
-                    println!("  Endpoint: {}", def.path);
-                }
                 for def in &version_def.label_policy_defs {
                     println!("  Label policy: {}", def.label);
                 }

--- a/cli/tests/integration_tests/framework.rs
+++ b/cli/tests/integration_tests/framework.rs
@@ -14,7 +14,7 @@ use tempdir::TempDir;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 
 pub mod prelude {
-    pub use super::TestContext;
+    pub use super::{Chisel, TestContext};
     pub use bytes::Bytes;
     pub use chisel_macros::test;
     pub use reqwest::Method;

--- a/cli/tests/integration_tests/lit_tests/access-origin.deno
+++ b/cli/tests/integration_tests/lit_tests/access-origin.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/foo.ts"
+cat << EOF > "$TEMPDIR/routes/foo.ts"
 import { responseFromJson } from "@chiselstrike/api"
 export default async function chisel(req: Request) {
     if (req.method == 'GET') {

--- a/cli/tests/integration_tests/lit_tests/aggregations.deno
+++ b/cli/tests/integration_tests/lit_tests/aggregations.deno
@@ -20,7 +20,7 @@ export class Person extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/store.ts"
+cat << EOF > "$TEMPDIR/routes/store.ts"
 import { Person, Biography } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -59,7 +59,7 @@ export default async function chisel(req: Request) {
 EOF
 
 
-cat << EOF > "$TEMPDIR/endpoints/compute_aggregations.ts"
+cat << EOF > "$TEMPDIR/routes/compute_aggregations.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/api-policy.deno
+++ b/cli/tests/integration_tests/lit_tests/api-policy.deno
@@ -3,14 +3,14 @@
 # RUN: sh -e @file
 
 cp examples/person.ts "$TEMPDIR/models"
-cp examples/store.ts "$TEMPDIR/endpoints"
+cp examples/store.ts "$TEMPDIR/routes"
 cat << EOF > "$TEMPDIR/policies/pol.yaml"
 labels:
   - name: pii
     transform: anonymize
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/query.ts"
+cat << EOF > "$TEMPDIR/routes/query.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/bad-url.deno
+++ b/cli/tests/integration_tests/lit_tests/bad-url.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/bad.ts"
+cat << EOF > "$TEMPDIR/routes/bad.ts"
 import indent from 'https://cdn.skypack.dev/pin/indent-string@v5.0.0-badhash/mode=imports,min/optimized/indent-string.js'
 
 export default function chisel(req: Request) {
@@ -13,6 +13,6 @@ EOF
 cd "$TEMPDIR"
 $CHISEL apply 2>&1 || true
 
-# CHECK: Error: could not compile endpoints
+# CHECK: Error: Could not compile routes
 # CHECK: Caused by:
 # CHECK: HTTP request failed

--- a/cli/tests/integration_tests/lit_tests/body-resource.deno
+++ b/cli/tests/integration_tests/lit_tests/body-resource.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/test1.ts"
+cat << EOF > "$TEMPDIR/routes/test1.ts"
 export default async function chisel(req: Request) {
     const getResources = () => {
         return Object.values(Deno.core.resources()).filter(x => x == "chisel_server::deno::BodyResource");
@@ -23,7 +23,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/test2.ts"
+cat << EOF > "$TEMPDIR/routes/test2.ts"
 export default async function chisel(req: Request) {
     const getResources = () => {
         return Object.values(Deno.core.resources()).filter(x => x == "chisel_server::deno::BodyResource");

--- a/cli/tests/integration_tests/lit_tests/build-entity.deno
+++ b/cli/tests/integration_tests/lit_tests/build-entity.deno
@@ -13,7 +13,7 @@ export class User extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/user.ts"
+cat << EOF > "$TEMPDIR/routes/user.ts"
 import { User } from "../models/user.ts";
 
 export default async function (req: Request): Promise<Response> {

--- a/cli/tests/integration_tests/lit_tests/build-without-default.deno
+++ b/cli/tests/integration_tests/lit_tests/build-without-default.deno
@@ -11,7 +11,7 @@ export class Person extends ChiselEntity {
 EOF
 
 
-cat << EOF > "$TEMPDIR/endpoints/build.ts"
+cat << EOF > "$TEMPDIR/routes/build.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/camel.node
+++ b/cli/tests/integration_tests/lit_tests/camel.node
@@ -11,7 +11,7 @@ export class Camel extends ChiselEntity {
    camelCase: string;
 }
 EOF
-cat << EOF > "$TEMPDIR/endpoints/camel.ts"
+cat << EOF > "$TEMPDIR/routes/camel.ts"
 import { Camel } from "../models/camel";
 
 export default async function chisel(req) {

--- a/cli/tests/integration_tests/lit_tests/chiselrequest.deno
+++ b/cli/tests/integration_tests/lit_tests/chiselrequest.deno
@@ -4,7 +4,7 @@
 
 cd "$TEMPDIR"
 
-cat << EOF > "$TEMPDIR/endpoints/chisel.ts"
+cat << EOF > "$TEMPDIR/routes/chisel.ts"
 import { ChiselRequest, responseFromJson } from "@chiselstrike/api"
 
 export default async function chisel(req: ChiselRequest) {
@@ -13,8 +13,8 @@ export default async function chisel(req: ChiselRequest) {
 }
 EOF
 
-mkdir "$TEMPDIR/endpoints/chisel"
-cat << EOF > "$TEMPDIR/endpoints/chisel/inner.ts"
+mkdir "$TEMPDIR/routes/chisel"
+cat << EOF > "$TEMPDIR/routes/chisel/inner.ts"
 import { ChiselRequest, responseFromJson } from "@chiselstrike/api"
 
 export default async function chisel(req: ChiselRequest) {

--- a/cli/tests/integration_tests/lit_tests/cli/chisel-apply-ignores.deno
+++ b/cli/tests/integration_tests/lit_tests/cli/chisel-apply-ignores.deno
@@ -4,20 +4,20 @@
 
 cd "$TEMPDIR"
 
-cat << EOF > "$TEMPDIR/endpoints/hello.ts"
+cat << EOF > "$TEMPDIR/routes/hello.ts"
 export default async function (req: Request) {
     return new Response('ok');
 }
 EOF
 
 # Generate hidden file (in this case, vim swap file):
-cp "$TEMPDIR/endpoints/hello.ts" "$TEMPDIR/endpoints/.hello.ts.swp"
+cp "$TEMPDIR/routes/hello.ts" "$TEMPDIR/routes/.hello.ts.swp"
 
 # Generate vim backup file:
-cp "$TEMPDIR/endpoints/hello.ts" "$TEMPDIR/endpoints/hello.ts~"
+cp "$TEMPDIR/routes/hello.ts" "$TEMPDIR/routes/hello.ts~"
 
 # Generate emacs autosave file:
-cp "$TEMPDIR/endpoints/hello.ts" "$TEMPDIR/endpoints/#hello.ts#"
+cp "$TEMPDIR/routes/hello.ts" "$TEMPDIR/routes/#hello.ts#"
 
 $CHISEL apply
 

--- a/cli/tests/integration_tests/lit_tests/cli/describe.deno
+++ b/cli/tests/integration_tests/lit_tests/cli/describe.deno
@@ -10,7 +10,7 @@ export class Foo extends ChiselEntity { a: string; }
 export class Bar extends ChiselEntity { b: string; }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/hello.ts"
+cat << EOF > "$TEMPDIR/routes/hello.ts"
 import { Foo } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -39,13 +39,13 @@ $CHISEL describe
 # CHECK: Endpoint: /dev/hello
 # CHECK: Label policy: pii
 
-echo "found $($CHISEL describe | grep Endpoint | wc -l | awk '{print $1}') endpoints"
-# CHECK: found 1 endpoints
+echo "found $($CHISEL describe | grep Endpoint | wc -l | awk '{print $1}') routes"
+# CHECK: found 1 routes
 
 ## check that an endpoint-only scenario works
 rm -rf "$TEMPDIR/models"
 rm -rf "$TEMPDIR/policies"
-cat << EOF > "$TEMPDIR/endpoints/hello.ts"
+cat << EOF > "$TEMPDIR/routes/hello.ts"
 export default async function chisel(req: Request) {
     return new Response('ok');
 }

--- a/cli/tests/integration_tests/lit_tests/cli/describe.deno
+++ b/cli/tests/integration_tests/lit_tests/cli/describe.deno
@@ -36,26 +36,4 @@ $CHISEL describe
 # CHECK: class Foo {
 # CHECK:   [[^ *a: string]]
 # CHECK: }
-# CHECK: Endpoint: /dev/hello
 # CHECK: Label policy: pii
-
-echo "found $($CHISEL describe | grep Endpoint | wc -l | awk '{print $1}') routes"
-# CHECK: found 1 routes
-
-## check that an endpoint-only scenario works
-rm -rf "$TEMPDIR/models"
-rm -rf "$TEMPDIR/policies"
-cat << EOF > "$TEMPDIR/routes/hello.ts"
-export default async function chisel(req: Request) {
-    return new Response('ok');
-}
-EOF
-$CHISEL apply
-
-$CHISEL describe
-# CHECK: Endpoint: /dev/hello
-
-$CHISEL restart
-
-$CHISEL describe
-# CHECK: Endpoint: /dev/hello

--- a/cli/tests/integration_tests/lit_tests/cli/reapply.deno
+++ b/cli/tests/integration_tests/lit_tests/cli/reapply.deno
@@ -68,7 +68,7 @@ export class Foo extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/seed.ts"
+cat << EOF > "$TEMPDIR/routes/seed.ts"
 import { Foo } from "../models/foo.ts"
 export default async function seed() {
     const c = Foo.build({"a": "seed", "b": 2})
@@ -80,7 +80,7 @@ $CHISEL apply
 # CHECK: Code was applied
 
 $CURL -X POST $CHISELD_HOST/dev/seed
-rm "$TEMPDIR/endpoints/seed.ts"
+rm "$TEMPDIR/routes/seed.ts"
 
 ## Changing b's type is not OK.
 cat << EOF > "$TEMPDIR/models/foo.ts"

--- a/cli/tests/integration_tests/lit_tests/concurrency-stream.deno
+++ b/cli/tests/integration_tests/lit_tests/concurrency-stream.deno
@@ -5,7 +5,7 @@
 # Test that we don't mixup the output from multiple endpoint
 # invocations when streaming.
 
-cat << EOF > "$TEMPDIR/endpoints/stream.ts"
+cat << EOF > "$TEMPDIR/routes/stream.ts"
 export default async function chisel(req: Request) {
     let i = 0;
     let stream = new ReadableStream({

--- a/cli/tests/integration_tests/lit_tests/concurrency-wait.deno
+++ b/cli/tests/integration_tests/lit_tests/concurrency-wait.deno
@@ -4,7 +4,7 @@
 
 cp examples/person.ts "$TEMPDIR/models"
 
-cat << EOF > "$TEMPDIR/endpoints/sleep.ts"
+cat << EOF > "$TEMPDIR/routes/sleep.ts"
 export default async function chisel(req: Request) {
     await new Promise(resolve => setTimeout(resolve, 2000));
     return new Response("sleeper");

--- a/cli/tests/integration_tests/lit_tests/concurrency.deno
+++ b/cli/tests/integration_tests/lit_tests/concurrency.deno
@@ -3,9 +3,9 @@
 # RUN: sh -e @file
 
 cp examples/person.ts "$TEMPDIR/models"
-cp examples/store.ts "$TEMPDIR/endpoints"
+cp examples/store.ts "$TEMPDIR/routes"
 
-cat << EOF > "$TEMPDIR/endpoints/query.ts"
+cat << EOF > "$TEMPDIR/routes/query.ts"
 import { Person } from "../models/person.ts";
 
 export default async function (req: Request) {

--- a/cli/tests/integration_tests/lit_tests/create.deno
+++ b/cli/tests/integration_tests/lit_tests/create.deno
@@ -13,7 +13,7 @@ export class Person extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/new.ts"
+cat << EOF > "$TEMPDIR/routes/new.ts"
 import { Person } from "../models/types.ts";
 import { responseFromJson } from "@chiselstrike/api"
 

--- a/cli/tests/integration_tests/lit_tests/crud-custom.node
+++ b/cli/tests/integration_tests/lit_tests/crud-custom.node
@@ -4,7 +4,7 @@
 
 cp examples/person.ts "$TEMPDIR/models"
 
-cat << EOF > "$TEMPDIR/endpoints/persons.ts"
+cat << EOF > "$TEMPDIR/routes/persons.ts"
 import { crud, standardCRUDMethods } from "@chiselstrike/api";
 import { Person } from "../models/person";
 

--- a/cli/tests/integration_tests/lit_tests/crud.node
+++ b/cli/tests/integration_tests/lit_tests/crud.node
@@ -4,7 +4,7 @@
 
 cp examples/person.ts "$TEMPDIR/models"
 
-cat << EOF > "$TEMPDIR/endpoints/persons.ts"
+cat << EOF > "$TEMPDIR/routes/persons.ts"
 import { Person } from "../models/person";
 export default Person.crud();
 EOF

--- a/cli/tests/integration_tests/lit_tests/csv.deno
+++ b/cli/tests/integration_tests/lit_tests/csv.deno
@@ -3,7 +3,7 @@
 # RUN: sh -e @file
 
 cp examples/person.ts "$TEMPDIR/models"
-cp examples/csv.ts examples/find.ts "$TEMPDIR/endpoints"
+cp examples/csv.ts examples/find.ts "$TEMPDIR/routes"
 
 cd "$TEMPDIR"
 $CHISEL apply

--- a/cli/tests/integration_tests/lit_tests/db-api.deno
+++ b/cli/tests/integration_tests/lit_tests/db-api.deno
@@ -3,9 +3,9 @@
 # RUN: sh -e @file
 
 cp examples/person.ts "$TEMPDIR/models"
-cp examples/store.ts "$TEMPDIR/endpoints"
+cp examples/store.ts "$TEMPDIR/routes"
 
-cat << EOF > "$TEMPDIR/endpoints/query.ts"
+cat << EOF > "$TEMPDIR/routes/query.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -19,7 +19,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/bug.ts"
+cat << EOF > "$TEMPDIR/routes/bug.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/defaults.deno
+++ b/cli/tests/integration_tests/lit_tests/defaults.deno
@@ -30,7 +30,7 @@ export class Foo extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/default.ts"
+cat << EOF > "$TEMPDIR/routes/default.ts"
 import { Foo } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -41,7 +41,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/read.ts"
+cat << EOF > "$TEMPDIR/routes/read.ts"
 import { Foo } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -82,7 +82,7 @@ export class Foo extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/readold.ts"
+cat << EOF > "$TEMPDIR/routes/readold.ts"
 import { Foo } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -99,7 +99,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/crud_foo.ts"
+cat << EOF > "$TEMPDIR/routes/crud_foo.ts"
 import { Foo } from "../models/types.ts";
 export default Foo.crud();
 EOF
@@ -153,7 +153,7 @@ $CURL "$CHISELD_HOST/dev/crud_foo?.d=2" | count_results
 # CHECK: "a": "dfl1"
 
 
-cat << EOF > "$TEMPDIR/endpoints/find_many.ts"
+cat << EOF > "$TEMPDIR/routes/find_many.ts"
 import { responseFromJson } from "@chiselstrike/api";
 import { Foo } from "../models/types.ts";
 

--- a/cli/tests/integration_tests/lit_tests/delete-type.deno
+++ b/cli/tests/integration_tests/lit_tests/delete-type.deno
@@ -13,7 +13,7 @@ export class User extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/user.ts"
+cat << EOF > "$TEMPDIR/routes/user.ts"
 import { User } from "../models/user.ts";
 export default User.crud();
 EOF
@@ -25,7 +25,7 @@ $CURL -X POST -d '{"username": "alice", "email": "alice@example.org"}' $CHISELD_
 # CHECK: "alice"
 
 rm models/user.ts
-rm endpoints/user.ts
+rm routes/user.ts
 
 ## can't remove the type because it has data
 $CHISEL apply 2>&1 || true

--- a/cli/tests/integration_tests/lit_tests/delete.deno
+++ b/cli/tests/integration_tests/lit_tests/delete.deno
@@ -13,12 +13,12 @@ export class User extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/user.ts"
+cat << EOF > "$TEMPDIR/routes/user.ts"
 import { User } from "../models/user.ts";
 export default User.crud();
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/delete.ts"
+cat << EOF > "$TEMPDIR/routes/delete.ts"
 import { User } from "../models/user.ts";
 export default async function chisel(req: Request) {
     await User.delete({ email: "alice@example.com"});
@@ -26,7 +26,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/update-delete.ts"
+cat << EOF > "$TEMPDIR/routes/update-delete.ts"
 import { User } from "../models/user.ts";
 export default async function chisel(req: Request) {
     await User.delete({ email: "test@example.com"});

--- a/cli/tests/integration_tests/lit_tests/drop-leftover.deno
+++ b/cli/tests/integration_tests/lit_tests/drop-leftover.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/inf.ts"
+cat << EOF > "$TEMPDIR/routes/inf.ts"
 export default async function chisel(req: Request) {
     let stream = new ReadableStream({
         async pull(controller) {
@@ -18,7 +18,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/ok.ts"
+cat << EOF > "$TEMPDIR/routes/ok.ts"
 export default async function chisel(req: Request) {
     return new Response("EXPECTED\n");
 }

--- a/cli/tests/integration_tests/lit_tests/duplicated.deno
+++ b/cli/tests/integration_tests/lit_tests/duplicated.deno
@@ -2,13 +2,13 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/foo.ts"
+cat << EOF > "$TEMPDIR/routes/foo.ts"
 export default async function chisel(req: Request) {
     return new Response("");
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/foo.js"
+cat << EOF > "$TEMPDIR/routes/foo.js"
 export default async function chisel(req) {
     return new Response("");
 }
@@ -17,4 +17,4 @@ EOF
 cd "$TEMPDIR"
 $CHISEL apply 2>&1 || true
 
-# CHECK: Error: Cannot add both endpoints/foo.js endpoints/foo.ts as routes. ChiselStrike uses filesystem-based routing, so we don't know what to do. Sorry!
+# CHECK: Error: Cannot add both routes/foo.js and routes/foo.ts as routes. ChiselStrike uses filesystem-based routing, so we don't know what to do. Sorry!

--- a/cli/tests/integration_tests/lit_tests/echo-endpoint.deno
+++ b/cli/tests/integration_tests/lit_tests/echo-endpoint.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/echo.ts"
+cat << EOF > "$TEMPDIR/routes/echo.ts"
 // This function produces a response whose body is a json of the request
 export default async function chisel(req: Request) {
     // Stringfy needs some help to see some of the fields

--- a/cli/tests/integration_tests/lit_tests/empty-response.deno
+++ b/cli/tests/integration_tests/lit_tests/empty-response.deno
@@ -2,13 +2,13 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/empty.ts"
+cat << EOF > "$TEMPDIR/routes/empty.ts"
 export default async function chisel(req: Request) {
     return new Response(null, { status : 204 });
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/emptychisel.ts"
+cat << EOF > "$TEMPDIR/routes/emptychisel.ts"
 import { responseFromJson } from "@chiselstrike/api"
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/endpoint-error.deno
+++ b/cli/tests/integration_tests/lit_tests/endpoint-error.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/test.ts"
+cat << EOF > "$TEMPDIR/routes/test.ts"
 // Intentionally invalid, there is no default export
 export async function chisel(req: Request) {
     return new Response("foo");
@@ -15,14 +15,14 @@ set +e
 $CHISEL apply 2>&1
 set -e
 
-# CHECK: Error: could not import endpoint code into the runtime
+# CHECK: Error: Could not apply the provided code
 # CHECK: expected type `v8::data::Function`, got `v8::data::Value`
 
 $CURL -o - $CHISELD_HOST/dev/test
 
 # CHECK: HTTP/1.1 404 Not Found
 
-cat << EOF > "$TEMPDIR/endpoints/test.ts"
+cat << EOF > "$TEMPDIR/routes/test.ts"
 // Now it is OK
 export default async function chisel(req: Request) {
     return new Response("foo");

--- a/cli/tests/integration_tests/lit_tests/entity-findone-filter.deno
+++ b/cli/tests/integration_tests/lit_tests/entity-findone-filter.deno
@@ -12,7 +12,7 @@ export class User extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/entity-methods.ts"
+cat << EOF > "$TEMPDIR/routes/entity-methods.ts"
 import { User } from "../models/user.ts";
 
 function validate(user: User): boolean {

--- a/cli/tests/integration_tests/lit_tests/entity-methods.deno
+++ b/cli/tests/integration_tests/lit_tests/entity-methods.deno
@@ -12,7 +12,7 @@ export class User extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/entity-methods.ts"
+cat << EOF > "$TEMPDIR/routes/entity-methods.ts"
 import { User } from "../models/user.ts";
 
 export default async function (req: Request): Promise<Response> {

--- a/cli/tests/integration_tests/lit_tests/error-leftover.deno
+++ b/cli/tests/integration_tests/lit_tests/error-leftover.deno
@@ -4,7 +4,7 @@
 
 # Test that we cleanup when a endpoint fails in the middle.
 
-cat << EOF > "$TEMPDIR/endpoints/error.ts"
+cat << EOF > "$TEMPDIR/routes/error.ts"
 export default async function chisel(req: Request) {
     let i = 0;
     let stream = new ReadableStream({
@@ -26,7 +26,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/ok.ts"
+cat << EOF > "$TEMPDIR/routes/ok.ts"
 export default async function chisel(req: Request) {
     return new Response("EXPECTED\n");
 }

--- a/cli/tests/integration_tests/lit_tests/error-on-stream.deno
+++ b/cli/tests/integration_tests/lit_tests/error-on-stream.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/stream.ts"
+cat << EOF > "$TEMPDIR/routes/stream.ts"
 export default async function chisel(req: Request) {
     let stream = new ReadableStream({
         pull(controller) {

--- a/cli/tests/integration_tests/lit_tests/escape-string.deno
+++ b/cli/tests/integration_tests/lit_tests/escape-string.deno
@@ -3,9 +3,9 @@
 # RUN: sh -e @file
 
 cp examples/person.ts "$TEMPDIR/models"
-cp examples/store.ts "$TEMPDIR/endpoints"
+cp examples/store.ts "$TEMPDIR/routes"
 
-cat << EOF > "$TEMPDIR/endpoints/query.ts"
+cat << EOF > "$TEMPDIR/routes/query.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/filter-with-predicate.deno
+++ b/cli/tests/integration_tests/lit_tests/filter-with-predicate.deno
@@ -19,7 +19,7 @@ export class Person extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/store.ts"
+cat << EOF > "$TEMPDIR/routes/store.ts"
 import { Person, Biography } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -54,7 +54,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/findall.ts"
+cat << EOF > "$TEMPDIR/routes/findall.ts"
 import { Person } from "../models/types.ts";
 
 function reverse(s: string): string {
@@ -133,7 +133,7 @@ $CURL -o - $CHISELD_HOST/dev/findall?fibonacciAge=12
 
 ## Check that take gets applied after filtering with predicate.
 
-cat << EOF > "$TEMPDIR/endpoints/filter_and_take.ts"
+cat << EOF > "$TEMPDIR/routes/filter_and_take.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -159,7 +159,7 @@ $CURL -o - $CHISELD_HOST/dev/filter_and_take
 
 ## Filter after take
 
-cat << EOF > "$TEMPDIR/endpoints/filter_and_take.ts"
+cat << EOF > "$TEMPDIR/routes/filter_and_take.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -184,7 +184,7 @@ $CURL -o - $CHISELD_HOST/dev/filter_and_take
 
 ## Check that restriction gets applied after filtering with predicate.
 
-cat << EOF > "$TEMPDIR/endpoints/filter_and_restrict.ts"
+cat << EOF > "$TEMPDIR/routes/filter_and_restrict.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -209,7 +209,7 @@ $CURL -o - $CHISELD_HOST/dev/filter_and_restrict
 
 ## Filter after restriction
 
-cat << EOF > "$TEMPDIR/endpoints/filter_and_restrict.ts"
+cat << EOF > "$TEMPDIR/routes/filter_and_restrict.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -234,7 +234,7 @@ $CURL -o - $CHISELD_HOST/dev/filter_and_restrict
 
 ## Check that column selection gets applied after filtering with predicate.
 
-cat << EOF > "$TEMPDIR/endpoints/filter_and_select.ts"
+cat << EOF > "$TEMPDIR/routes/filter_and_select.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -257,7 +257,7 @@ $CURL -o - $CHISELD_HOST/dev/filter_and_select
 
 ## Filter after select
 
-cat << EOF > "$TEMPDIR/endpoints/filter_and_select.ts"
+cat << EOF > "$TEMPDIR/routes/filter_and_select.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -282,7 +282,7 @@ $CURL -o - $CHISELD_HOST/dev/filter_and_select
 
 ## Filter with expression - simple
 
-cat << EOF > "$TEMPDIR/endpoints/filter_with_expression.ts"
+cat << EOF > "$TEMPDIR/routes/filter_with_expression.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -320,7 +320,7 @@ $CURL -o - $CHISELD_HOST/dev/filter_with_expression
 
 ## Filter with expression - nested Entities
 
-cat << EOF > "$TEMPDIR/endpoints/filter_with_expression.ts"
+cat << EOF > "$TEMPDIR/routes/filter_with_expression.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -362,7 +362,7 @@ $CURL -o - $CHISELD_HOST/dev/filter_with_expression
 
 ## Filter by nonexistent field - check for errors
 
-cat << EOF > "$TEMPDIR/endpoints/filter_with_expression.ts"
+cat << EOF > "$TEMPDIR/routes/filter_with_expression.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -400,7 +400,7 @@ $CURL -o - $CHISELD_HOST/dev/filter_with_expression
 
 ## Filter by nonexistent joined field - check for errors
 
-cat << EOF > "$TEMPDIR/endpoints/filter_with_expression.ts"
+cat << EOF > "$TEMPDIR/routes/filter_with_expression.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -442,7 +442,7 @@ $CURL -o - $CHISELD_HOST/dev/filter_with_expression
 
 ## Filter by unary boolean predicate.
 
-cat << EOF > "$TEMPDIR/endpoints/filter_with_expression.ts"
+cat << EOF > "$TEMPDIR/routes/filter_with_expression.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/filter.deno
+++ b/cli/tests/integration_tests/lit_tests/filter.deno
@@ -3,7 +3,7 @@
 # RUN: sh -e @file
 
 cp examples/person.ts "$TEMPDIR/models"
-cp examples/store.ts "$TEMPDIR/endpoints"
+cp examples/store.ts "$TEMPDIR/routes"
 
 cd "$TEMPDIR"
 $CHISEL apply
@@ -27,7 +27,7 @@ $CURL --data '{
     "height": 10.01
 }' -o - $CHISELD_HOST/dev/store
 
-cat << EOF > "$TEMPDIR/endpoints/query.ts"
+cat << EOF > "$TEMPDIR/routes/query.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -78,7 +78,7 @@ export class Post extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/take_filter.ts"
+cat << EOF > "$TEMPDIR/routes/take_filter.ts"
 import { responseFromJson } from "@chiselstrike/api"
 import { Post } from '../models/post.ts';
 
@@ -137,7 +137,7 @@ export class TestingEntity extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/store_testing_entity.ts"
+cat << EOF > "$TEMPDIR/routes/store_testing_entity.ts"
 import { TestingEntity } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -146,7 +146,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/findall.ts"
+cat << EOF > "$TEMPDIR/routes/findall.ts"
 import { TestingEntity } from "../models/types.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/foreach.deno
+++ b/cli/tests/integration_tests/lit_tests/foreach.deno
@@ -6,7 +6,7 @@ cp examples/person.ts "$TEMPDIR/models"
 
 cd "$TEMPDIR"
 
-cat << EOF > "$TEMPDIR/endpoints/store.ts"
+cat << EOF > "$TEMPDIR/routes/store.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -22,7 +22,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/foreach.ts"
+cat << EOF > "$TEMPDIR/routes/foreach.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/head-of-infinity.deno
+++ b/cli/tests/integration_tests/lit_tests/head-of-infinity.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/inf.ts"
+cat << EOF > "$TEMPDIR/routes/inf.ts"
 export default async function chisel(req: Request) {
     let i = 0;
     let stream = new ReadableStream({

--- a/cli/tests/integration_tests/lit_tests/headers.deno
+++ b/cli/tests/integration_tests/lit_tests/headers.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/foo.ts"
+cat << EOF > "$TEMPDIR/routes/foo.ts"
 export default async function chisel(req: Request) {
     return new Response("foo");
 }

--- a/cli/tests/integration_tests/lit_tests/id.deno
+++ b/cli/tests/integration_tests/lit_tests/id.deno
@@ -6,7 +6,7 @@ cp examples/person.ts "$TEMPDIR/models"
 
 cd "$TEMPDIR"
 
-cat << EOF > "$TEMPDIR/endpoints/bad_id.ts"
+cat << EOF > "$TEMPDIR/routes/bad_id.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -19,7 +19,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/store_with_id.ts"
+cat << EOF > "$TEMPDIR/routes/store_with_id.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -31,7 +31,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/find_by_id.ts"
+cat << EOF > "$TEMPDIR/routes/find_by_id.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -42,7 +42,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/store_no_id.ts"
+cat << EOF > "$TEMPDIR/routes/store_no_id.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -53,7 +53,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/update_by_id.ts"
+cat << EOF > "$TEMPDIR/routes/update_by_id.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -64,7 +64,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/count_glaubers.ts"
+cat << EOF > "$TEMPDIR/routes/count_glaubers.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/ignore-policy-field.deno
+++ b/cli/tests/integration_tests/lit_tests/ignore-policy-field.deno
@@ -3,7 +3,7 @@
 # RUN: sh -e @file
 
 cp examples/person.ts "$TEMPDIR/models"
-cp examples/store.ts "$TEMPDIR/endpoints"
+cp examples/store.ts "$TEMPDIR/routes"
 
 cat << EOF > "$TEMPDIR/policies/pol.yaml"
 labels:
@@ -11,7 +11,7 @@ labels:
     transform: anonymize
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/query.ts"
+cat << EOF > "$TEMPDIR/routes/query.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/infinite.deno
+++ b/cli/tests/integration_tests/lit_tests/infinite.deno
@@ -2,13 +2,13 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/hello.ts"
+cat << EOF > "$TEMPDIR/routes/hello.ts"
 export default async function chisel(req: Request) {
     return new Response("HELLO\n");
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/inf.ts"
+cat << EOF > "$TEMPDIR/routes/inf.ts"
 export default async function chisel(req: Request) {
     let stream = new ReadableStream({
         async pull(controller) {

--- a/cli/tests/integration_tests/lit_tests/introspect.node
+++ b/cli/tests/integration_tests/lit_tests/introspect.node
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/simple.ts"
+cat << EOF > "$TEMPDIR/routes/simple.ts"
 export default function chisel(_req: Request) : Promise<Response> {
     return new Response("");
 }
@@ -58,7 +58,7 @@ $CURL $CHISELD_HOST/dev
 # CHECK: "version": "1.0.0"
 
 git init ./
-git add endpoints/simple.ts
+git add routes/simple.ts
 git commit -m "test"
 $CHISEL apply
 $CURL $CHISELD_HOST/dev

--- a/cli/tests/integration_tests/lit_tests/join.lit.disabled
+++ b/cli/tests/integration_tests/lit_tests/join.lit.disabled
@@ -3,7 +3,7 @@
 # RUN: sh -e @file
 
 cp examples/person.ts "$TEMPDIR/models"
-cp examples/store.ts "$TEMPDIR/endpoints"
+cp examples/store.ts "$TEMPDIR/routes"
 
 cat << EOF > "$TEMPDIR/policies/pol.yaml"
 labels:
@@ -20,7 +20,7 @@ export class Nickname extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/store_nick.js"
+cat << EOF > "$TEMPDIR/routes/store_nick.js"
 export default async function chisel(req: Request) {
     const nick = new Nickname();
     nick.first_name = "Glauber";
@@ -30,7 +30,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/query.ts"
+cat << EOF > "$TEMPDIR/routes/query.ts"
 import { Person } from "../models/person.ts";
 import { Nickname } from "../models/nickname.ts";
 

--- a/cli/tests/integration_tests/lit_tests/lib.deno
+++ b/cli/tests/integration_tests/lit_tests/lib.deno
@@ -4,7 +4,7 @@
 
 cd "$TEMPDIR"
 
-cat << EOF > "$TEMPDIR/endpoints/hello.ts"
+cat << EOF > "$TEMPDIR/routes/hello.ts"
 import { hello } from "../lib/hello.ts";
 
 export default async function (req: Request) {

--- a/cli/tests/integration_tests/lit_tests/map.deno
+++ b/cli/tests/integration_tests/lit_tests/map.deno
@@ -13,7 +13,7 @@ export class Person extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/store.ts"
+cat << EOF > "$TEMPDIR/routes/store.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel() {
@@ -23,7 +23,7 @@ export default async function chisel() {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/maparray.ts"
+cat << EOF > "$TEMPDIR/routes/maparray.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(): Promise<Array<number>> {
@@ -31,7 +31,7 @@ export default async function chisel(): Promise<Array<number>> {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/mapfor.ts"
+cat << EOF > "$TEMPDIR/routes/mapfor.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(): Promise<number> {
@@ -43,7 +43,7 @@ export default async function chisel(): Promise<number> {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/doublemap.ts"
+cat << EOF > "$TEMPDIR/routes/doublemap.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(): Promise<Array<number>> {
@@ -51,7 +51,7 @@ export default async function chisel(): Promise<Array<number>> {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/maptake.ts"
+cat << EOF > "$TEMPDIR/routes/maptake.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(): Promise<number> {
@@ -61,7 +61,7 @@ export default async function chisel(): Promise<number> {
 EOF
 
 
-cat << EOF > "$TEMPDIR/endpoints/mapskip.ts"
+cat << EOF > "$TEMPDIR/routes/mapskip.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(): Promise<number> {
@@ -70,7 +70,7 @@ export default async function chisel(): Promise<number> {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/mapfilter.ts"
+cat << EOF > "$TEMPDIR/routes/mapfilter.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(): Promise<number> {

--- a/cli/tests/integration_tests/lit_tests/missing-await.deno
+++ b/cli/tests/integration_tests/lit_tests/missing-await.deno
@@ -10,7 +10,7 @@ export class User extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/find.ts"
+cat << EOF > "$TEMPDIR/routes/find.ts"
 import { User } from "../models/user.ts";
 
 export default async function (req: Request): Promise<Response> {

--- a/cli/tests/integration_tests/lit_tests/multiple-endpoints.deno
+++ b/cli/tests/integration_tests/lit_tests/multiple-endpoints.deno
@@ -5,13 +5,13 @@
 # Test that we can have multiple end points, that they can use the
 # same function name and that that name is arbitrary.
 
-cat << EOF > "$TEMPDIR/endpoints/foo.js"
+cat << EOF > "$TEMPDIR/routes/foo.js"
 export default async function my_req_func(req) {
     return new Response("foo");
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/bar.js"
+cat << EOF > "$TEMPDIR/routes/bar.js"
 export default async function my_req_func(req) {
     return new Response("bar");
 }
@@ -34,7 +34,7 @@ $CURL -o - $CHISELD_HOST/dev/bar
 # Test that all of this works in node-mode as well
 cat << EOF > "$TEMPDIR/Chisel.toml"
 models = ["models"]
-endpoints = ["endpoints"]
+routes = ["routes"]
 policies = ["policies"]
 modules = "node"
 EOF

--- a/cli/tests/integration_tests/lit_tests/node-std.deno
+++ b/cli/tests/integration_tests/lit_tests/node-std.deno
@@ -4,7 +4,7 @@
 
 cd "$TEMPDIR"
 
-cat << EOF > "$TEMPDIR/endpoints/foo.ts"
+cat << EOF > "$TEMPDIR/routes/foo.ts"
 import * as module from "https://deno.land/std@0.145.0/node/module.ts";
 
 export default async function (req: Request): Promise<Response> {

--- a/cli/tests/integration_tests/lit_tests/optional-field.deno
+++ b/cli/tests/integration_tests/lit_tests/optional-field.deno
@@ -16,7 +16,7 @@ export class Foo extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/save.ts"
+cat << EOF > "$TEMPDIR/routes/save.ts"
 import { Foo } from "../models/t.ts";
 import { responseFromJson } from "@chiselstrike/api";
 export default async function (req: Request) {
@@ -26,7 +26,7 @@ export default async function (req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/sum.ts"
+cat << EOF > "$TEMPDIR/routes/sum.ts"
 import { Foo } from "../models/t.ts";
 export default async function (_: Request) {
     let sum = 0;

--- a/cli/tests/integration_tests/lit_tests/parse-error.deno
+++ b/cli/tests/integration_tests/lit_tests/parse-error.deno
@@ -4,7 +4,7 @@
 
 cp examples/person.ts "$TEMPDIR/models"
 
-cat << EOF > "$TEMPDIR/endpoints/error.ts"
+cat << EOF > "$TEMPDIR/routes/error.ts"
 export default async function chisel(req: Request) {
     return new Response("foo" "bar");
 }
@@ -13,11 +13,11 @@ EOF
 cd "$TEMPDIR"
 
 $CHISEL apply 2>&1 | $RMCOLOR || true
-# CHECK: Error: could not compile endpoints
+# CHECK: Error: Could not compile routes
 # CHECK: Caused by:
-# CHECK:     The module's source code could not be parsed: Expected ',', got 'string literal (bar, "bar")' at file:///[[.*]]/endpoints/error.ts:2:31
+# CHECK:     The module's source code could not be parsed: Expected ',', got 'string literal (bar, "bar")' at file:///[[.*]]/routes/error.ts:2:31
 
-cat << EOF > "$TEMPDIR/endpoints/error.ts"
+cat << EOF > "$TEMPDIR/routes/error.ts"
 const xyz = foo();
 export default async function chisel(req: Request) {
     return xyz;
@@ -25,12 +25,12 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply 2>&1 | $RMCOLOR|| true
-#CHECK: Error: could not compile endpoints
+#CHECK: Error: Could not compile routes
 #CHECK: Caused by:
 #CHECK:     Compilation failed:
-#CHECK:     endpoints/error.ts:1:13 - error TS2304: Cannot find name 'foo'.
+#CHECK:     routes/error.ts:1:13 - error TS2304: Cannot find name 'foo'.
 
-cat << EOF > "$TEMPDIR/endpoints/error.ts"
+cat << EOF > "$TEMPDIR/routes/error.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -44,12 +44,12 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply 2>&1 | $RMCOLOR|| true
-#CHECK: Error: could not compile endpoints
+#CHECK: Error: Could not compile routes
 #CHECK: Caused by:
 #CHECK:     Compilation failed:
-#CHECK:     endpoints/error.ts:7:20 - error TS2339: Property 'nickname' does not exist on type 'Person'.
+#CHECK:     routes/error.ts:7:20 - error TS2339: Property 'nickname' does not exist on type 'Person'.
 
-cat << EOF > "$TEMPDIR/endpoints/error.ts"
+cat << EOF > "$TEMPDIR/routes/error.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -58,13 +58,13 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply 2>&1 | $RMCOLOR|| true
-#CHECK: Error: could not compile endpoints
+#CHECK: Error: Could not compile routes
 #CHECK: Caused by:
 #CHECK:     Compilation failed:
-#CHECK:      endpoints/error.ts:4:32 - error TS2339: Property 'first_name' does not exist on type 'typeof Person'.
+#CHECK:      routes/error.ts:4:32 - error TS2339: Property 'first_name' does not exist on type 'typeof Person'.
 
 
-cat << EOF > "$TEMPDIR/endpoints/error.ts"
+cat << EOF > "$TEMPDIR/routes/error.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -78,12 +78,12 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply 2>&1 | $RMCOLOR|| true
-#CHECK: Error: could not compile endpoints
+#CHECK: Error: Could not compile routes
 #CHECK: Caused by:
 #CHECK:     Compilation failed:
-#CHECK:     endpoints/error.ts:7:20 - error TS2339: Property 'first_name' does not exist on type 'Pick<Person, "last_name">'.
+#CHECK:     routes/error.ts:7:20 - error TS2339: Property 'first_name' does not exist on type 'Pick<Person, "last_name">'.
 
-cat << EOF > "$TEMPDIR/endpoints/error.ts"
+cat << EOF > "$TEMPDIR/routes/error.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -93,10 +93,10 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply 2>&1 | $RMCOLOR|| true
-# CHECK: endpoints/error.ts:4:25 - error TS2345: Argument of type '{ a: number; }' is not assignable to parameter of type 'Partial<Person>'
+# CHECK: routes/error.ts:4:25 - error TS2345: Argument of type '{ a: number; }' is not assignable to parameter of type 'Partial<Person>'
 # CHECK:     Object literal may only specify known properties, and 'a' does not exist in type 'Partial<Person>'.
 
-cat << EOF > "$TEMPDIR/endpoints/error.ts"
+cat << EOF > "$TEMPDIR/routes/error.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -106,15 +106,15 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply 2>&1 | $RMCOLOR|| true
-# CHECK: endpoints/error.ts:4:25 - error TS2322: Type 'string' is not assignable to type 'number'.
+# CHECK: routes/error.ts:4:25 - error TS2322: Type 'string' is not assignable to type 'number'.
 # CHECK:  The expected type comes from property 'height' which is declared here on type 'Partial<Person>'
 
-rm "$TEMPDIR/endpoints/error.ts"
-cat << EOF > "$TEMPDIR/endpoints/not-js.js"
+rm "$TEMPDIR/routes/error.ts"
+cat << EOF > "$TEMPDIR/routes/not-js.js"
 export default async function chisel(req: Request) {
     return new Response("");
 }
 EOF
 
 $CHISEL apply 2>&1 | $RMCOLOR|| true
-# CHECK: The module's source code could not be parsed: Expected ',', got ':' at file:///[[.*]]/endpoints/not-js.js:1:41
+# CHECK: The module's source code could not be parsed: Expected ',', got ':' at file:///[[.*]]/routes/not-js.js:1:41

--- a/cli/tests/integration_tests/lit_tests/permissions.deno
+++ b/cli/tests/integration_tests/lit_tests/permissions.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/mischief.ts"
+cat << EOF > "$TEMPDIR/routes/mischief.ts"
 export default async function (req: Request): Promise<string> {
     try {
         const status = await Deno.run({cmd: ["true"]}).status();

--- a/cli/tests/integration_tests/lit_tests/pol-loggedin.deno
+++ b/cli/tests/integration_tests/lit_tests/pol-loggedin.deno
@@ -3,16 +3,16 @@
 # RUN: sh -e @file
 
 cp examples/person.ts "$TEMPDIR/models"
-mkdir -p "$TEMPDIR/endpoints/a/b/c"
-cp examples/find.ts "$TEMPDIR/endpoints"
-cp examples/find.ts "$TEMPDIR/endpoints/a/b/c/findc1.ts"
-cp examples/find.ts "$TEMPDIR/endpoints/a/b/c/findc2.ts"
+mkdir -p "$TEMPDIR/routes/a/b/c"
+cp examples/find.ts "$TEMPDIR/routes"
+cp examples/find.ts "$TEMPDIR/routes/a/b/c/findc1.ts"
+cp examples/find.ts "$TEMPDIR/routes/a/b/c/findc2.ts"
 
-echo "$(sed 's|../models/person.ts|../../../../models/person.ts|' "$TEMPDIR/endpoints/a/b/c/findc1.ts")" > "$TEMPDIR/endpoints/a/b/c/findc1.ts"
-echo "$(sed 's|../models/person.ts|../../../../models/person.ts|' "$TEMPDIR/endpoints/a/b/c/findc2.ts")" > "$TEMPDIR/endpoints/a/b/c/findc2.ts"
+echo "$(sed 's|../models/person.ts|../../../../models/person.ts|' "$TEMPDIR/routes/a/b/c/findc1.ts")" > "$TEMPDIR/routes/a/b/c/findc1.ts"
+echo "$(sed 's|../models/person.ts|../../../../models/person.ts|' "$TEMPDIR/routes/a/b/c/findc2.ts")" > "$TEMPDIR/routes/a/b/c/findc2.ts"
 
 cat << EOF > "$TEMPDIR/policies/pol.yaml"
-endpoints:
+routes:
   - path: /find
     users: .*
   - path: /a/b/c/findc1
@@ -64,7 +64,7 @@ $CURL -H ChiselUID\:$id_als $CHISELD_HOST/dev/a/b/c/findc2
 # CHECK: HTTP/1.1 200 OK
 
 cat << EOF > "$TEMPDIR/policies/pol.yaml"
-endpoints:
+routes:
   - path: /find
     users: .*
   - path: /find
@@ -85,7 +85,7 @@ export class Blog extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/po.ts"
+cat << EOF > "$TEMPDIR/routes/po.ts"
 import { Post } from '../models/post.ts';
 import { loggedInUser, responseFromJson } from '@chiselstrike/api';
 export default async function (req: Request) {
@@ -133,7 +133,7 @@ $CURL -H ChiselUID\:$id_al $CHISELD_HOST/dev/po
 # CHECK: "text": "first post by al"
 # CHECK: "text": "second post by al"
 
-cat << EOF > "$TEMPDIR/endpoints/blogs.ts"
+cat << EOF > "$TEMPDIR/routes/blogs.ts"
 import { Blog, Post } from '../models/post.ts';
 import { loggedInUser, responseFromJson } from '@chiselstrike/api';
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/populate.deno
+++ b/cli/tests/integration_tests/lit_tests/populate.deno
@@ -3,9 +3,9 @@
 # RUN: sh -e @file
 
 cp examples/person.ts "$TEMPDIR/models"
-cp examples/store.ts "$TEMPDIR/endpoints/ins.ts"
+cp examples/store.ts "$TEMPDIR/routes/ins.ts"
 
-cat << EOF > "$TEMPDIR/endpoints/count.ts"
+cat << EOF > "$TEMPDIR/routes/count.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -64,7 +64,7 @@ export class Company extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/store_adalbrecht.ts"
+cat << EOF > "$TEMPDIR/routes/store_adalbrecht.ts"
 import { Company, Employee } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -85,7 +85,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/retrieve_nested.ts"
+cat << EOF > "$TEMPDIR/routes/retrieve_nested.ts"
 import { Company, Employee } from "../models/types.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/prefix.deno
+++ b/cli/tests/integration_tests/lit_tests/prefix.deno
@@ -2,14 +2,14 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/foo.ts"
+cat << EOF > "$TEMPDIR/routes/foo.ts"
 export default async function chisel(req: Request) {
     return new Response("foo with url " + req.url);
 }
 EOF
 
-mkdir "$TEMPDIR/endpoints/foo"
-cat << EOF > "$TEMPDIR/endpoints/foo/bar.ts"
+mkdir "$TEMPDIR/routes/foo"
+cat << EOF > "$TEMPDIR/routes/foo/bar.ts"
 export default async function chisel(req: Request) {
     return new Response("foo/bar with url " + req.url);
 }

--- a/cli/tests/integration_tests/lit_tests/reject-without-handler.deno
+++ b/cli/tests/integration_tests/lit_tests/reject-without-handler.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/err.ts"
+cat << EOF > "$TEMPDIR/routes/err.ts"
 export default async function (req: Request): Promise<Response> {
    let reject: (reason?: unknown) => void;
    const p = new Promise((_, r) => {

--- a/cli/tests/integration_tests/lit_tests/remove-endpoints.deno
+++ b/cli/tests/integration_tests/lit_tests/remove-endpoints.deno
@@ -2,22 +2,22 @@
 
 # RUN: sh -e @file
 
-mkdir -p "$TEMPDIR/endpoints"
+mkdir -p "$TEMPDIR/routes"
 cd "$TEMPDIR"
 
-cat << EOF > ./endpoints/end.ts
+cat << EOF > ./routes/end.ts
 export default async function chisel(req: Request) {
     return new Response("");
 }
 EOF
 
-cat << EOF > ./endpoints/endpoint.ts
+cat << EOF > ./routes/endpoint.ts
 export default async function chisel(req: Request) {
     return new Response("");
 }
 EOF
 
-cat << EOF > ./endpoints/endpo.ts
+cat << EOF > ./routes/endpo.ts
 export default async function chisel(req: Request) {
     return new Response("");
 }
@@ -33,7 +33,7 @@ $CURL -o - $CHISELD_HOST/dev/endpo
 $CURL -o - $CHISELD_HOST/dev/endpoint
 # CHECK: HTTP/1.1 200 OK
 
-rm ./endpoints/end.ts
+rm ./routes/end.ts
 
 $CHISEL apply
 
@@ -44,7 +44,7 @@ $CURL -o - $CHISELD_HOST/dev/endpo
 $CURL -o - $CHISELD_HOST/dev/endpoint
 # CHECK: HTTP/1.1 200 OK
 
-rm ./endpoints/endpoint.ts
+rm ./routes/endpoint.ts
 
 $CHISEL apply
 

--- a/cli/tests/integration_tests/lit_tests/restart-js.deno
+++ b/cli/tests/integration_tests/lit_tests/restart-js.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/test1.ts"
+cat << EOF > "$TEMPDIR/routes/test1.ts"
 import { getSecret } from "@chiselstrike/api"
 
 const issue728 = getSecret("somesecret");
@@ -30,7 +30,7 @@ $CHISEL restart
 
 # CHECK: Server restarted successfully.
 
-cat << EOF > "$TEMPDIR/endpoints/test2.js"
+cat << EOF > "$TEMPDIR/routes/test2.js"
 export default async function chisel(req) {
     return new Response(foo());
 }

--- a/cli/tests/integration_tests/lit_tests/return.deno
+++ b/cli/tests/integration_tests/lit_tests/return.deno
@@ -4,7 +4,7 @@
 
 cd "$TEMPDIR"
 
-cat << EOF > "$TEMPDIR/endpoints/return.ts"
+cat << EOF > "$TEMPDIR/routes/return.ts"
 type MyReturn = {
     a: string;
     b: number;
@@ -15,7 +15,7 @@ export default async function() : Promise<MyReturn> {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/undefined.ts"
+cat << EOF > "$TEMPDIR/routes/undefined.ts"
 type MyReturn = {
     a: string;
     b: number;
@@ -36,7 +36,7 @@ $CURL $CHISELD_HOST/dev/undefined && echo "UniqueString"
 # CHECK: HTTP/1.1 200 OK
 # CHECK: UniqueString
 
-cat << EOF > "$TEMPDIR/endpoints/return.ts"
+cat << EOF > "$TEMPDIR/routes/return.ts"
 type MyReturn = {
     a: string;
     b: number;

--- a/cli/tests/integration_tests/lit_tests/savemany.deno
+++ b/cli/tests/integration_tests/lit_tests/savemany.deno
@@ -13,7 +13,7 @@ export class Person extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/savemany.ts"
+cat << EOF > "$TEMPDIR/routes/savemany.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/savewrong.deno
+++ b/cli/tests/integration_tests/lit_tests/savewrong.deno
@@ -6,7 +6,7 @@ cp examples/person.ts "$TEMPDIR/models"
 
 cd "$TEMPDIR"
 
-cat << EOF > "$TEMPDIR/endpoints/store.ts"
+cat << EOF > "$TEMPDIR/routes/store.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -19,12 +19,12 @@ EOF
 
 $CHISEL apply 2>&1 | $RMCOLOR|| true
 
-# CHECK:  Error: could not compile endpoints
+# CHECK:  Error: Could not compile routes
 # CHECK:  Caused by:
 # CHECK:      Compilation failed:
-# CHECK:      endpoints/store.ts:5:12 - error TS2339: Property 'invalidField' does not exist on type 'Person'.
+# CHECK:      routes/store.ts:5:12 - error TS2339: Property 'invalidField' does not exist on type 'Person'.
 
-cat << EOF > "$TEMPDIR/endpoints/store.ts"
+cat << EOF > "$TEMPDIR/routes/store.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -46,8 +46,8 @@ $CURL -X POST $CHISELD_HOST/dev/store
 
 # CHECK: Ok984
 
-## Can't save auth types from user endpoints:
-cat << EOF > "$TEMPDIR/endpoints/store.ts"
+## Can't save auth types from user routes:
+cat << EOF > "$TEMPDIR/routes/store.ts"
 import { AuthUser } from '@chiselstrike/api';
 export default AuthUser.crud();
 EOF
@@ -68,7 +68,7 @@ export class Post extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/store.ts"
+cat << EOF > "$TEMPDIR/routes/store.ts"
 import { Post } from '../models/post.ts';
 export default Post.crud();
 EOF

--- a/cli/tests/integration_tests/lit_tests/secrets-update.deno
+++ b/cli/tests/integration_tests/lit_tests/secrets-update.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/secret.ts"
+cat << EOF > "$TEMPDIR/routes/secret.ts"
 import { getSecret } from "@chiselstrike/api"
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/secrets.deno
+++ b/cli/tests/integration_tests/lit_tests/secrets.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/secret.ts"
+cat << EOF > "$TEMPDIR/routes/secret.ts"
 import { getSecret } from "@chiselstrike/api"
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/select-order-with-pol.deno
+++ b/cli/tests/integration_tests/lit_tests/select-order-with-pol.deno
@@ -3,7 +3,7 @@
 # RUN: sh -e @file
 
 cp examples/person.ts "$TEMPDIR/models"
-cp examples/store.ts "$TEMPDIR/endpoints"
+cp examples/store.ts "$TEMPDIR/routes"
 
 cat << EOF > "$TEMPDIR/policies/pol.yaml"
 labels:
@@ -11,7 +11,7 @@ labels:
     transform: anonymize
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/query.ts"
+cat << EOF > "$TEMPDIR/routes/query.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/select-order.deno
+++ b/cli/tests/integration_tests/lit_tests/select-order.deno
@@ -3,9 +3,9 @@
 # RUN: sh -e @file
 
 cp examples/person.ts "$TEMPDIR/models"
-cp examples/store.ts "$TEMPDIR/endpoints"
+cp examples/store.ts "$TEMPDIR/routes"
 
-cat << EOF > "$TEMPDIR/endpoints/query.ts"
+cat << EOF > "$TEMPDIR/routes/query.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/simple-module.node
+++ b/cli/tests/integration_tests/lit_tests/simple-module.node
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/pad.ts"
+cat << EOF > "$TEMPDIR/routes/pad.ts"
 import * as handlebars from 'handlebars';
 const template = handlebars.compile('foo: {{ FOO }}');
 

--- a/cli/tests/integration_tests/lit_tests/sort.deno
+++ b/cli/tests/integration_tests/lit_tests/sort.deno
@@ -13,7 +13,7 @@ export class Person extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/store.ts"
+cat << EOF > "$TEMPDIR/routes/store.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -36,7 +36,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/get_sorted_by.ts"
+cat << EOF > "$TEMPDIR/routes/get_sorted_by.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -76,7 +76,7 @@ $CURL -o - "$CHISELD_HOST/dev/get_sorted_by?key=age&order=descending"
 
 ## ________________ Double sortBy ________________
 
-cat << EOF > "$TEMPDIR/endpoints/get_sorted.ts"
+cat << EOF > "$TEMPDIR/routes/get_sorted.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -99,7 +99,7 @@ $CURL -o - $CHISELD_HOST/dev/get_sorted
 
 ## ________________ sortBy filter ________________
 
-cat << EOF > "$TEMPDIR/endpoints/get_sorted.ts"
+cat << EOF > "$TEMPDIR/routes/get_sorted.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -123,7 +123,7 @@ $CURL -o - $CHISELD_HOST/dev/get_sorted
 
 ## ________________ sortBy take SortBy ________________
 
-cat << EOF > "$TEMPDIR/endpoints/get_sorted.ts"
+cat << EOF > "$TEMPDIR/routes/get_sorted.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -146,7 +146,7 @@ $CURL -o - $CHISELD_HOST/dev/get_sorted
 
 ## ________________ sortBy invalid key ________________
 
-cat << EOF > "$TEMPDIR/endpoints/get_sorted.ts"
+cat << EOF > "$TEMPDIR/routes/get_sorted.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -167,7 +167,7 @@ $CURL -o - $CHISELD_HOST/dev/get_sorted
 
 ## ________________ enforce sorting in Typescript ________________
 
-cat << EOF > "$TEMPDIR/endpoints/get_sorted.ts"
+cat << EOF > "$TEMPDIR/routes/get_sorted.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/store-nested-type.deno
+++ b/cli/tests/integration_tests/lit_tests/store-nested-type.deno
@@ -29,7 +29,7 @@ export class Company extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/store_adalbrecht.ts"
+cat << EOF > "$TEMPDIR/routes/store_adalbrecht.ts"
 import { Company, Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -54,7 +54,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/query_people.ts"
+cat << EOF > "$TEMPDIR/routes/query_people.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -66,7 +66,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/query_companies.ts"
+cat << EOF > "$TEMPDIR/routes/query_companies.ts"
 import { Company } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -98,7 +98,7 @@ $CURL -o - $CHISELD_HOST/dev/query_companies
 
 ## Test find + update
 
-cat << EOF > "$TEMPDIR/endpoints/update.ts"
+cat << EOF > "$TEMPDIR/routes/update.ts"
 import { Company, Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -124,7 +124,7 @@ $CURL -o - $CHISELD_HOST/dev/query_people
 
 ## Try saving the inner entity
 
-cat << EOF > "$TEMPDIR/endpoints/update.ts"
+cat << EOF > "$TEMPDIR/routes/update.ts"
 import { Company, Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -149,7 +149,7 @@ $CURL -o - $CHISELD_HOST/dev/query_people
 
 ## Try saving created entity
 
-cat << EOF > "$TEMPDIR/endpoints/update.ts"
+cat << EOF > "$TEMPDIR/routes/update.ts"
 import { Company, Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -177,7 +177,7 @@ $CURL -o - $CHISELD_HOST/dev/query_people
 # CHECK: HTTP/1.1 200 OK
 # CHECK: [(Many, Bianco), (Adalbrecht, Bond)]
 
-cat << EOF > "$TEMPDIR/endpoints/update.ts"
+cat << EOF > "$TEMPDIR/routes/update.ts"
 import { Company, Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/stream-db.deno
+++ b/cli/tests/integration_tests/lit_tests/stream-db.deno
@@ -16,7 +16,7 @@ export class Data extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/stream.ts"
+cat << EOF > "$TEMPDIR/routes/stream.ts"
 import { Data } from "../models/types.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/stream-error.deno
+++ b/cli/tests/integration_tests/lit_tests/stream-error.deno
@@ -10,7 +10,7 @@ export class Data extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/stream.ts"
+cat << EOF > "$TEMPDIR/routes/stream.ts"
 import { Data } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -33,7 +33,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/add.ts"
+cat << EOF > "$TEMPDIR/routes/add.ts"
 import { Data } from "../models/types.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/take-skip.deno
+++ b/cli/tests/integration_tests/lit_tests/take-skip.deno
@@ -13,7 +13,7 @@ export class Person extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/store.ts"
+cat << EOF > "$TEMPDIR/routes/store.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -32,7 +32,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/findall.ts"
+cat << EOF > "$TEMPDIR/routes/findall.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -43,7 +43,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/findtake.ts"
+cat << EOF > "$TEMPDIR/routes/findtake.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -55,7 +55,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/taketwice.ts"
+cat << EOF > "$TEMPDIR/routes/taketwice.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -68,7 +68,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/taketwicereverse.ts"
+cat << EOF > "$TEMPDIR/routes/taketwicereverse.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -81,7 +81,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/takecopies.ts"
+cat << EOF > "$TEMPDIR/routes/takecopies.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -98,7 +98,7 @@ export default async function chisel(req: Request) {
 EOF
 
 
-cat << EOF > "$TEMPDIR/endpoints/findfilter.ts"
+cat << EOF > "$TEMPDIR/routes/findfilter.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -136,7 +136,7 @@ $CURL $CHISELD_HOST/dev/takecopies
 # CHECK: [Glauber, Glauber, Jan]
 
 
-cat << EOF > "$TEMPDIR/endpoints/skip1.ts"
+cat << EOF > "$TEMPDIR/routes/skip1.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -148,7 +148,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/two_skips.ts"
+cat << EOF > "$TEMPDIR/routes/two_skips.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -161,7 +161,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/filter_skip.ts"
+cat << EOF > "$TEMPDIR/routes/filter_skip.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -174,7 +174,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/predicate_filter_skip.ts"
+cat << EOF > "$TEMPDIR/routes/predicate_filter_skip.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -187,7 +187,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/sort_skip_sort.ts"
+cat << EOF > "$TEMPDIR/routes/sort_skip_sort.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -200,7 +200,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/sort_take_skip.ts"
+cat << EOF > "$TEMPDIR/routes/sort_take_skip.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -213,7 +213,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/sort_skip_take.ts"
+cat << EOF > "$TEMPDIR/routes/sort_skip_take.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -226,7 +226,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/sort_skip_take_filter.ts"
+cat << EOF > "$TEMPDIR/routes/sort_skip_take_filter.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/toarray.deno
+++ b/cli/tests/integration_tests/lit_tests/toarray.deno
@@ -6,7 +6,7 @@ cp examples/person.ts "$TEMPDIR/models"
 
 cd "$TEMPDIR"
 
-cat << EOF > "$TEMPDIR/endpoints/store.ts"
+cat << EOF > "$TEMPDIR/routes/store.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {
@@ -24,7 +24,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/toarray.ts"
+cat << EOF > "$TEMPDIR/routes/toarray.ts"
 import { Person } from "../models/person.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/transaction.deno
+++ b/cli/tests/integration_tests/lit_tests/transaction.deno
@@ -9,7 +9,7 @@ export class Person extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/store_person.ts"
+cat << EOF > "$TEMPDIR/routes/store_person.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -27,7 +27,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/retrieve_all.ts"
+cat << EOF > "$TEMPDIR/routes/retrieve_all.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -39,7 +39,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/write_and_read.ts"
+cat << EOF > "$TEMPDIR/routes/write_and_read.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -83,7 +83,7 @@ $CURL -X POST $CHISELD_HOST/dev/write_and_read
 ## Test transaction completion on 501 returned by endpoint.
 ## -----------------------------------------------------------------------------
 
-cat << EOF > "$TEMPDIR/endpoints/write_and_501.ts"
+cat << EOF > "$TEMPDIR/routes/write_and_501.ts"
 import { Person } from "../models/types.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/type-evolve.deno
+++ b/cli/tests/integration_tests/lit_tests/type-evolve.deno
@@ -24,7 +24,7 @@ EOF
 $CHISEL apply
 # CHECK: Code was applied
 
-cat << EOF > "$TEMPDIR/endpoints/store.js"
+cat << EOF > "$TEMPDIR/routes/store.js"
 import { Evolving } from "../models/types.ts";
 
 export default async function chisel(req) {
@@ -35,7 +35,7 @@ export default async function chisel(req) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/find.js"
+cat << EOF > "$TEMPDIR/routes/find.js"
 import { Evolving } from "../models/types.ts";
 
 export default async function chisel(req) {
@@ -136,7 +136,7 @@ $CURL $CHISELD_HOST/dev/find
 
 ## Test field deletion with index
 
-cat << EOF > "$TEMPDIR/endpoints/test_indexes.ts"
+cat << EOF > "$TEMPDIR/routes/test_indexes.ts"
 import { Evolving } from "../models/types.ts";
 
 export default async function chisel(req: Request) {
@@ -161,13 +161,13 @@ export class Evolving extends ChiselEntity {
 }
 EOF
 
-rm $TEMPDIR/endpoints/test_indexes.ts
+rm $TEMPDIR/routes/test_indexes.ts
 
 $CHISEL apply
 # CHECK: Code was applied
 
 ### get / set helpers for the tests below
-cat << EOF > "$TEMPDIR/endpoints/get.ts"
+cat << EOF > "$TEMPDIR/routes/get.ts"
 import { Defaults } from "../models/defaults.ts";
 
 export default async function chisel(req: Request) {
@@ -175,7 +175,7 @@ export default async function chisel(req: Request) {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/set.ts"
+cat << EOF > "$TEMPDIR/routes/set.ts"
 import { Defaults } from "../models/defaults.ts";
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/unique.deno
+++ b/cli/tests/integration_tests/lit_tests/unique.deno
@@ -12,7 +12,7 @@ export class BlogPost extends ChiselEntity {
     content: string;
 }
 EOF
-cat << EOF > "$TEMPDIR/endpoints/post.ts"
+cat << EOF > "$TEMPDIR/routes/post.ts"
 import { BlogPost } from "../models/post.ts";
 import { responseFromJson } from "@chiselstrike/api";
 

--- a/cli/tests/integration_tests/lit_tests/upsert.deno
+++ b/cli/tests/integration_tests/lit_tests/upsert.deno
@@ -14,7 +14,7 @@ export class Person extends ChiselEntity {
 }
 EOF
 
-cat << EOF > "$TEMPDIR/endpoints/upsert.ts"
+cat << EOF > "$TEMPDIR/routes/upsert.ts"
 import { Person } from "../models/types.ts";
 import { responseFromJson } from "@chiselstrike/api"
 

--- a/cli/tests/integration_tests/lit_tests/url-query.deno
+++ b/cli/tests/integration_tests/lit_tests/url-query.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/title.ts"
+cat << EOF > "$TEMPDIR/routes/title.ts"
 const titles = {'glauber': 'CEO', 'dejan': 'CTO'}
 type keys = 'glauber' | 'dejan';
 

--- a/cli/tests/integration_tests/lit_tests/use-module.deno
+++ b/cli/tests/integration_tests/lit_tests/use-module.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/pad.ts"
+cat << EOF > "$TEMPDIR/routes/pad.ts"
 import indent from 'https://cdn.skypack.dev/pin/indent-string@v5.0.0-VgKPSgi4hUX5NbF4n3aC/mode=imports,min/optimized/indent-string.js'
 
 export default function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/use-ts-moduled.deno
+++ b/cli/tests/integration_tests/lit_tests/use-ts-moduled.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/pad.ts"
+cat << EOF > "$TEMPDIR/routes/pad.ts"
 import indent from 'https://deno.land/x/text_indent@v0.1.0/mod.ts';
 
 export default async function chisel(req: Request) {

--- a/cli/tests/integration_tests/lit_tests/versions.deno
+++ b/cli/tests/integration_tests/lit_tests/versions.deno
@@ -3,10 +3,10 @@
 # RUN: sh -e @file
 
 cp examples/person.ts "$TEMPDIR/models"
-cp examples/csv.ts examples/find.ts "$TEMPDIR/endpoints"
+cp examples/csv.ts examples/find.ts "$TEMPDIR/routes"
 
 cd "$TEMPDIR"
-cat << EOF > "endpoints/foo.js"
+cat << EOF > "routes/foo.js"
 export default async function my_req_func(req) {
     return new Response("v0");
 }
@@ -34,7 +34,7 @@ $CHISEL apply --version v0-_
 # CHECK: Code was applied
 
 
-cat << EOF > "endpoints/foo.js"
+cat << EOF > "routes/foo.js"
 export default async function my_req_func(req) {
     return new Response("v1");
 }
@@ -70,7 +70,7 @@ $CURL -o - $CHISELD_HOST/v1/find
 # CHECK: terry stone 100 true 5 jill lasalle 100 true 5
 
 cat << EOF > "$TEMPDIR/policies/pol.yaml"
-endpoints:
+routes:
   - path: /find
     users: .*
 EOF

--- a/cli/tests/integration_tests/lit_tests/worker.deno
+++ b/cli/tests/integration_tests/lit_tests/worker.deno
@@ -2,7 +2,7 @@
 
 # RUN: sh -e @file
 
-cat << EOF > "$TEMPDIR/endpoints/worker.js"
+cat << EOF > "$TEMPDIR/routes/worker.js"
 export default async function chisel(req) {
     const worker = new Worker('./bar.js', {type: 'module'});
     return new Response("worker");

--- a/cli/tests/integration_tests/rust_tests/array.rs
+++ b/cli/tests/integration_tests/rust_tests/array.rs
@@ -15,7 +15,7 @@ pub async fn test(c: TestContext) {
     "##,
     );
     c.chisel.write(
-        "endpoints/store.ts",
+        "routes/store.ts",
         r##"
         import { Foo } from "../models/types.ts";
         export default async function chisel(req: Request) {
@@ -29,7 +29,7 @@ pub async fn test(c: TestContext) {
     "##,
     );
     c.chisel.write(
-        "endpoints/get.ts",
+        "routes/get.ts",
         r##"
         import { Foo } from "../models/types.ts";
         export default async function chisel(req: Request) {
@@ -38,7 +38,7 @@ pub async fn test(c: TestContext) {
     "##,
     );
     c.chisel.write(
-        "endpoints/crud_foos.ts",
+        "routes/crud_foos.ts",
         r##"
         import { Foo } from "../models/types.ts";
         export default Foo.crud();

--- a/cli/tests/integration_tests/rust_tests/bad_filter.rs
+++ b/cli/tests/integration_tests/rust_tests/bad_filter.rs
@@ -4,7 +4,7 @@ use crate::framework::prelude::*;
 pub async fn test(c: TestContext) {
     c.chisel.copy_to_dir("examples/person.ts", "models");
     c.chisel.write(
-        "endpoints/query.ts",
+        "routes/query.ts",
         r##"
         import { Person } from "../models/person.ts";
 
@@ -21,6 +21,6 @@ pub async fn test(c: TestContext) {
 
     let mut output = c.chisel.apply_err().await;
     output.stderr
-        .read("endpoints/query.ts:6:53 - error TS2769: No overload matches this call.")
+        .read("routes/query.ts:6:53 - error TS2769: No overload matches this call.")
         .read("Argument of type '{ foo: string; }' is not assignable to parameter of type 'Partial<Person>'");
 }

--- a/cli/tests/integration_tests/rust_tests/endpoint_back_compat.rs
+++ b/cli/tests/integration_tests/rust_tests/endpoint_back_compat.rs
@@ -1,0 +1,38 @@
+use crate::framework::prelude::*;
+
+#[self::test(modules = Deno, optimize = Yes)]
+pub async fn test_deno(c: TestContext) {
+    test_modules(c, "deno").await
+}
+
+#[self::test(modules = Node, optimize = Yes)]
+pub async fn test_node(c: TestContext) {
+    test_modules(c, "node").await
+}
+
+async fn test_modules(c: TestContext, modules_str: &str) {
+    c.chisel.write(
+        "endpoints/hello.ts",
+        r##"
+        import { ChiselRequest } from "@chiselstrike/api";
+        export default async function(req: ChiselRequest) {
+            return ["hello"];
+        }
+        "##,
+    );
+
+    let chisel_toml = format!(
+        r##"
+        models = ["models"]
+        endpoints = ["endpoints"]
+        events = ["events"]
+        policies = ["policies"]
+        modules = "{}""##,
+        modules_str
+    );
+    c.chisel.write_unindent("Chisel.toml", &chisel_toml);
+
+    c.chisel.apply_ok().await;
+
+    assert_eq!(c.chisel.get_json("/dev/hello").await, json!(["hello"]));
+}

--- a/cli/tests/integration_tests/rust_tests/find.rs
+++ b/cli/tests/integration_tests/rust_tests/find.rs
@@ -1,5 +1,4 @@
 use crate::framework::prelude::*;
-use crate::framework::Chisel;
 
 async fn store_people(chisel: &Chisel) {
     chisel

--- a/cli/tests/integration_tests/rust_tests/find.rs
+++ b/cli/tests/integration_tests/rust_tests/find.rs
@@ -43,9 +43,9 @@ async fn store_people(chisel: &Chisel) {
 #[chisel_macros::test(modules = Deno, optimize = Both)]
 pub async fn find_many(c: TestContext) {
     c.chisel.copy_to_dir("examples/person.ts", "models");
-    c.chisel.copy_to_dir("examples/store.ts", "endpoints");
+    c.chisel.copy_to_dir("examples/store.ts", "routes");
     c.chisel.write(
-        "endpoints/find_many.ts",
+        "routes/find_many.ts",
         r##"
         import { ChiselRequest } from "@chiselstrike/api"
         import { Person } from "../models/person.ts";
@@ -122,9 +122,9 @@ pub async fn find_many(c: TestContext) {
 #[chisel_macros::test(modules = Deno, optimize = Both)]
 pub async fn find_one(c: TestContext) {
     c.chisel.copy_to_dir("examples/person.ts", "models");
-    c.chisel.copy_to_dir("examples/store.ts", "endpoints");
+    c.chisel.copy_to_dir("examples/store.ts", "routes");
     c.chisel.write(
-        "endpoints/find_one.ts",
+        "routes/find_one.ts",
         r##"
         import { ChiselRequest } from "@chiselstrike/api"
         import { Person } from "../models/person.ts";
@@ -203,8 +203,8 @@ pub async fn find_one(c: TestContext) {
 #[chisel_macros::test(modules = Deno, optimize = Both)]
 pub async fn find_by(mut c: TestContext) {
     c.chisel.copy_to_dir("examples/person.ts", "models");
-    c.chisel.copy_to_dir("examples/find_by.ts", "endpoints");
-    c.chisel.copy_to_dir("examples/store.ts", "endpoints");
+    c.chisel.copy_to_dir("examples/find_by.ts", "routes");
+    c.chisel.copy_to_dir("examples/store.ts", "routes");
 
     c.chisel.apply_ok().await;
 

--- a/cli/tests/integration_tests/rust_tests/http_import.rs
+++ b/cli/tests/integration_tests/rust_tests/http_import.rs
@@ -3,7 +3,7 @@ use crate::framework::prelude::*;
 #[chisel_macros::test(modules = Node)]
 pub async fn test(c: TestContext) {
     c.chisel.write(
-        "endpoints/error.ts",
+        "routes/error.ts",
         r##"
         import { foo } from "https://foo.bar";
 
@@ -16,6 +16,6 @@ pub async fn test(c: TestContext) {
     let mut output = c.chisel.apply_err().await;
     output
         .stderr
-        .read("could not import endpoint code into the runtime")
+        .read("Could not apply the provided code")
         .read("chiseld cannot load module https://foo.bar/ at runtime");
 }

--- a/cli/tests/integration_tests/rust_tests/policies.rs
+++ b/cli/tests/integration_tests/rust_tests/policies.rs
@@ -14,10 +14,10 @@ async fn fetch_person(chisel: &Chisel) -> serde_json::Value {
 #[chisel_macros::test(modules = Deno, optimize = Both)]
 pub async fn policies(c: TestContext) {
     c.chisel.copy_to_dir("examples/person.ts", "models");
-    c.chisel.copy_to_dir("examples/store.ts", "endpoints");
+    c.chisel.copy_to_dir("examples/store.ts", "routes");
 
     c.chisel.write(
-        "endpoints/find_person.ts",
+        "routes/find_person.ts",
         r##"
         import { Person } from "../models/person.ts";
         export default async function chisel(req: Request) {
@@ -171,7 +171,7 @@ pub async fn policies(c: TestContext) {
     "##,
     );
     c.chisel.write(
-        "endpoints/companies.ts",
+        "routes/companies.ts",
         r##"
         import { crud } from "@chiselstrike/api";
         import { Company } from "../models/company.ts";

--- a/cli/tests/integration_tests/rust_tests/token_auth.rs
+++ b/cli/tests/integration_tests/rust_tests/token_auth.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 pub async fn test(c: TestContext) {
     c.chisel.write(
         "policies/p.yaml",
-        r##"endpoints:
+        r##"routes:
  - path: /
    mandatory_header: { name: header33, secret_value_ref: TOKEN33 }"##,
     );
@@ -39,7 +39,7 @@ pub async fn test(c: TestContext) {
     // Header spec references non-existing secret.
     c.chisel.write(
         "policies/p.yaml",
-        r##"endpoints:
+        r##"routes:
  - path: /
    mandatory_header: { name: header33, secret_value_ref: WXYZ }"##,
     );
@@ -54,7 +54,7 @@ pub async fn test(c: TestContext) {
     // Repeated path for header auth.
     c.chisel.write(
         "policies/p.yaml",
-        r##"endpoints:
+        r##"routes:
  - path: /
    mandatory_header: { name: header33, secret_value_ref: TOKEN33 }
  - path: /
@@ -70,7 +70,7 @@ pub async fn test(c: TestContext) {
     // Unparsable header.
     c.chisel.write(
         "policies/p.yaml",
-        r##"endpoints:
+        r##"routes:
  - path: /
    mandatory_header: aaabbb"##,
     );
@@ -84,7 +84,7 @@ pub async fn test(c: TestContext) {
     // Header without name.
     c.chisel.write(
         "policies/p.yaml",
-        r##"endpoints:
+        r##"routes:
  - path: /
    mandatory_header: { secret_value_ref: TOKEN33 }"##,
     );
@@ -98,7 +98,7 @@ pub async fn test(c: TestContext) {
     // Non-string secret_value_ref.
     c.chisel.write(
         "policies/p.yaml",
-        r##"endpoints:
+        r##"routes:
  - path: /
    mandatory_header: { name: header33, secret_value_ref: 99 }"##,
     );
@@ -112,7 +112,7 @@ pub async fn test(c: TestContext) {
     // Only PUTs and GETs require a header.
     c.chisel.write(
         "policies/p.yaml",
-        r##"endpoints:
+        r##"routes:
  - path: /
    mandatory_header: { name: header33, secret_value_ref: TOKEN33, only_for_methods: [ PUT, GET ] } "##,
     );

--- a/docusaurus/docs/InDepth/advanced-data.md
+++ b/docusaurus/docs/InDepth/advanced-data.md
@@ -29,14 +29,14 @@ export class BlogPost extends ChiselEntity {
 }
 ```
 
-We can now code an endpoint that will store a post, but posts must
+We can now code a request handler that will store a post, but posts must
 have unique URLs:
 
-```typescript title="my-backend/endpoints/post.ts"
+```typescript title="my-backend/routes/post.ts"
 import { BlogPost } from "../models/BlogPost";
 import { responseFromJson } from "@chiselstrike/api";
 
-export default async function chisel(req) {
+export default async function (req) {
     if (req.method == 'POST') {
         const payload = await req.json();
         const content = payload["content"] ?? "";
@@ -182,7 +182,7 @@ export class Custom extends ChiselEntity {
 ```
 
 But doing that is not enough. The field exists, but we don't want to add
-custom logic into endpoints to handle it. We want to make sure it is always
+custom logic into request handlers to handle it. We want to make sure it is always
 updated when we save the model.
 
 To do that, we can override the `save()` method of `ChiselEntity`. That is the method

--- a/docusaurus/docs/InDepth/chisel-cli.md
+++ b/docusaurus/docs/InDepth/chisel-cli.md
@@ -37,7 +37,7 @@ TODO
 
 ### `chisel describe`
 
-The `chisel describe` command displays the current state of the running ChiselStrike server: models, endpoints, and policies.
+The `chisel describe` command displays the current state of the running ChiselStrike server: models, routes, and policies.
 
 ### `chisel dev`
 
@@ -131,7 +131,7 @@ The CLI parses a manifest file `Chisel.toml`, which has the following format:
 
 ```toml
 models = ["models"]
-endpoints = ["endpoints"]
+routess = ["routes"]
 policies = ["policies"]
 ```
 
@@ -141,7 +141,7 @@ The `chiseld` program is the ChiselStrike server daemon. For development purpose
 
 #### `--api-listen-addr [ADDR]`
 
-The API listen address of the server. This is the address that servers ChiselStrike endpoints.
+The API listen address of the server. This is the address that serves ChiselStrike API.
 
 #### `--data-db-uri [URI]`
 

--- a/docusaurus/docs/InDepth/cursors.md
+++ b/docusaurus/docs/InDepth/cursors.md
@@ -11,7 +11,7 @@ for building queries.
 
 For example, the `findOne()` example could be written using the cursor-based API as:
 
-```typescript title="my-backend/endpoints/find-one-cursor.ts"
+```typescript title="my-backend/routes/find-one-cursor.ts"
 import { responseFromJson } from "@chiselstrike/api"
 import { User } from "../models/models"
 
@@ -22,7 +22,7 @@ export default async function (req) {
 }
 ```
 
-You can invoke the `/dev/find-one-cursor` endpoint with:
+You can invoke the `POST /dev/find-one-cursor` endpoint with:
 
 ```bash
 curl -d '{ "email": "alice@mit.edu" }' localhost:8080/dev/find-one-cursor
@@ -73,8 +73,8 @@ The second overload takes a restrictions-object parameter. It allows you to filt
 ## Notes On Transactions
 
 ChiselStrke currently implements implicit transactional evaluation. A transaction is created before ChiselStrike
-starts evaluating your endpoint and is automatically committed after your endpoint ends and we generate
-the HTTP response. In case your endpoint returns a stream, any database-related operation done within
+starts evaluating your request handler and is automatically committed after your handler ends and we generate
+the HTTP response. If your handler returns a stream, any database-related operation done within
 stream-generation code will happen outside of the transaction and can result in a crash.
 
 If your code crashes or explicitly throws an exception that is not caught, ChiselStrike rolls back the

--- a/docusaurus/docs/InDepth/login.md
+++ b/docusaurus/docs/InDepth/login.md
@@ -28,7 +28,7 @@ NextAuth user ID.
 
 The ChiselStrike backend keeps track of your website's users via a
 builtin type called AuthUser.  When a user logs in for the first
-time, a new AuthUser entity is added.  And when an endpoint is
+time, a new AuthUser entity is added.  And when a request handler is
 executed, it has access to this builtin type.
 
 One interesting thing to do is have AuthUser-typed fields in your
@@ -50,7 +50,7 @@ returns the AuthUser object corresponding to the user currently
 logged in (or `undefined` if no one is logged in).  This works, for
 example:
 
-```typescript title="my-backend/endpoints/example.ts"
+```typescript title="my-backend/routes/example.ts"
 import { BlogComment } from '../models/models.ts';
 import { loggedInUser, responseFromJson } from '@chiselstrike/api';
 export default async function (req) {

--- a/docusaurus/docs/InDepth/pol.md
+++ b/docusaurus/docs/InDepth/pol.md
@@ -60,7 +60,7 @@ Policy defined for label pii
 
 And now notice how the output of the `comments` endpoint changes.
 
-If you invoke the `/dev/comments` endpoint with:
+If send a `GET /dev/comments` request with:
 
 ```bash
 curl -s localhost:8080/dev/comments
@@ -96,7 +96,7 @@ The `curl` command reports:
 ```
 
 The `pii` fields were anonymized!  It is not possible for any
-endpoint code to accidentally read `pii` data, eliminating human
+request handler code to accidentally read `pii` data, eliminating human
 errors from the process.
 
 Another transformation you can do is omitting a field altogether.  If you modify
@@ -108,7 +108,7 @@ labels:
     transform: omit
 ```
 
-your endpoints will not see the existence of any `@pii` fields:
+your code will not see the existence of any `@pii` fields:
 
 ```bash
 curl -s localhost:8080/dev/comments
@@ -141,7 +141,7 @@ will return
 
 ## Policy Exceptions
 
-Here is how you can except the `comments` endpoint from automatic
+Here is how you can except request handlers under the `comments` path from automatic
 data anonymization.  Please edit the file
 `my-backend/policies/pol.yml` like this:
 
@@ -154,11 +154,11 @@ labels:
 
 The `except_uri` key lets you specify a path that's exempt from the
 transformation policy being defined.  In this case, it matches exactly
-the `comments` endpoint.  But in general, the value can be a path
-prefix and even a regular expression; any matching endpoints will be
+the `comments` request handler.  But in general, the value can be a path
+prefix and even a regular expression; any matching requests will be
 exempt from the policy.
 
-If you now query the `/dev/comments` endpoint:
+If you now send the `GET /dev/comments` request:
 
 ```bash
 curl -s localhost:8080/dev/comments
@@ -193,26 +193,25 @@ The `curl` command reports:
 }
 ```
 
-As you can see, this endpoint now operates with the raw, untransformed
+As you can see, this request handler now operates with the raw, untransformed
 data.
 
 ## Policies for Logged-in Users
 
 ChiselStrike supports [having users log into your dynamic
-website](./login.md).  It even lets you restrict endpoint access by
+website](./login.md).  It even lets you restrict access to HTTP routes by
 user.
 
-To restrict who can access the `comments` endpoint, please edit the
+To restrict who can access the `comments` path, please edit the
 file `my-backend/policies/pol.yml` like this:
 
 ```yaml title="my-backend/policies/pol.yml"
-endpoints:
+routes:
   - path: /comments
     users: ^admin@example.com$
 ```
 
-This says that only the user `admin@example.com` can access the `/comments`
-endpoint.
+This says that only the user `admin@example.com` can send requests to `/comments`.
 
 :::note
 We currently match `users` against the user's email -- the only field
@@ -220,13 +219,13 @@ NextAuth guarantees to be unique.  Your feedback is welcome as we
 evolve this aspect of our product.
 :::
 
-The `endpoints` section can have any number of `path` items, each
+The `routes` section can have any number of `path` items, each
 affecting a different path prefix.  The `users` attribute is a regular
 expression that the logged-in user's email must match in order to access
 endpoints under the given path.
 
 `path` values may overlap, in which case longer overrides shorter.
-When you attempt to access an endpoint, the longest specified prefix
+When you attempt to send a request, the longest specified prefix
 of its path dictates which users may access it.  Although multiple
 `path` entries may overlap, they must not be identical.
 
@@ -263,7 +262,7 @@ labels:
 The `match_login` transformation compares fields labeled with
 `protect` (if they are of AuthUser type) to the value of
 `loggedInUser()`.  When the field value doesn't match, the row is
-ignored.  So in this case, when endpoints read BlogComment entities,
+ignored.  So in this case, when request handlers read BlogComment entities,
 they will see only the rows whose `author` matches the currently
 logged-in user.
 

--- a/docusaurus/docs/InDepth/routing.md
+++ b/docusaurus/docs/InDepth/routing.md
@@ -2,20 +2,20 @@
 
 Like [Gatsby](https://www.gatsbyjs.com/docs/reference/routing/creating-routes/#define-routes-in-srcpages) and
 [NextJS](https://nextjs.org/docs/routing/introduction#nested-routes), ChiselStrike routes incoming requests by
-matching the URL path against the endpoint-code path.  
+matching the URL path against the files in the `routes/` directory.
 
-When you create a file `endpoints/posts.ts`, the URL
-`/dev/posts` invokes it.  When you create a file `endpoints/new/york/city.ts`, the URL `/dev/new/york/city`
+When you create a file `routes/posts.ts`, the URL
+`/dev/posts` invokes it.  When you create a file `routes/new/york/city.ts`, the URL `/dev/new/york/city`
 invokes it.
 
 When there is no exact match, ChiselStrike uses the longest
-prefix of the URL path that matches an existing endpoint definition.  In the previous example, the URL
-`/dev/new/york/city/manhattan/downtown` will also be handled by `endpoints/new/york/city.ts` (assuming no
-other endpoints).
+prefix of the URL path that matches an existing route definition. In the previous example, the URL
+`/dev/new/york/city/manhattan/downtown` will also be handled by `routes/new/york/city.ts` (assuming no
+other routes).
 
-This routing procedure enables endpoints to handle both the 'plural' and 'single' versions of themselves. 
+This routing procedure enables request handlers to handle both the 'plural' and 'single' versions of themselves. 
 
-For example, the above endpoint `my-backend/endpoints/comments.ts` will be invoked when you access a specific comment, eg, at
+For example, the above file `my-backend/routes/comments.ts` will be invoked when you access a specific comment, e.g., at
 `/dev/comments/1234-abcd-5678-efgh`.  The `BlogComment.crud()` will parse the URL and understand that a single
 collection element is being accessed.
 

--- a/docusaurus/docs/InDepth/secrets.md
+++ b/docusaurus/docs/InDepth/secrets.md
@@ -29,7 +29,7 @@ This must be explicitly named ".env", it's not a file with a ".env" suffix.
 
 Now those values are available as objects from your typescript code:
 
-```typescript title="my-backend/endpoints/secrets.ts"
+```typescript title="my-backend/routes/secrets.ts"
 import { getSecret, responseFromJson } from "@chiselstrike/api"
 
 export default async function (req) {

--- a/docusaurus/docs/InDepth/versions.md
+++ b/docusaurus/docs/InDepth/versions.md
@@ -1,7 +1,7 @@
 # API Versioning
 
-Now that we have defined our endpoints, models, and policies, it is time to spice things up.
-You may have noticed that all endpoints created by ChiselStrike have `/dev/` as part of the route.
+Now that we have defined our routes, models, and policies, it is time to spice things up.
+You may have noticed that all routes created by ChiselStrike start with `/dev/`.
 That's because ChiselStrike makes API versioning a first-class citizen: everything you deploy to
 ChiselStrike is deployed as part of a _version_.
 
@@ -35,7 +35,7 @@ Model defined: BlogComment
 End point defined: /experimental/comments
 ```
 
-Now let's try comparing the two endpoints.
+Now let's try comparing the two versions.
 
 If we invoke the new `experimental` API version:
 
@@ -49,7 +49,7 @@ The `curl` command reports no data:
 []
 ```
 
-However, we can still invoke the old `dev` version of the endpoint:
+However, we can still invoke the old `dev` version of the code:
 
 ```bash
 curl localhost:8080/dev/comments
@@ -78,7 +78,7 @@ chisel populate --version experimental --from dev
 Assuming `experimental` is empty before the population starts, you should see that the `experimental` version
 now holding the same data as `dev`.
 
-If you invoke the `/experimental/comments` endpoint:
+If you invoke the `GET /experimental/comments` endpoint:
 
 ```bash
 curl localhost:8080/experimental/comments

--- a/docusaurus/docs/Intro/data-access.md
+++ b/docusaurus/docs/Intro/data-access.md
@@ -1,6 +1,6 @@
 # Data Access
 
-We're already previewed working with data in [Getting Started](first). Let's explain the data system a bit more.
+We've already previewed working with data in [Getting Started](first). Let's explain the data system a bit more.
 
 ## Defining Models
 
@@ -36,10 +36,11 @@ The ChiselStrike runtime will detect changes in the `models/` directory and make
 ## Saving Objects
 
 The `ChiselEntity` base class that our `User` entity extends provides a `save()` method that will save an object to the datastore.
+
 Here is an example endpoint demo:
 
 <!-- FIXME : update the example below to return JSON -->
-```typescript title="my-backend/endpoints/create.ts"
+```typescript title="my-backend/routes/create.ts"
 import { responseFromJson } from "@chiselstrike/api"
 import { User } from "../models/User"
 
@@ -54,7 +55,7 @@ export default async function (req) {
 }
 ```
 
-We can now create a user through a REST post!:
+We can now create a user using a POST request:
 
 ```bash
 curl -d '{"username": "alice", "email": "alice@example.com", "city": "Cambridge" }' localhost:8080/dev/create
@@ -65,7 +66,7 @@ and we'll get the following response:
 <!-- FIXME : JSON -->
 
 ```console
-{"username": "alice", "email": "alice@example.com", "city": "Cambridge", "id": "Created user alice with id 72325865-1887-4604-a127-025919ca281c" }
+{"username": "alice", "email": "alice@example.com", "city": "Cambridge", "id": "72325865-1887-4604-a127-025919ca281c" }
 ```
 
 As discussed in the [Getting Started](Intro/first.md) section, the ChiselStrike runtime assigns an `id` to your entity automatically upon `save()`. If you want to _update_ your entity, you need know its `id`.  The ID can be returned when you create the object, or you can query for it.
@@ -73,9 +74,9 @@ As discussed in the [Getting Started](Intro/first.md) section, the ChiselStrike 
 <!-- FIXME: need a Section "Updating Objects" -->
 <!-- FIXME: need a Section "Deleting Objects" -->
 
-Still, you are not technically limited to making every endpoint follow REST principles by using ids. For example, you could write the following 'update' endpoint that recieves the same JSON, but finds the `User` entity based on the provided `username`:
+Still, you are not technically limited to making every HTTP route follow REST principles by using ids. For example, you could write the following 'update' route that recieves the same JSON, but finds the `User` entity based on the provided `username`:
 
-```typescript title="my-backend/endpoints/update.ts"
+```typescript title="my-backend/routes/update.ts"
 import { responseFromJson } from "@chiselstrike/api";
 import { User } from "../models/User";
 
@@ -106,9 +107,9 @@ In some of the above examples, we've previewed how to query objects using the `U
 
 There are two search methods `findOne()` and `findMany()` for querying.
 
-For example, to query one entity with a given `username`, we could use the following example code in an endpoint:
+For example, to query one entity with a given `username`, we could use the following code:
 
-```typescript title="my-backend/endpoints/find-one.ts"
+```typescript title="my-backend/routes/find-one.ts"
 import { responseFromJson } from "@chiselstrike/api"
 import { User } from "../models/User"
 
@@ -119,7 +120,7 @@ export default async function (req) {
 }
 ```
 
-and query it with `/dev/find-one`:
+and query it with `POST /dev/find-one`:
 
 ```bash
 curl -d '{ "email": "alice@mit.edu" }' localhost:8080/dev/find-one
@@ -135,7 +136,7 @@ and see `curl` report:
 
 To find multiple entities, use the `findMany()` method:
 
-```typescript title="my-backend/endpoints/find-many.ts"
+```typescript title="my-backend/routes/find-many.ts"
 import { responseFromJson } from "@chiselstrike/api"
 import { User } from "../models/User"
 
@@ -146,7 +147,7 @@ export default async function (req) {
 }
 ```
 
-and query it with `/dev/find-many`:
+and query it with `POST /dev/find-many`:
 
 ```bash
 curl -d '{ "city": "Cambridge" }' localhost:8080/dev/find-many
@@ -164,7 +165,7 @@ We can create more entities with:
 curl -d '{"username": "bob", "email": "bob@example.com", "city": "Cambridge" }' localhost:8080/dev/create
 ```
 
-We can then invoke the `/dev/find-many` endpoint again:
+We can then invoke the `POST /dev/find-many` route again:
 
 ```bash
 curl -d '{ "city": "Cambridge" }' localhost:8080/dev/find-many
@@ -179,7 +180,7 @@ which returns additional results:
 :::note
 `findMany` can be called with a predicate lambda as well:
 
-```typescript title="my-backend/endpoints/find-many.ts"
+```typescript title="my-backend/routes/find-many.ts"
 import { responseFromJson } from "@chiselstrike/api"
 import { User } from "../models/User"
 
@@ -192,7 +193,7 @@ export default async function (req) {
 
 You can also pass an empty restrictions object to `findMany()` and you will get all the entities of that type.
 
-To do that, invoke the `/dev/find-many` test endpoint with an empty JSON document:
+To do that, invoke the `POST /dev/find-many` route with an empty JSON document:
 
 ```bash
 curl -d '{}' localhost:8080/dev/find-many
@@ -223,7 +224,7 @@ The documentation robots are at work. Examples coming soon!
 Entities are deleted using the `ChiselEntity.delete(restriction)` method. For
 example, with the `User` entity defined earlier, you delete an entity as follows:
 
-```typescript title="my-backend/endpoints/delete.ts"
+```typescript title="my-backend/routes/delete.ts"
 import { User } from "../models/User.ts"
 
 export default async function (req: Request) {

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -24,7 +24,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'Introduction',
-      items: ['Intro/welcome', 'Intro/first', 'Intro/endpoints', 'Intro/data-access', 'Intro/streaming', 'Intro/deploying', 'Intro/debugging' ]
+      items: ['Intro/welcome', 'Intro/first', 'Intro/routes', 'Intro/data-access', 'Intro/streaming', 'Intro/deploying', 'Intro/debugging' ]
     },
     {
       type: 'category',

--- a/packages/create-chiselstrike-app/index.ts
+++ b/packages/create-chiselstrike-app/index.ts
@@ -34,13 +34,13 @@ function run(projectDirectory: string, chiselVersion: string) {
         } ...`,
     );
 
-    const endpointsPath = path.join(projectDirectory, "endpoints");
+    const routesPath = path.join(projectDirectory, "routes");
     const eventsPath = path.join(projectDirectory, "events");
     const modelsPath = path.join(projectDirectory, "models");
     const policiesPath = path.join(projectDirectory, "policies");
 
     fs.mkdirSync(path.join(projectDirectory, ".vscode"));
-    fs.mkdirSync(endpointsPath);
+    fs.mkdirSync(routesPath);
     fs.mkdirSync(eventsPath);
     fs.closeSync(fs.openSync(path.join(eventsPath, ".gitkeep"), "w"));
     fs.mkdirSync(modelsPath);
@@ -83,11 +83,11 @@ function run(projectDirectory: string, chiselVersion: string) {
     );
     fs.copyFileSync(
         path.join(__dirname, "template", "hello.ts"),
-        path.join(projectDirectory, "endpoints", "hello.ts"),
+        path.join(projectDirectory, "routes", "hello.ts"),
     );
     fs.copyFileSync(
         path.join(__dirname, "template", "hello.ts"),
-        path.join(projectDirectory, "endpoints", "hello.ts"),
+        path.join(projectDirectory, "routes", "hello.ts"),
     );
     fs.copyFileSync(
         path.join(__dirname, "template", "gitignore"),
@@ -108,7 +108,7 @@ if (os.type() == "Windows_NT") {
     );
     console.log("");
     console.log(
-        "Please create your project in an ext4 filesystem (like the $HOME folder) to support hot reloading of endpoints.",
+        "Please create your project in an ext4 filesystem (like the $HOME folder) to support hot reloading of routes.",
     );
     console.log("");
     console.log(

--- a/packages/create-chiselstrike-app/template/Chisel.toml
+++ b/packages/create-chiselstrike-app/template/Chisel.toml
@@ -1,4 +1,4 @@
 models = ["models"]
-endpoints = ["endpoints"]
+routes = ["routes"]
 events = ["events"]
 policies = ["policies"]

--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -43,7 +43,7 @@ async fn add_crud_endpoint_for_type(
 ) -> Result<()> {
     let mut sources = HashMap::new();
     sources.insert(
-        format!("/__chiselstrike/endpoints/auth/{}", endpoint_name),
+        format!("/__chiselstrike/routes/auth/{}", endpoint_name),
         format!(
             r#"
 import {{ ChiselEntity }} from "@chiselstrike/api"

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -1572,7 +1572,7 @@ fn get() -> RcMut<DenoService> {
 }
 
 pub fn endpoint_path_from_source_path(path: &str) -> String {
-    // The source path format is /api_version/endpoints/rest.js. The endpoint is /api_version/rest.
+    // The source path format is /api_version/routes/rest.js. The endpoint is /api_version/rest.
     let mut iter = path.splitn(4, '/');
     let api_version = iter.nth(1).unwrap();
     let rest = iter.nth(1).unwrap();
@@ -1602,7 +1602,7 @@ pub async fn compile_endpoints(sources: HashMap<String, String>) -> Result<()> {
                 continue;
             }
             match path.split('/').nth(2) {
-                Some("endpoints") => {
+                Some("routes") => {
                     let path = without_extension(&path);
                     let url = Url::parse(&format!("file://{}", path)).unwrap();
                     code_map.insert(url, code);

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -1602,7 +1602,7 @@ pub async fn compile_endpoints(sources: HashMap<String, String>) -> Result<()> {
                 continue;
             }
             match path.split('/').nth(2) {
-                Some("routes") => {
+                Some("routes") | Some("endpoints") => {
                     let path = without_extension(&path);
                     let url = Url::parse(&format!("file://{}", path)).unwrap();
                     code_map.insert(url, code);

--- a/server/src/internal.rs
+++ b/server/src/internal.rs
@@ -38,7 +38,7 @@ async fn webapply(body: Body, rpc_addr: &SocketAddr) -> Result<Response<Body>> {
     let body: WebUIPostBody = serde_json::from_slice(&hyper::body::to_bytes(body).await?)?;
     let mut client = ChiselRpcClient::connect(format!("http://{}", rpc_addr)).await?;
     let mut endpoints = HashMap::new();
-    endpoints.insert("endpoints/ep1.js".to_string(), body.endpoint);
+    endpoints.insert("routes/ep1.js".to_string(), body.endpoint);
     client
         .apply(tonic::Request::new(ChiselApplyRequest {
             types: vec![],

--- a/server/src/policies.rs
+++ b/server/src/policies.rs
@@ -245,18 +245,18 @@ impl VersionPolicy {
                     None => {}
                 };
             }
-            for endpoint in config["endpoints"]
+            for route in config["routes"]
                 .as_vec()
                 .get_or_insert(&[].into())
                 .iter()
             {
-                if let Some(path) = endpoint["path"].as_str() {
-                    if let Some(users) = endpoint["users"].as_str() {
+                if let Some(path) = route["path"].as_str() {
+                    if let Some(users) = route["users"].as_str() {
                         policies
                             .user_authorization
                             .add(path, regex::Regex::new(users)?)?;
                     }
-                    let header = &endpoint["mandatory_header"];
+                    let header = &route["mandatory_header"];
                     match header {
                         Yaml::BadValue => {}
                         Yaml::Hash(_) => {

--- a/server/src/policies.rs
+++ b/server/src/policies.rs
@@ -245,11 +245,7 @@ impl VersionPolicy {
                     None => {}
                 };
             }
-            for route in config["routes"]
-                .as_vec()
-                .get_or_insert(&[].into())
-                .iter()
-            {
+            for route in config["routes"].as_vec().get_or_insert(&[].into()).iter() {
                 if let Some(path) = route["path"].as_str() {
                     if let Some(users) = route["users"].as_str() {
                         policies

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -243,7 +243,9 @@ impl RpcService {
 
             sources.insert(format!("/{}/{}", api_version, path), code.clone());
             let path = without_extension(&path);
-            if let Some(path) = path.strip_prefix("routes/") {
+            if let Some(path) = path.strip_prefix("routes/")
+                .or_else(|| path.strip_prefix("endpoints/"))
+            {
                 let path = format!("/{}/{}", api_version, path);
                 endpoint_paths.push(path);
             }
@@ -450,7 +452,8 @@ impl ChiselRpc for RpcService {
             let mut endpoint_defs = vec![];
             let version_path_str = format!("/{}/", api_version);
             for (path, _) in state.sources.iter() {
-                if path.split('/').nth(2) != Some("routes") {
+                let dir_name = path.split('/').nth(2);
+                if dir_name != Some("routes") || dir_name != Some("endpoints") {
                     continue;
                 }
                 let path = endpoint_path_from_source_path(path);

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -243,7 +243,8 @@ impl RpcService {
 
             sources.insert(format!("/{}/{}", api_version, path), code.clone());
             let path = without_extension(&path);
-            if let Some(path) = path.strip_prefix("routes/")
+            if let Some(path) = path
+                .strip_prefix("routes/")
                 .or_else(|| path.strip_prefix("endpoints/"))
             {
                 let path = format!("/{}/{}", api_version, path);

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -243,7 +243,7 @@ impl RpcService {
 
             sources.insert(format!("/{}/{}", api_version, path), code.clone());
             let path = without_extension(&path);
-            if let Some(path) = path.strip_prefix("endpoints/") {
+            if let Some(path) = path.strip_prefix("routes/") {
                 let path = format!("/{}/{}", api_version, path);
                 endpoint_paths.push(path);
             }
@@ -266,7 +266,7 @@ impl RpcService {
         state
             .send_command(cmd)
             .await
-            .context("could not import endpoint code into the runtime")?;
+            .context("Could not apply the provided code")?;
 
         anyhow::ensure!(
             "__chiselstrike" != &api_version,
@@ -450,7 +450,7 @@ impl ChiselRpc for RpcService {
             let mut endpoint_defs = vec![];
             let version_path_str = format!("/{}/", api_version);
             for (path, _) in state.sources.iter() {
-                if path.split('/').nth(2) != Some("endpoints") {
+                if path.split('/').nth(2) != Some("routes") {
                     continue;
                 }
                 let path = endpoint_path_from_source_path(path);

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -161,7 +161,7 @@ pub async fn add_endpoints(
 
     for path in sources.keys() {
         // FIXME: make this symmetric with apply_aux() logic.
-        if path.contains("/routes/") {
+        if path.contains("/routes/") || path.contains("/endpoints/") {
             let path = deno::endpoint_path_from_source_path(path);
             activate_endpoint(&path).await?;
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -161,7 +161,7 @@ pub async fn add_endpoints(
 
     for path in sources.keys() {
         // FIXME: make this symmetric with apply_aux() logic.
-        if path.contains("/endpoints/") {
+        if path.contains("/routes/") {
             let path = deno::endpoint_path_from_source_path(path);
             activate_endpoint(&path).await?;
 


### PR DESCRIPTION
PR https://github.com/chiselstrike/chiselstrike/pull/1618 replaces the concept of "endpoint" with the concept of a "route", so let's change this now, before the main PR lands.

Notably, this changes the default directory "endpoints/" to "routes/". Unfortunately, even though the directory appears to be configurable in "Chisel.toml", it is in fact hard-coded in several places, so we have to hack around this to retain backward compatibility.

This change also affects some error messages, which are brought in alignment with https://github.com/chiselstrike/chiselstrike/pull/1618 by this commit.

This is a spin-off from #1618.