### PR TITLE
Fix backward compatibility with `endpoints` in policies

### DIFF
--- a/cli/tests/integration_tests/rust_tests/policies_loggedin.rs
+++ b/cli/tests/integration_tests/rust_tests/policies_loggedin.rs
@@ -67,6 +67,23 @@ async fn basic(mut c: TestContext) {
 }
 
 #[self::test(modules = Deno, optimize = Yes)]
+async fn endpoints_backcompat(c: TestContext) {
+    // test that we support `endpoints:` instead of `routes:` for backwards compatibility
+    c.chisel.write_unindent("routes/test.ts", TEST_ROUTE);
+    c.chisel.write_unindent(
+        "policies/pol.yaml",
+        r##"
+            endpoints:
+            - path: /test
+              users: ^$
+        "##,
+    );
+    c.chisel.apply_ok().await;
+
+    c.chisel.get("/dev/test").send().await.assert_status(403);
+}
+
+#[self::test(modules = Deno, optimize = Yes)]
 async fn repeated_path(c: TestContext) {
     c.chisel.write_unindent(
         "policies/pol.yaml",

--- a/server/src/policies.rs
+++ b/server/src/policies.rs
@@ -245,7 +245,16 @@ impl VersionPolicy {
                     None => {}
                 };
             }
-            for route in config["routes"].as_vec().get_or_insert(&[].into()).iter() {
+
+            #[allow(clippy::or_fun_call)]
+            let routes = config["routes"]
+                .as_vec()
+                .or(config["endpoints"].as_vec())
+                .map(|vec| vec.iter())
+                .into_iter()
+                .flatten();
+
+            for route in routes {
                 if let Some(path) = route["path"].as_str() {
                     if let Some(users) = route["users"].as_str() {
                         policies


### PR DESCRIPTION
In my eagerness to remove all traces of "endpoints" in #1686, I forgot to provide backward compatibility for policies. This PR fixes that and adds tests for this regression.

Perhaps we should be more strict when parsing policies and reject YAMLs that have unknown keys, because if the user makes a typo in their policy, the results might be disastrous, because we will simply ignore the policy and open the backend to everybody on the internet.

Builds on #1712