### PR TITLE
docs: Bump up Node version

### DIFF
--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -40,5 +40,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "engines": {
+    "node": "^16"
   }
 }


### PR DESCRIPTION
Docusaurus does not work with Node 14, so bump up the engine
requirement.