### PR TITLE
Remove the `Chisel` global variable (from #1618)

### DIFF
--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
 import * as Chisel from "./chisel.ts";
-(globalThis as unknown as { Chisel: unknown }).Chisel = Chisel;
 
 // Hack to pretend we are not in a web worker. On workers 'window'
 // doesn't exist, but globalThis does. They are not exactly the same,

--- a/cli/examples/person.ts
+++ b/cli/examples/person.ts
@@ -1,8 +1,8 @@
 /* SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com> */
 
-import { labels } from "@chiselstrike/api";
+import { ChiselEntity, labels } from "@chiselstrike/api";
 
-export class Person extends Chisel.ChiselEntity {
+export class Person extends ChiselEntity {
   first_name: string = "";
   @labels("pii") last_name: string = "";
   age: number = 0;
@@ -11,6 +11,6 @@ export class Person extends Chisel.ChiselEntity {
 }
 
 
-export class Position extends Chisel.ChiselEntity {
+export class Position extends ChiselEntity {
   title: string = "title";
 }

--- a/cli/tests/integration_tests/lit_tests/aggregations.deno
+++ b/cli/tests/integration_tests/lit_tests/aggregations.deno
@@ -6,12 +6,14 @@ cd "$TEMPDIR"
 
 
 cat << EOF > "$TEMPDIR/models/types.ts"
-export class Biography extends Chisel.ChiselEntity {
+import { ChiselEntity } from '@chiselstrike/api';
+
+export class Biography extends ChiselEntity {
     title: string = "";
     page_count: number = 0;
 }
 
-export class Person extends Chisel.ChiselEntity {
+export class Person extends ChiselEntity {
     name: string = "bob";
     age: number = 0;
     biography: Biography;

--- a/cli/tests/integration_tests/lit_tests/cli/describe.deno
+++ b/cli/tests/integration_tests/lit_tests/cli/describe.deno
@@ -5,8 +5,9 @@
 cd "$TEMPDIR"
 
 cat << EOF > "$TEMPDIR/models/types.ts"
-export class Foo extends Chisel.ChiselEntity { a: string; }
-export class Bar extends Chisel.ChiselEntity { b: string; }
+import { ChiselEntity } from '@chiselstrike/api';
+export class Foo extends ChiselEntity { a: string; }
+export class Bar extends ChiselEntity { b: string; }
 EOF
 
 cat << EOF > "$TEMPDIR/endpoints/hello.ts"

--- a/cli/tests/integration_tests/lit_tests/defaults.deno
+++ b/cli/tests/integration_tests/lit_tests/defaults.deno
@@ -21,7 +21,8 @@ $CHISEL describe
 # CHECK: }
 
 cat << EOF > "$TEMPDIR/models/types.ts"
-export class Foo extends Chisel.ChiselEntity {
+import { ChiselEntity } from '@chiselstrike/api';
+export class Foo extends ChiselEntity {
 	a: string = "dfl1";
 	b: number = 0.0;
 	c: boolean = false;
@@ -65,7 +66,8 @@ $CURL -o - $CHISELD_HOST/dev/read
 # CHECK: dfl1 0 false 2 value
 
 cat << EOF > "$TEMPDIR/models/types.ts"
-export class Foo extends Chisel.ChiselEntity {
+import { ChiselEntity } from '@chiselstrike/api';
+export class Foo extends ChiselEntity {
 	a: string = "dfl1";
 	b: number = 0.0;
 	c: boolean = false;

--- a/cli/tests/integration_tests/lit_tests/filter-with-predicate.deno
+++ b/cli/tests/integration_tests/lit_tests/filter-with-predicate.deno
@@ -6,11 +6,13 @@ cd "$TEMPDIR"
 
 
 cat << EOF > "$TEMPDIR/models/types.ts"
-export class Biography extends Chisel.ChiselEntity {
+import { ChiselEntity } from '@chiselstrike/api';
+
+export class Biography extends ChiselEntity {
     title: string = "";
 }
 
-export class Person extends Chisel.ChiselEntity {
+export class Person extends ChiselEntity {
     name: string = "bob";
     age: number = 0;
     biography: Biography;

--- a/cli/tests/integration_tests/lit_tests/filter.deno
+++ b/cli/tests/integration_tests/lit_tests/filter.deno
@@ -128,8 +128,8 @@ $CURL -X POST -o - $CHISELD_HOST/dev/take_filter
 # Test sql keywords
 
 cat << EOF > "$TEMPDIR/models/types.ts"
-
-export class TestingEntity extends Chisel.ChiselEntity {
+import { ChiselEntity } from '@chiselstrike/api';
+export class TestingEntity extends ChiselEntity {
     limit: string = "limit";
     group: string = "group";
     where: string = "where";

--- a/cli/tests/integration_tests/lit_tests/pol-anon.deno
+++ b/cli/tests/integration_tests/lit_tests/pol-anon.deno
@@ -41,9 +41,9 @@ $CURL -o - $CHISELD_HOST/dev/find
 # CHECK: hello xxxxx
 
 cat << EOF > "$TEMPDIR/models/person.ts"
-import { labels } from "@chiselstrike/api";
+import { ChiselEntity, labels } from "@chiselstrike/api";
 
-export class Person extends Chisel.ChiselEntity {
+export class Person extends ChiselEntity {
   @labels("L1", "L2", "L3") first_name: string;
   @labels("pii", "L2") last_name: string;
   @labels("L1", "L3") human: boolean;
@@ -126,13 +126,13 @@ labels:
 EOF
 
 cat << EOF > "$TEMPDIR/models/company.ts"
-import { labels } from "@chiselstrike/api";
+import { ChiselEntity, labels } from "@chiselstrike/api";
 
-export class Human extends Chisel.ChiselEntity {
+export class Human extends ChiselEntity {
   @labels("pii") firstName: string = "";
   lastName: string = "";
 }
-export class Company extends Chisel.ChiselEntity {
+export class Company extends ChiselEntity {
   name: string = "";
   ceo: Human;
   @labels("pii") accountant: Human;

--- a/cli/tests/integration_tests/lit_tests/populate.deno
+++ b/cli/tests/integration_tests/lit_tests/populate.deno
@@ -57,10 +57,11 @@ $CURL $CHISELD_HOST/staging/count
 # ----- Check functionality with nested types -----
 
 cat << EOF > "$TEMPDIR/models/types.ts"
-export class Employee extends Chisel.ChiselEntity {
+import { ChiselEntity } from '@chiselstrike/api';
+export class Employee extends ChiselEntity {
    name: string = "";
 }
-export class Company extends Chisel.ChiselEntity {
+export class Company extends ChiselEntity {
    name: string = "";
    ceo?: Employee;
    cfo?: Employee;

--- a/cli/tests/integration_tests/lit_tests/sort.deno
+++ b/cli/tests/integration_tests/lit_tests/sort.deno
@@ -6,7 +6,8 @@ cd "$TEMPDIR"
 
 
 cat << EOF > "$TEMPDIR/models/types.ts"
-export class Person extends Chisel.ChiselEntity {
+import { ChiselEntity } from '@chiselstrike/api';
+export class Person extends ChiselEntity {
   name: string = "";
   age: number = 0;
 }

--- a/cli/tests/integration_tests/lit_tests/store-nested-type.deno
+++ b/cli/tests/integration_tests/lit_tests/store-nested-type.deno
@@ -3,10 +3,11 @@
 # RUN: sh -e @file
 
 cat << EOF > "$TEMPDIR/models/types.ts"
-export class Person extends Chisel.ChiselEntity {
+import { ChiselEntity } from '@chiselstrike/api';
+export class Person extends ChiselEntity {
     firstName: string = "";
 }
-export class Company extends Chisel.ChiselEntity {
+export class Company extends ChiselEntity {
     ceo: Person;
 }
 EOF
@@ -17,11 +18,12 @@ $CHISEL apply 2>&1
 
 
 cat << EOF > "$TEMPDIR/models/types.ts"
-export class Person extends Chisel.ChiselEntity {
+import { ChiselEntity } from '@chiselstrike/api';
+export class Person extends ChiselEntity {
     firstName: string = "";
     lastName: string = "";
 }
-export class Company extends Chisel.ChiselEntity {
+export class Company extends ChiselEntity {
     name: string = "";
     ceo: Person = new Person();
 }

--- a/cli/tests/integration_tests/lit_tests/transaction.deno
+++ b/cli/tests/integration_tests/lit_tests/transaction.deno
@@ -3,7 +3,8 @@
 # RUN: sh -e @file
 
 cat << EOF > "$TEMPDIR/models/types.ts"
-export class Person extends Chisel.ChiselEntity {
+import { ChiselEntity } from '@chiselstrike/api';
+export class Person extends ChiselEntity {
    name: string = "";
 }
 EOF

--- a/cli/tests/integration_tests/rust_tests/array.rs
+++ b/cli/tests/integration_tests/rust_tests/array.rs
@@ -5,7 +5,8 @@ pub async fn test(c: TestContext) {
     c.chisel.write(
         "models/types.ts",
         r##"
-        export class Foo extends Chisel.ChiselEntity {
+        import { ChiselEntity } from '@chiselstrike/api';
+        export class Foo extends ChiselEntity {
             order: number = 0;
             numbers: number[] = [];
             strings: string[] = [];

--- a/server/src/main.js
+++ b/server/src/main.js
@@ -1,2 +1,1 @@
-import * as Chisel from "./chisel.ts";
-globalThis.Chisel = Chisel;
+// this script does nothing at the moment


### PR DESCRIPTION
In modern JavaScript, it is usually better to use imports rather than a global variable. For example, to type-check code that uses the global variable, we must feed `tsc` with an extra file that specifies the type of the variable. Getting rid of the `Chisel` variable will simplify our code in the fugure.

This is a spin-off from #1618.