### PR TITLE
cli: Simplify apply output

### DIFF
--- a/cli/src/cmd/apply.rs
+++ b/cli/src/cmd/apply.rs
@@ -112,7 +112,7 @@ pub(crate) async fn apply(
         deno::apply(&endpoints, &events, &entities, optimize, auto_index).await
     }?;
 
-    for p in policies {
+    for p in &policies {
         policy_req.push(PolicyUpdateRequest {
             policy_config: read_to_string(p)?,
         });
@@ -178,11 +178,19 @@ pub(crate) async fn apply(
 
     let msg = execute!(client.apply(tonic::Request::new(req)).await);
 
-    println!("Code was applied to the ChiselStrike server. It contained:");
-    println!("  - models: {}", msg.types.len());
-    println!("  - routes: {}", msg.endpoints.len());
-    println!("  - event handlers: {}", msg.event_handlers.len());
-    println!("  - labels: {}", msg.labels.len());
+    println!("Applied:");
+    if !msg.types.is_empty() {
+        println!("  {} models", msg.types.len());
+    }
+    if !msg.endpoints.is_empty() {
+        println!("  {} routes", msg.endpoints.len());
+    }
+    if !msg.event_handlers.is_empty() {
+        println!("  {} event handlers", msg.event_handlers.len());
+    }
+    if !msg.labels.is_empty() {
+        println!("  {} labels", msg.labels.len());
+    }
 
     Ok(())
 }

--- a/cli/tests/integration_tests/lit_tests/access-origin.deno
+++ b/cli/tests/integration_tests/lit_tests/access-origin.deno
@@ -16,7 +16,7 @@ EOF
 cd "$TEMPDIR"
 $CHISEL apply
 
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/foo
 

--- a/cli/tests/integration_tests/lit_tests/aggregations.deno
+++ b/cli/tests/integration_tests/lit_tests/aggregations.deno
@@ -86,7 +86,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST -o - $CHISELD_HOST/dev/store
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/api-policy.deno
+++ b/cli/tests/integration_tests/lit_tests/api-policy.deno
@@ -27,7 +27,7 @@ EOF
 cd "$TEMPDIR"
 $CHISEL apply
 
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL --data '{
     "first_name":"Glauber",

--- a/cli/tests/integration_tests/lit_tests/auth-header.node
+++ b/cli/tests/integration_tests/lit_tests/auth-header.node
@@ -4,7 +4,7 @@
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL $CHISELD_HOST/__chiselstrike/auth/users
 # CHECK: HTTP/1.1 403 Forbidden

--- a/cli/tests/integration_tests/lit_tests/body-resource.deno
+++ b/cli/tests/integration_tests/lit_tests/body-resource.deno
@@ -44,7 +44,7 @@ EOF
 cd "$TEMPDIR"
 $CHISEL apply
 
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL --data foobar -o - $CHISELD_HOST/dev/test1
 

--- a/cli/tests/integration_tests/lit_tests/build-entity.deno
+++ b/cli/tests/integration_tests/lit_tests/build-entity.deno
@@ -26,7 +26,7 @@ export default async function (req: Request): Promise<Response> {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -d '{"username": "penberg"}' $CHISELD_HOST/dev/user
 # CHECK: penbergPekka

--- a/cli/tests/integration_tests/lit_tests/build-without-default.deno
+++ b/cli/tests/integration_tests/lit_tests/build-without-default.deno
@@ -25,7 +25,7 @@ cd "$TEMPDIR"
 # FIXME, We should detect this error at compile time.
 $CHISEL apply
 
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST $CHISELD_HOST/dev/build
 

--- a/cli/tests/integration_tests/lit_tests/cli/chisel-apply-ignores.deno
+++ b/cli/tests/integration_tests/lit_tests/cli/chisel-apply-ignores.deno
@@ -21,4 +21,4 @@ cp "$TEMPDIR/routes/hello.ts" "$TEMPDIR/routes/#hello.ts#"
 
 $CHISEL apply
 
-# CHECK: Code was applied
+# CHECK: Applied:

--- a/cli/tests/integration_tests/lit_tests/cli/describe.deno
+++ b/cli/tests/integration_tests/lit_tests/cli/describe.deno
@@ -26,7 +26,7 @@ EOF
 
 $CHISEL apply
 
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CHISEL describe
 

--- a/cli/tests/integration_tests/lit_tests/cli/reapply.deno
+++ b/cli/tests/integration_tests/lit_tests/cli/reapply.deno
@@ -11,11 +11,11 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 ## Identical definition is OK.
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 ## Changing labels is OK.
 cat << EOF > "$TEMPDIR/models/foo.ts"
@@ -25,7 +25,7 @@ export class Foo extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 # Adding default values is OK.
 cat << EOF > "$TEMPDIR/models/foo.ts"
@@ -35,7 +35,7 @@ export class Foo extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 ## Two compatible definitions in different files are rejected.
 cat << EOF > "$TEMPDIR/models/fooNoteADifferentFilenameHere.ts"
@@ -57,7 +57,7 @@ export class Foo extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 ## Go back to the basics, and add some data
 cat << EOF > "$TEMPDIR/models/foo.ts"
@@ -77,7 +77,7 @@ export default async function seed() {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST $CHISELD_HOST/dev/seed
 rm "$TEMPDIR/routes/seed.ts"
@@ -111,7 +111,7 @@ export class Foo extends ChiselEntity {
 }
 EOF
 $CHISEL apply 2>&1 || echo # (swallow the apply abort)
-# CHECK: Code was applied
+# CHECK: Applied:
 
 ## Removing fields is OK if they previously had a default
 cat << EOF > "$TEMPDIR/models/foo.ts"
@@ -120,7 +120,7 @@ export class Foo extends ChiselEntity {
 }
 EOF
 $CHISEL apply 2>&1 || echo # (swallow the apply abort)
-# CHECK: Code was applied
+# CHECK: Applied:
 
 ## clean up data.
 rm "$TEMPDIR/models/foo.ts"

--- a/cli/tests/integration_tests/lit_tests/concurrency.deno
+++ b/cli/tests/integration_tests/lit_tests/concurrency.deno
@@ -17,7 +17,7 @@ EOF
 cd "$TEMPDIR"
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 NUM=100
 for i in $(seq 1 $NUM); do

--- a/cli/tests/integration_tests/lit_tests/create.deno
+++ b/cli/tests/integration_tests/lit_tests/create.deno
@@ -24,7 +24,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST $CHISELD_HOST/dev/new
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/crud-custom.node
+++ b/cli/tests/integration_tests/lit_tests/crud-custom.node
@@ -87,7 +87,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -d '{"first_name":"Alice","last_name":"Anderson","age":30,"human":true,"height":10}' $CHISELD_HOST/dev/persons
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/crud.node
+++ b/cli/tests/integration_tests/lit_tests/crud.node
@@ -11,7 +11,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -d '{"first_name":"Alice","last_name":"Anderson","age":30,"human":true,"height":10}' $CHISELD_HOST/dev/persons
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/csv.deno
+++ b/cli/tests/integration_tests/lit_tests/csv.deno
@@ -7,7 +7,7 @@ cp examples/csv.ts examples/find.ts "$TEMPDIR/routes"
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL --data '
 adam,smith

--- a/cli/tests/integration_tests/lit_tests/db-api.deno
+++ b/cli/tests/integration_tests/lit_tests/db-api.deno
@@ -48,7 +48,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL --data '{
     "first_name":"Glauber",

--- a/cli/tests/integration_tests/lit_tests/defaults.deno
+++ b/cli/tests/integration_tests/lit_tests/defaults.deno
@@ -8,7 +8,7 @@ cat << EOF > "$TEMPDIR/models/types.ts"
 export class Unary extends ChiselEntity { a: number = +1; b: number = 0; c: number = -1 ;}
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CHISEL restart
 $CHISEL describe
@@ -106,7 +106,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 
 $CURL -o - $CHISELD_HOST/dev/readold
@@ -169,7 +169,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - "$CHISELD_HOST/dev/find_many?key=a&value=xaxa" | count_results
 # CHECK: Number of results: 0

--- a/cli/tests/integration_tests/lit_tests/delete-type.deno
+++ b/cli/tests/integration_tests/lit_tests/delete-type.deno
@@ -19,7 +19,7 @@ export default User.crud();
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST -d '{"username": "alice", "email": "alice@example.org"}' $CHISELD_HOST/dev/user
 # CHECK: "alice"

--- a/cli/tests/integration_tests/lit_tests/delete.deno
+++ b/cli/tests/integration_tests/lit_tests/delete.deno
@@ -36,7 +36,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST -d '{"username": "alice", "email": "alice@example.org"}' $CHISELD_HOST/dev/user
 # CHECK: "alice"

--- a/cli/tests/integration_tests/lit_tests/echo-endpoint.deno
+++ b/cli/tests/integration_tests/lit_tests/echo-endpoint.deno
@@ -29,7 +29,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL --data foobar -o - $CHISELD_HOST/dev/echo
 

--- a/cli/tests/integration_tests/lit_tests/endpoint-error.deno
+++ b/cli/tests/integration_tests/lit_tests/endpoint-error.deno
@@ -30,7 +30,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/test
 

--- a/cli/tests/integration_tests/lit_tests/entity-findone-filter.deno
+++ b/cli/tests/integration_tests/lit_tests/entity-findone-filter.deno
@@ -26,7 +26,7 @@ export default async function (req: Request): Promise<Response> {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST $CHISELD_HOST/dev/entity-methods
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/entity-methods.deno
+++ b/cli/tests/integration_tests/lit_tests/entity-methods.deno
@@ -28,7 +28,7 @@ export default async function (req: Request): Promise<Response> {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST $CHISELD_HOST/dev/entity-methods
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/escape-string.deno
+++ b/cli/tests/integration_tests/lit_tests/escape-string.deno
@@ -20,7 +20,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL --data '{
     "first_name":"Bob'\''",

--- a/cli/tests/integration_tests/lit_tests/filter-with-predicate.deno
+++ b/cli/tests/integration_tests/lit_tests/filter-with-predicate.deno
@@ -97,7 +97,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CHISEL apply
 $CURL -X POST -o - $CHISELD_HOST/dev/store

--- a/cli/tests/integration_tests/lit_tests/filter.deno
+++ b/cli/tests/integration_tests/lit_tests/filter.deno
@@ -7,7 +7,7 @@ cp examples/store.ts "$TEMPDIR/routes"
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL --data '{
     "first_name":"Glauber",
@@ -109,7 +109,7 @@ export default async (req: Request) => {
 }
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST -o - $CHISELD_HOST/dev/take_filter
 # CHECK: "simple_take": [
@@ -167,7 +167,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST -o - $CHISELD_HOST/dev/store_testing_entity
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/foreach.deno
+++ b/cli/tests/integration_tests/lit_tests/foreach.deno
@@ -36,7 +36,7 @@ EOF
 
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST $CHISELD_HOST/dev/store
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/headers.deno
+++ b/cli/tests/integration_tests/lit_tests/headers.deno
@@ -10,7 +10,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 num=$($CURL $CHISELD_HOST/dev/foo | grep ChiselUID | wc -l)
 echo Found $num copies

--- a/cli/tests/integration_tests/lit_tests/id.deno
+++ b/cli/tests/integration_tests/lit_tests/id.deno
@@ -78,7 +78,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST $CHISELD_HOST/dev/bad_id  2>&1 || echo
 # CHECK: invalid ID 'badid'

--- a/cli/tests/integration_tests/lit_tests/ignore-policy-field.deno
+++ b/cli/tests/integration_tests/lit_tests/ignore-policy-field.deno
@@ -26,7 +26,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL --data '{
     "first_name":"Glauber",

--- a/cli/tests/integration_tests/lit_tests/introspect.node
+++ b/cli/tests/integration_tests/lit_tests/introspect.node
@@ -17,7 +17,7 @@ cd "$TEMPDIR"
 mv package.json pkg.json
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL $CHISELD_HOST/__chiselstrike/
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/join.lit.disabled
+++ b/cli/tests/integration_tests/lit_tests/join.lit.disabled
@@ -47,7 +47,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL --data '{
     "first_name":"Glauber",

--- a/cli/tests/integration_tests/lit_tests/map.deno
+++ b/cli/tests/integration_tests/lit_tests/map.deno
@@ -81,7 +81,7 @@ EOF
 
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST $CHISELD_HOST/dev/store
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/missing-await.deno
+++ b/cli/tests/integration_tests/lit_tests/missing-await.deno
@@ -21,7 +21,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/find
 

--- a/cli/tests/integration_tests/lit_tests/multiple-endpoints.deno
+++ b/cli/tests/integration_tests/lit_tests/multiple-endpoints.deno
@@ -19,7 +19,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/foo
 
@@ -41,7 +41,7 @@ EOF
 
 npm i
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/foo
 

--- a/cli/tests/integration_tests/lit_tests/optional-field.deno
+++ b/cli/tests/integration_tests/lit_tests/optional-field.deno
@@ -39,7 +39,7 @@ export default async function (_: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 ## Accept payload without optional values:
 $CURL -d '{}' $CHISELD_HOST/dev/save
@@ -84,11 +84,11 @@ export class Foo extends ChiselEntity {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 ## Correctly populate from optional fields
 $CHISEL apply --version=v2
-# CHECK: Code was applied
+# CHECK: Applied:
 $CHISEL populate --version=v2 --from=dev
 $CURL $CHISELD_HOST/v2/sum
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/out-of-order-models.deno
+++ b/cli/tests/integration_tests/lit_tests/out-of-order-models.deno
@@ -34,4 +34,4 @@ EOF
 cd "$TEMPDIR"
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:

--- a/cli/tests/integration_tests/lit_tests/permissions.deno
+++ b/cli/tests/integration_tests/lit_tests/permissions.deno
@@ -16,7 +16,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/mischief
 

--- a/cli/tests/integration_tests/lit_tests/pol-loggedin.deno
+++ b/cli/tests/integration_tests/lit_tests/pol-loggedin.deno
@@ -105,7 +105,7 @@ export default async function (req: Request) {
 EOF
 
 $CHISEL apply --allow-type-deletion
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -H ChiselUID\:$id_al -d '{"text": "first post by al"}' $CHISELD_HOST/dev/po
 # CHECK: HTTP/1.1 200 OK
@@ -153,7 +153,7 @@ EOF
 
 rm "$TEMPDIR/policies/pol.yaml"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -d '{"text": "first post by al"}' $CHISELD_HOST/dev/po
 # CHECK:  HTTP/1.1 401 Unauthorized
@@ -193,7 +193,7 @@ labels:
     transform: match_login
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 count=$($CURL -H ChiselUID\:$id_al $CHISELD_HOST/dev/blogs | grep 'blog post by' | wc -l | tr -d '[:space:]')
 echo "result count:$count"

--- a/cli/tests/integration_tests/lit_tests/populate.deno
+++ b/cli/tests/integration_tests/lit_tests/populate.deno
@@ -19,7 +19,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL --data '{
     "first_name":"Glauber",
@@ -36,7 +36,7 @@ $CURL $CHISELD_HOST/dev/count
 # CHECK: 1
 
 $CHISEL apply --version staging
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL $CHISELD_HOST/staging/count
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/prefix.deno
+++ b/cli/tests/integration_tests/lit_tests/prefix.deno
@@ -17,7 +17,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/foo
 

--- a/cli/tests/integration_tests/lit_tests/reject-without-handler.deno
+++ b/cli/tests/integration_tests/lit_tests/reject-without-handler.deno
@@ -15,7 +15,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/err
 

--- a/cli/tests/integration_tests/lit_tests/remove-endpoints.deno
+++ b/cli/tests/integration_tests/lit_tests/remove-endpoints.deno
@@ -24,7 +24,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/end
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/restart-js.deno
+++ b/cli/tests/integration_tests/lit_tests/restart-js.deno
@@ -18,7 +18,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/test1
 # CHECK: HTTP/1.1 200 OK
@@ -36,7 +36,7 @@ export default async function chisel(req) {
 }
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/test2
 

--- a/cli/tests/integration_tests/lit_tests/savemany.deno
+++ b/cli/tests/integration_tests/lit_tests/savemany.deno
@@ -30,7 +30,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST $CHISELD_HOST/dev/savemany
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/savewrong.deno
+++ b/cli/tests/integration_tests/lit_tests/savewrong.deno
@@ -36,7 +36,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL $CHISELD_HOST/dev/store
 
@@ -52,7 +52,7 @@ import { AuthUser } from '@chiselstrike/api';
 export default AuthUser.crud();
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -d '{"name":"Foo", "email":"foo@t.co"}' $CHISELD_HOST/dev/store
 # CHECK: Error: Cannot save into type AuthUser.
@@ -74,7 +74,7 @@ export default Post.crud();
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -d '{"author":{"email": "foo@t.co"}}' $CHISELD_HOST/dev/store
 # CHECK: Error: Cannot save into type AuthUser.

--- a/cli/tests/integration_tests/lit_tests/select-order-with-pol.deno
+++ b/cli/tests/integration_tests/lit_tests/select-order-with-pol.deno
@@ -30,7 +30,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL --data '{
     "first_name":"Glauber",

--- a/cli/tests/integration_tests/lit_tests/select-order.deno
+++ b/cli/tests/integration_tests/lit_tests/select-order.deno
@@ -24,7 +24,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL --data '{
     "first_name":"Glauber",

--- a/cli/tests/integration_tests/lit_tests/simple-module.node
+++ b/cli/tests/integration_tests/lit_tests/simple-module.node
@@ -16,7 +16,7 @@ EOF
 cd "$TEMPDIR"
 npm i handlebars
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/pad
 

--- a/cli/tests/integration_tests/lit_tests/sort.deno
+++ b/cli/tests/integration_tests/lit_tests/sort.deno
@@ -56,7 +56,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST -o - $CHISELD_HOST/dev/store
 # CHECK: Ok
@@ -90,7 +90,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/get_sorted
 # CHECK: [Glauber, Jan, Pekka]
@@ -115,7 +115,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/get_sorted
 # CHECK: [Pekka]
@@ -138,7 +138,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/get_sorted
 # CHECK: [Glauber, Pekka]
@@ -159,7 +159,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/get_sorted
 # CHECK: Error: entity 'Person' has no field named 'invalid_field'
@@ -185,7 +185,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/get_sorted
 # CHECK: [Glauber, Jan, Pekka]

--- a/cli/tests/integration_tests/lit_tests/store-nested-type.deno
+++ b/cli/tests/integration_tests/lit_tests/store-nested-type.deno
@@ -81,7 +81,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST $CHISELD_HOST/dev/store_adalbrecht
 # CHECK: Successfully stored data

--- a/cli/tests/integration_tests/lit_tests/take-skip.deno
+++ b/cli/tests/integration_tests/lit_tests/take-skip.deno
@@ -112,7 +112,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST $CHISELD_HOST/dev/store
 # CHECK: Ok
@@ -241,7 +241,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL $CHISELD_HOST/dev/skip1
 # CHECK: [Jan, Pekka]

--- a/cli/tests/integration_tests/lit_tests/toarray.deno
+++ b/cli/tests/integration_tests/lit_tests/toarray.deno
@@ -34,7 +34,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST $CHISELD_HOST/dev/store
 # CHECK: Ok

--- a/cli/tests/integration_tests/lit_tests/type-evolve.deno
+++ b/cli/tests/integration_tests/lit_tests/type-evolve.deno
@@ -11,7 +11,7 @@ export class Evolving extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 cat << EOF > "$TEMPDIR/models/types.ts"
 import { ChiselEntity } from "@chiselstrike/api";
@@ -22,7 +22,7 @@ export class Evolving extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 cat << EOF > "$TEMPDIR/routes/store.js"
 import { Evolving } from "../models/types.ts";
@@ -51,7 +51,7 @@ export default async function chisel(req) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST $CHISELD_HOST/dev/store
 # CHECK: HTTP/1.1 200 OK
@@ -70,7 +70,7 @@ export class Evolving extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL $CHISELD_HOST/dev/find
 # CHECK: HTTP/1.1 200 OK
@@ -85,7 +85,7 @@ export class Evolving extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL $CHISELD_HOST/dev/find
 # CHECK: HTTP/1.1 200 OK
@@ -100,7 +100,7 @@ export class Evolving extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL $CHISELD_HOST/dev/find
 # CHECK: HTTP/1.1 200 OK
@@ -116,7 +116,7 @@ export class Evolving extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 cat << EOF > "$TEMPDIR/models/types.ts"
 import { ChiselEntity } from "@chiselstrike/api";
@@ -127,7 +127,7 @@ export class Evolving extends ChiselEntity {
 }
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL $CHISELD_HOST/dev/find
 # CHECK: HTTP/1.1 200 OK
@@ -150,7 +150,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 
 cat << EOF > "$TEMPDIR/models/types.ts"
@@ -164,7 +164,7 @@ EOF
 rm $TEMPDIR/routes/test_indexes.ts
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 ### get / set helpers for the tests below
 cat << EOF > "$TEMPDIR/routes/get.ts"
@@ -194,7 +194,7 @@ export class Defaults extends ChiselEntity {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -d '{}' $CHISELD_HOST/dev/set
 # CHECK: HTTP/1.1 200 OK
@@ -237,7 +237,7 @@ export class Defaults extends ChiselEntity {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -d '{}' $CHISELD_HOST/dev/set
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/types.deno
+++ b/cli/tests/integration_tests/lit_tests/types.deno
@@ -9,7 +9,7 @@ export class Foo extends ChiselEntity { a?: string; }
 export class Bar extends ChiselEntity { a: string = "default"; }
 EOF
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CHISEL restart
 $CHISEL describe

--- a/cli/tests/integration_tests/lit_tests/unique.deno
+++ b/cli/tests/integration_tests/lit_tests/unique.deno
@@ -78,7 +78,7 @@ export class BlogPost extends ChiselEntity {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CHISEL restart
 describe_output=$($CHISEL describe)

--- a/cli/tests/integration_tests/lit_tests/upsert.deno
+++ b/cli/tests/integration_tests/lit_tests/upsert.deno
@@ -33,7 +33,7 @@ export default async function chisel(req: Request) {
 EOF
 
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -X POST $CHISELD_HOST/dev/upsert
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/url-query.deno
+++ b/cli/tests/integration_tests/lit_tests/url-query.deno
@@ -16,7 +16,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/title?name=glauber
 

--- a/cli/tests/integration_tests/lit_tests/use-module.deno
+++ b/cli/tests/integration_tests/lit_tests/use-module.deno
@@ -12,7 +12,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/pad
 

--- a/cli/tests/integration_tests/lit_tests/use-ts-moduled.deno
+++ b/cli/tests/integration_tests/lit_tests/use-ts-moduled.deno
@@ -12,7 +12,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/pad
 

--- a/cli/tests/integration_tests/lit_tests/versions.deno
+++ b/cli/tests/integration_tests/lit_tests/versions.deno
@@ -28,10 +28,10 @@ $CHISEL apply --version string-# 2>&1 || echo
 # CHECK: Error
 
 $CHISEL apply --version v0
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CHISEL apply --version v0-_
-# CHECK: Code was applied
+# CHECK: Applied:
 
 
 cat << EOF > "routes/foo.js"
@@ -41,7 +41,7 @@ export default async function my_req_func(req) {
 EOF
 
 $CHISEL apply --version v1
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/v0/foo
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/worker.deno
+++ b/cli/tests/integration_tests/lit_tests/worker.deno
@@ -11,7 +11,7 @@ EOF
 
 cd "$TEMPDIR"
 $CHISEL apply
-# CHECK: Code was applied
+# CHECK: Applied:
 
 $CURL -o - $CHISELD_HOST/dev/worker
 


### PR DESCRIPTION
This simplifies "chisel apply" and "chisel dev" output to improve
developer experience:

```
% chisel apply
Applied:
  12 models
  19 routes
```