### PR TITLE
Deny auth endpoints when AUTH_SECRET is absent

### DIFF
--- a/cli/tests/integration_tests/rust_tests/auth.rs
+++ b/cli/tests/integration_tests/rust_tests/auth.rs
@@ -2,6 +2,27 @@ use crate::framework::prelude::*;
 
 #[chisel_macros::test(modules = Node)]
 pub async fn next_auth_crud(mut c: TestContext) {
+    // If CHISELD_AUTH_SECRET isn't set, any access is forbidden.
+    c.chisel
+        .get("/__chiselstrike/auth/users")
+        .send()
+        .await
+        .assert_status(403);
+    c.chisel
+        .post("/__chiselstrike/auth/users")
+        .json(json!({}))
+        .header("ChiselAuth", "0")
+        .send()
+        .await
+        .assert_status(403);
+    c.chisel
+        .put("/__chiselstrike/auth/users/1")
+        .json(json!({}))
+        .header("ChiselAuth", "")
+        .send()
+        .await
+        .assert_status(403);
+
     c.chisel
         .write(".env", r##"{ "CHISELD_AUTH_SECRET" : "1234" }"##);
 

--- a/cli/tests/integration_tests/rust_tests/policies_loggedin.rs
+++ b/cli/tests/integration_tests/rust_tests/policies_loggedin.rs
@@ -190,6 +190,8 @@ async fn store_post(chisel: &Chisel, uid: &str, text: &str) {
 async fn logged_in_user_post(c: TestContext) {
     c.chisel.write_unindent("models/post.ts", MODEL_POST);
     c.chisel.write_unindent("routes/posts.ts", ROUTE_POSTS);
+    c.chisel
+        .write(".env", r#"{ "CHISELD_AUTH_SECRET": "dud" }"#);
     c.chisel.apply_ok().await;
 
     let id_al = store_user(&c.chisel, "Al", "al").await;
@@ -223,6 +225,8 @@ async fn transform_match_login(c: TestContext) {
               transform: match_login
         "##,
     );
+    c.chisel
+        .write(".env", r#"{ "CHISELD_AUTH_SECRET": "dud" }"#);
     c.chisel.apply_ok().await;
 
     let id_al = store_user(&c.chisel, "Al", "al").await;
@@ -277,6 +281,8 @@ async fn transform_match_login_related_entities(c: TestContext) {
     c.chisel.write_unindent("models/post.ts", MODEL_POST);
     c.chisel.write_unindent("routes/posts.ts", ROUTE_POSTS);
     c.chisel.write_unindent("routes/blogs.ts", ROUTE_BLOGS);
+    c.chisel
+        .write(".env", r#"{ "CHISELD_AUTH_SECRET": "dud" }"#);
     c.chisel.apply_ok().await;
 
     let id_al = store_user(&c.chisel, "Al", "al").await;

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -1271,10 +1271,8 @@ async fn special_response(
             .get("CHISELD_AUTH_SECRET")
             .cloned();
         match (expected_secret, auth_header) {
-            (Some(serde_json::Value::String(s)), Some(h)) if s != *h => {
-                return Ok(Some(ApiService::forbidden("Fundamental auth")?))
-            }
-            _ => (),
+            (Some(serde_json::Value::String(s)), Some(h)) if s == *h => (),
+            _ => return Ok(Some(ApiService::forbidden("Fundamental auth")?)),
         }
     } else {
         let username = get_username_from_id(state.clone(), userid.clone()).await;


### PR DESCRIPTION
In 5a98be7 we forbade auth-endpoint access without the ChiselAuth
header.  But a bug snuck in where a request WITH that header would
succeed even if CHISELD_AUTH_SECRET was absent.  This patch fixes it by
requiring the header value be strictly equal to the secret value.

A couple of policies_loggedin tests were relying on the buggy behavior
and needed fixing, too.