### PR TITLE
Removed esbuild and typescript deps from the app template package.json

### DIFF
--- a/packages/create-chiselstrike-app/template/package.json
+++ b/packages/create-chiselstrike-app/template/package.json
@@ -9,9 +9,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@chiselstrike/api": "{{chiselVersion}}",
-        "esbuild": "^0.14.14",
-        "typescript": "4.6.2"
+        "@chiselstrike/api": "{{chiselVersion}}"
     },
     "devDependencies": {
         "@chiselstrike/cli": "{{chiselVersion}}"


### PR DESCRIPTION
They are already provided transitively by the CLI package.