### PR TITLE
Apply post read filters

### DIFF
--- a/chiselc/src/policies.rs
+++ b/chiselc/src/policies.rs
@@ -345,15 +345,11 @@ impl Predicate {
                 ctx,
             ),
             Predicate::Bin { lhs, rhs, .. } if lhs.is_var() || rhs.is_var() => self.clone(),
-            Predicate::Bin { op, lhs, rhs } => {
-                let new_pred = Predicate::Bin {
-                    op: *op,
-                    lhs: Box::new(lhs.eval(ctx)),
-                    rhs: Box::new(rhs.eval(ctx)),
-                };
-
-                new_pred.eval(ctx)
-            }
+            Predicate::Bin { op, lhs, rhs } => Predicate::Bin {
+                op: *op,
+                lhs: Box::new(lhs.eval(ctx)),
+                rhs: Box::new(rhs.eval(ctx)),
+            },
             Predicate::Not(p) if p.is_lit() => {
                 let js_value = json_to_js_value(p.as_lit().unwrap());
                 Predicate::Lit(Value::Bool(!js_value.as_boolean().unwrap()))

--- a/chiselc/src/tools/functions.rs
+++ b/chiselc/src/tools/functions.rs
@@ -34,7 +34,6 @@ impl<'a> ArrowFunction<'a> {
     }
 
     /// Returns an iterator over the param name and type of the function.
-    #[allow(dead_code)]
     pub fn params(&self) -> impl Iterator<Item = (&Ident, Option<&Ident>)> {
         self.orig.params.iter().map(|p| match p {
             Pat::Ident(ident) => {

--- a/chiselc/tests/filters/filter_properties.rs
+++ b/chiselc/tests/filters/filter_properties.rs
@@ -32,7 +32,7 @@ fn filter() {
 
 #[test]
 fn find_many() {
-    let compiled: Value = dbg!(compile!(
+    let compiled: Value = compile!(
         r#"
         await Person.findMany({ name: "Pekka", age: 39 });
         await Person.findMany({ });
@@ -44,7 +44,7 @@ fn find_many() {
         "#,
         "Person";
         Target::FilterProperties
-    ))
+    )
     .parse()
     .unwrap();
 
@@ -59,7 +59,7 @@ fn find_many() {
 
 #[test]
 fn find_one() {
-    let compiled: Value = dbg!(compile!(
+    let compiled: Value = compile!(
         r#"
         await Person.findOne({ name: "Pekka", age: 39 });
         await Person.findOne({ });
@@ -70,7 +70,7 @@ fn find_one() {
         await Person.findOne({ [property]: "Pekka" });"#,
         "Person";
         Target::FilterProperties
-    ))
+    )
     .parse()
     .unwrap();
 

--- a/server/src/apply.rs
+++ b/server/src/apply.rs
@@ -2,7 +2,7 @@
 
 use crate::api::ApiInfo;
 use crate::datastore::{MetaService, QueryEngine};
-use crate::policies::{EntityPolicy, Policies, VersionPolicy};
+use crate::policies::{Policies, VersionPolicy};
 use crate::proto::{
     type_msg::TypeEnum, ChiselApplyRequest, ContainerType, IndexCandidate, TypeMsg,
 };
@@ -27,27 +27,26 @@ pub struct ApplyResult {
 #[allow(dead_code)]
 pub struct ParsedPolicies {
     version_policy: (VersionPolicy, String),
-    entity_policies: HashMap<String, EntityPolicy>,
 }
 
 impl ParsedPolicies {
     fn parse(request: &[PolicyUpdateRequest]) -> Result<Self> {
         let mut version_policy = None;
-        let mut entity_policies = HashMap::new();
 
         for p in request {
             let path = PathBuf::from(&p.path);
             match path.extension().and_then(|s| s.to_str()) {
                 Some("ts") if FEATURES.typescript_policies => {
-                    let entity_name = path
-                        .file_name()
-                        .and_then(|s| s.to_str())
-                        .and_then(|s| s.strip_suffix(".ts"))
-                        .context("invalid policy path")?
-                        .to_owned();
+                    // let entity_name = path
+                    //     .file_name()
+                    //     .and_then(|s| s.to_str())
+                    //     .and_then(|s| s.strip_suffix(".ts"))
+                    //     .context("invalid policy path")?
+                    //     .to_owned();
 
-                    let policy = EntityPolicy::from_policy_code(p.policy_config.clone())?;
-                    entity_policies.insert(entity_name, policy);
+                    todo!();
+                    // let policy = EntityPolicy::from_policy_code(p.policy_config.clone())?;
+                    // entity_policies.insert(entity_name, policy);
                 }
                 _ => {
                     if version_policy.is_none() {
@@ -64,7 +63,6 @@ impl ParsedPolicies {
 
         Ok(Self {
             version_policy: version_policy.unwrap_or_default(),
-            entity_policies,
         })
     }
 }

--- a/server/src/apply.rs
+++ b/server/src/apply.rs
@@ -24,6 +24,7 @@ pub struct ApplyResult {
     pub version_policy: VersionPolicy,
 }
 
+#[allow(dead_code)]
 pub struct ParsedPolicies {
     version_policy: (VersionPolicy, String),
     entity_policies: HashMap<String, EntityPolicy>,
@@ -104,10 +105,7 @@ pub async fn apply(
         }
     }
 
-    let ParsedPolicies {
-        version_policy,
-        mut entity_policies,
-    } = ParsedPolicies::parse(&apply_request.policies)?;
+    let ParsedPolicies { version_policy, .. } = ParsedPolicies::parse(&apply_request.policies)?;
 
     if !to_remove_has_data.is_empty() && !apply_request.allow_type_deletion {
         let s = to_remove_has_data
@@ -180,14 +178,7 @@ or
             ty_indexes,
         )?);
 
-        let policy = dbg!(&mut entity_policies).remove(&name);
-        new_types.insert(
-            name.to_owned(),
-            dbg!(Entity::Custom {
-                object: ty.clone(),
-                policy,
-            }),
-        );
+        new_types.insert(name.to_owned(), Entity::Custom(ty.clone()));
 
         match version_types.lookup_custom_type(&name) {
             Ok(old_type) => {

--- a/server/src/datastore/crud.rs
+++ b/server/src/datastore/crud.rs
@@ -576,6 +576,7 @@ mod tests {
     };
     use crate::deno::ChiselRequestContext;
     use crate::policies::Policies;
+    use crate::policy::engine::PolicyEngine;
     use crate::types::{FieldDescriptor, ObjectDescriptor};
     use crate::JsonObject;
 
@@ -781,10 +782,12 @@ mod tests {
             headers,
             _method: "GET".into(),
         };
+        let type_policies = PolicyEngine::default();
         super::run_query(
             &RequestContext {
                 policies: &Policies::default(),
                 ts: &make_type_system(&*ENTITIES),
+                type_policies: &type_policies,
                 inner,
             },
             QueryParams {
@@ -1108,6 +1111,7 @@ mod tests {
                     policies: &Policies::default(),
                     ts: &make_type_system(&*ENTITIES),
                     inner,
+                    type_policies: &Default::default(),
                 },
                 entity_name,
                 url,

--- a/server/src/datastore/crud.rs
+++ b/server/src/datastore/crud.rs
@@ -574,6 +574,7 @@ mod tests {
         add_row, binary, fetch_rows, make_entity, make_field, make_type_system, setup_clear_db,
         VERSION,
     };
+    use crate::deno::ChiselRequestContext;
     use crate::policies::Policies;
     use crate::types::{FieldDescriptor, ObjectDescriptor};
     use crate::JsonObject;
@@ -773,14 +774,18 @@ mod tests {
     ) -> Result<JsonObject> {
         let qe = Arc::new(qe.clone());
         let tr = qe.clone().begin_transaction_static().await.unwrap();
+        let inner = ChiselRequestContext {
+            api_version: VERSION.to_owned(),
+            user_id: None,
+            path: "".to_string(),
+            headers,
+            _method: "GET".into(),
+        };
         super::run_query(
             &RequestContext {
                 policies: &Policies::default(),
                 ts: &make_type_system(&*ENTITIES),
-                api_version: VERSION.to_owned(),
-                user_id: None,
-                path: "".to_string(),
-                headers,
+                inner,
             },
             QueryParams {
                 type_name: entity_name.to_owned(),
@@ -1091,14 +1096,18 @@ mod tests {
         }
 
         let delete_from_url = |entity_name: &str, url: &str| {
+            let inner = ChiselRequestContext {
+                path: "".to_string(),
+                _method: "GET".into(),
+                api_version: VERSION.to_owned(),
+                user_id: None,
+                headers: HashMap::default(),
+            };
             delete_from_url(
                 &RequestContext {
                     policies: &Policies::default(),
                     ts: &make_type_system(&*ENTITIES),
-                    api_version: VERSION.to_owned(),
-                    user_id: None,
-                    path: "".to_string(),
-                    headers: HashMap::default(),
+                    inner,
                 },
                 entity_name,
                 url,

--- a/server/src/datastore/crud.rs
+++ b/server/src/datastore/crud.rs
@@ -54,6 +54,7 @@ fn run_query_impl(
         base_type,
         inner: stream,
         policy_instances: std::mem::take(&mut context.policy_instances),
+        engine: context.type_policies.clone(),
     };
 
     Ok(async move {
@@ -792,12 +793,12 @@ mod tests {
             headers,
             _method: "GET".into(),
         };
-        let type_policies = PolicyEngine::default();
+        let type_policies = PolicyEngine::default().into();
         super::run_query(
             &mut RequestContext {
                 policies: &Policies::default(),
                 ts: &make_type_system(&*ENTITIES),
-                type_policies: &type_policies,
+                type_policies,
                 inner,
                 policy_instances: Default::default(),
             },
@@ -1122,7 +1123,7 @@ mod tests {
                     policies: &Policies::default(),
                     ts: &make_type_system(&*ENTITIES),
                     inner,
-                    type_policies: &Default::default(),
+                    type_policies: Default::default(),
                     policy_instances: Default::default(),
                 },
                 entity_name,

--- a/server/src/datastore/meta/mod.rs
+++ b/server/src/datastore/meta/mod.rs
@@ -515,10 +515,7 @@ impl MetaService {
                     let indexes = self.load_type_indexes(type_id, backing_table).await?;
 
                     let ty = ObjectType::new(&desc, fields, indexes)?;
-                    ts.add_custom_type(Entity::Custom {
-                        object: Arc::new(ty),
-                        policy: None,
-                    })?;
+                    ts.add_custom_type(Entity::Custom(Arc::new(ty)))?;
                 }
                 Err(_) => {
                     failures.push(row);
@@ -543,10 +540,7 @@ impl MetaService {
             let indexes = self.load_type_indexes(type_id, backing_table).await?;
 
             let ty = ObjectType::new(&desc, fields, indexes)?;
-            ts.add_custom_type(Entity::Custom {
-                object: Arc::new(ty),
-                policy: None,
-            })?;
+            ts.add_custom_type(Entity::Custom(Arc::new(ty)))?;
         }
 
         Ok(ts)

--- a/server/src/datastore/mod.rs
+++ b/server/src/datastore/mod.rs
@@ -59,6 +59,72 @@ pub mod expr;
 pub mod meta;
 pub mod query;
 
+use std::collections::HashMap;
+use std::task::Poll;
+
 pub use dbconn::DbConnection;
 pub use engine::QueryEngine;
 pub use meta::MetaService;
+
+use deno_core::futures::{self, StreamExt};
+use serde_json::Value as JsonValue;
+
+use self::engine::QueryResults;
+use crate::policy::engine::{Action, PolicyEvalInstance};
+use crate::types::Entity;
+
+struct EntityStream {
+    base_type: Entity,
+    inner: QueryResults,
+    policy_instances: HashMap<String, PolicyEvalInstance>,
+}
+
+impl EntityStream {
+    fn validate(
+        &self,
+        value: serde_json::Map<String, JsonValue>,
+    ) -> anyhow::Result<Option<serde_json::Map<String, JsonValue>>> {
+        match self.policy_instances.get(self.base_type.name()) {
+            Some(instance) => match instance.get_read_action(&self.base_type, &value)? {
+                Action::Allow => Ok(Some(value)),
+                Action::Deny => Err(anyhow::anyhow!("access denied")),
+                Action::Skip => Ok(None),
+                Action::Log => {
+                    info!("json value: {:?}", value);
+                    Ok(Some(value))
+                }
+            },
+            // no policy, don't do anything.
+            None => Ok(Some(value)),
+        }
+    }
+}
+
+impl futures::Stream for EntityStream {
+    type Item = anyhow::Result<serde_json::Map<String, JsonValue>>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        // we "could" be dropping many elements here, to avoid blocking the main loop for too long,
+        // we limit the amount of items that get can get at once, and collaboratively yield.
+        for _ in 0..64 {
+            let item = futures::ready!(self.inner.poll_next_unpin(cx));
+            match item {
+                Some(item) => match item {
+                    Ok(value) => match self.validate(value) {
+                        Ok(Some(value)) => return Poll::Ready(Some(Ok(value))),
+                        Ok(None) => continue,
+                        Err(e) => return Poll::Ready(Some(Err(e))),
+                    },
+                    Err(e) => return Poll::Ready(Some(Err(e))),
+                },
+                None => return Poll::Ready(None),
+            }
+        }
+
+        cx.waker().wake_by_ref();
+        Poll::Pending
+    }
+}

--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -894,10 +894,7 @@ pub mod tests {
 
     pub fn make_entity(name: &str, fields: Vec<Field>) -> Entity {
         let desc = types::NewObject::new(name, VERSION);
-        Entity::Custom {
-            object: Arc::new(ObjectType::new(&desc, fields, vec![]).unwrap()),
-            policy: None,
-        }
+        Entity::Custom(Arc::new(ObjectType::new(&desc, fields, vec![]).unwrap()))
     }
 
     pub fn make_field(name: &str, ty: Type) -> Field {

--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -58,7 +58,7 @@ impl RequestContext<'_> {
             .make_field_policies(&self.user_id, &self.path, ty)
     }
 
-    fn get_or_create_policy_instance(
+    pub fn get_or_create_policy_instance(
         &mut self,
         ty: &Entity,
     ) -> Result<Option<&PolicyEvalInstance>> {

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -501,36 +501,33 @@ async fn op_chisel_read_body(
 }
 
 /// RequestContext corresponds to `requestContext` structure used in datastore.ts.
-#[derive(Deserialize)]
-struct ChiselRequestContext {
+#[derive(Deserialize, Serialize)]
+pub struct ChiselRequestContext {
     /// Current URL path.
-    path: String,
+    pub path: String,
     /// Current HTTP method.
     #[serde(rename = "method")]
-    _method: String,
+    pub _method: String,
     /// Current HTTP request headers.
-    headers: HashMap<String, String>,
+    pub headers: HashMap<String, String>,
     /// Schema version to be used with the request.
     #[serde(rename = "apiVersion")]
-    api_version: String,
+    pub api_version: String,
     /// Current user ID.
     #[serde(rename = "userId")]
-    user_id: Option<String>,
+    pub user_id: Option<String>,
 }
 
 impl RequestContext<'_> {
     fn new<'a>(
         policies: &'a Policies,
         ts: &'a TypeSystem,
-        context: ChiselRequestContext,
+        inner: ChiselRequestContext,
     ) -> RequestContext<'a> {
         RequestContext {
             policies,
             ts,
-            api_version: context.api_version,
-            user_id: context.user_id,
-            path: context.path,
-            headers: context.headers,
+            inner,
         }
     }
 }

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -537,6 +537,7 @@ impl RequestContext<'_> {
             ts,
             type_policies,
             inner,
+            policy_instances: Default::default(),
         }
     }
 }
@@ -604,7 +605,7 @@ async fn op_chisel_entity_delete(
     let mutation = {
         let state = state.borrow_mut();
         Mutation::delete_from_expr(
-            &RequestContext::new(
+            &mut RequestContext::new(
                 current_policies(&state),
                 current_type_system(&state),
                 context,
@@ -646,7 +647,7 @@ async fn op_chisel_crud_delete(
     let mutation = {
         let state = state.borrow_mut();
         crud::delete_from_url(
-            &RequestContext::new(
+            &mut RequestContext::new(
                 current_policies(&state),
                 current_type_system(&state),
                 context,
@@ -723,7 +724,7 @@ async fn op_chisel_crud_query(
         let query_engine = query_engine_arc(op_state);
 
         crud::run_query(
-            &RequestContext::new(
+            &mut RequestContext::new(
                 current_policies(op_state),
                 current_type_system(op_state),
                 context,
@@ -744,7 +745,7 @@ fn op_chisel_relational_query_create(
     context: ChiselRequestContext,
 ) -> Result<ResourceId> {
     let query_plan = QueryPlan::from_op_chain(
-        &RequestContext::new(
+        &mut RequestContext::new(
             current_policies(op_state),
             current_type_system(op_state),
             context,

--- a/server/src/deno.rs
+++ b/server/src/deno.rs
@@ -719,21 +719,17 @@ async fn op_chisel_crud_query(
 ) -> Result<JsonObject> {
     // Contextualize stream creation to prevent state RC borrow living across await
     {
-        let op_state = &state.borrow();
-        let transaction = current_transaction(op_state);
-        let query_engine = query_engine_arc(op_state);
+        let op_state = state.borrow();
+        let transaction = current_transaction(&op_state);
+        let query_engine = query_engine_arc(&op_state);
+        let mut ctx = RequestContext::new(
+            current_policies(&op_state),
+            current_type_system(&op_state),
+            context,
+            policy_engine(&op_state),
+        );
 
-        crud::run_query(
-            &mut RequestContext::new(
-                current_policies(op_state),
-                current_type_system(op_state),
-                context,
-                policy_engine(op_state),
-            ),
-            params,
-            query_engine,
-            transaction,
-        )
+        crud::run_query(&mut ctx, params, query_engine, transaction)
     }
     .await
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -11,7 +11,7 @@ pub use crate::server::{run_all, DoRepeat, Opt};
 pub(crate) type JsonObject = serde_json::Map<String, serde_json::Value>;
 
 pub(crate) static FEATURES: Lazy<Features> = Lazy::new(|| Features {
-    typescript_policies: false,
+    typescript_policies: true,
 });
 
 /// Chiseld experimental features

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -10,7 +10,9 @@ pub use crate::server::{run_all, DoRepeat, Opt};
 
 pub(crate) type JsonObject = serde_json::Map<String, serde_json::Value>;
 
-pub(crate) static FEATURES: Lazy<Features> = Lazy::new(Features::default);
+pub(crate) static FEATURES: Lazy<Features> = Lazy::new(|| Features {
+    typescript_policies: false,
+});
 
 /// Chiseld experimental features
 #[derive(Default)]
@@ -36,6 +38,7 @@ pub(crate) mod internal;
 pub(crate) mod introspect;
 pub(crate) mod kafka;
 pub(crate) mod policies;
+pub(crate) mod policy;
 pub(crate) mod prefix_map;
 pub(crate) mod rcmut;
 pub(crate) mod rpc;

--- a/server/src/policies.rs
+++ b/server/src/policies.rs
@@ -4,7 +4,6 @@ use crate::prefix_map::PrefixMap;
 use crate::types::ObjectType;
 use crate::JsonObject;
 use anyhow::Result;
-use chiselc::parse::ParserContext;
 use hyper::Request;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
@@ -317,20 +316,4 @@ fn parse_methods(v: &Vec<Yaml>) -> Result<Vec<hyper::Method>> {
         }
     }
     Ok(methods)
-}
-
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub struct EntityPolicy {
-    policies: chiselc::policies::Policies,
-}
-
-impl EntityPolicy {
-    #[allow(dead_code)]
-    pub fn from_policy_code(code: String) -> Result<Self> {
-        let ctx = ParserContext::new();
-        let module = ctx.parse(code, true)?;
-        let policies = chiselc::policies::Policies::parse(&module);
-        Ok(Self { policies })
-    }
 }

--- a/server/src/policy/engine.rs
+++ b/server/src/policy/engine.rs
@@ -1,0 +1,41 @@
+use std::cell::RefCell;
+
+use anyhow::Result;
+use chiselc::policies::PolicyEvalContext;
+
+use super::store::Store;
+use crate::datastore::expr::Expr;
+use crate::deno::ChiselRequestContext;
+
+#[derive(Default)]
+pub struct PolicyEngine {
+    eval_context: RefCell<PolicyEvalContext>,
+    store: Store,
+}
+
+impl PolicyEngine {
+    pub fn new(store: Store) -> Self {
+        Self {
+            eval_context: Default::default(),
+            store,
+        }
+    }
+
+    pub fn store_mut(&mut self) -> &mut Store {
+        &mut self.store
+    }
+
+    /// Returns the filters to be applied to the DB query for reading the entity, if any.
+    pub fn read_fitlers(
+        &self,
+        ty_name: &str,
+        version: &str,
+        ctx: &ChiselRequestContext,
+    ) -> Result<Option<Expr>> {
+        let mut eval_ctx = self.eval_context.borrow_mut();
+        self.store
+            .get_policy(version, ty_name)
+            .and_then(|p| p.compute_read_filter(ctx, &mut eval_ctx).transpose())
+            .transpose()
+    }
+}

--- a/server/src/policy/engine.rs
+++ b/server/src/policy/engine.rs
@@ -1,16 +1,140 @@
 use std::cell::RefCell;
+use std::rc::Rc;
 
-use anyhow::Result;
-use chiselc::policies::PolicyEvalContext;
+use anyhow::{bail, Result};
+use chiselc::policies::{Cond, Policy, PolicyEvalContext, Predicate, Predicates, Values, Var};
 
 use super::store::Store;
-use crate::datastore::expr::Expr;
+use crate::datastore::expr::{BinaryExpr, BinaryOp, Expr, PropertyAccess, Value};
 use crate::deno::ChiselRequestContext;
 
 #[derive(Default)]
 pub struct PolicyEngine {
-    eval_context: RefCell<PolicyEvalContext>,
+    eval_context: Rc<RefCell<PolicyEvalContext>>,
     store: Store,
+}
+
+/// An evaluation context instance for a given type, in a given request context.
+/// This instance allows to build the filter expression, or to test the filters against an entity
+/// instance.
+pub struct PolicyEvalInstance {
+    predicates: Predicates,
+    where_conds: Option<Cond>,
+    entity_param_name: String,
+}
+
+impl PolicyEvalInstance {
+    fn new(
+        chisel_ctx: &ChiselRequestContext,
+        read_policy: &Policy,
+        eval_ctx: Rc<RefCell<PolicyEvalContext>>,
+    ) -> Result<Self> {
+        let entity_param_name = read_policy.params().get_positional_param_name(0).to_owned();
+        let ctx_param_name = read_policy.params().get_positional_param_name(1).to_owned();
+
+        let mut env = Values::new();
+        let ctx_json = serde_json::to_value(chisel_ctx)?;
+        env.insert(ctx_param_name.clone(), ctx_json);
+
+        let predicates = read_policy.predicates.substitute(&env);
+        let mut eval_ctx = eval_ctx.borrow_mut();
+        let predicates = predicates.eval(&mut eval_ctx);
+
+        let where_conds = read_policy
+            .where_conds
+            .as_ref()
+            .map(|conds| conds.simplify(&predicates));
+
+        Ok(Self {
+            predicates,
+            where_conds,
+            entity_param_name,
+        })
+    }
+
+    pub fn make_read_filter_expr(&self) -> Result<Option<Expr>> {
+        self.where_conds
+            .as_ref()
+            .map(|w| Self::cond_to_expr(w, &self.predicates, &self.entity_param_name))
+            .transpose()
+    }
+
+    fn cond_to_expr(cond: &Cond, preds: &Predicates, entity_param_name: &str) -> Result<Expr> {
+        let val = match cond {
+            Cond::And(left, right) => {
+                let right = Self::cond_to_expr(right, preds, entity_param_name)?;
+                let left = Self::cond_to_expr(left, preds, entity_param_name)?;
+                Expr::Binary(BinaryExpr {
+                    left: Box::new(left),
+                    op: BinaryOp::And,
+                    right: Box::new(right),
+                })
+            }
+            Cond::Or(left, right) => {
+                let right = Self::cond_to_expr(right, preds, entity_param_name)?;
+                let left = Self::cond_to_expr(left, preds, entity_param_name)?;
+                Expr::Binary(BinaryExpr {
+                    left: Box::new(left),
+                    op: BinaryOp::Or,
+                    right: Box::new(right),
+                })
+            }
+            Cond::Not(cond) => Expr::Not(Box::new(Self::cond_to_expr(
+                cond,
+                preds,
+                entity_param_name,
+            )?)),
+            Cond::Predicate(id) => {
+                let predicate = preds.get(*id);
+                Self::predicate_to_expr(predicate, entity_param_name)?
+            }
+            Cond::True => Expr::Value {
+                value: Value::Bool(true),
+            },
+            Cond::False => Expr::Value {
+                value: Value::Bool(false),
+            },
+        };
+
+        Ok(val)
+    }
+
+    fn predicate_to_expr(pred: &Predicate, entity_param_name: &str) -> Result<Expr> {
+        let val = match pred {
+            Predicate::Bin { op, lhs, rhs } => {
+                let left = Box::new(Self::predicate_to_expr(lhs, entity_param_name)?);
+                let right = Box::new(Self::predicate_to_expr(rhs, entity_param_name)?);
+                Expr::Binary(BinaryExpr {
+                    op: BinaryOp::from(*op),
+                    left,
+                    right,
+                })
+            }
+            Predicate::Not(_) => todo!(),
+            Predicate::Lit(val) => Expr::Value {
+                value: Value::from(val),
+            },
+            Predicate::Var(var) => match var {
+                Var::Ident(id) => bail!("unknow variable: `{id}`"),
+                Var::Member(obj, prop) => {
+                    match &**obj {
+                        // at this point, the only unresolved variables should be our entities, and we
+                        // have statically verified that the correct fields are being accessed.
+                        Var::Ident(n) if n == entity_param_name => {
+                            let property_chain = Expr::Parameter { position: 0 };
+                            Expr::Property(PropertyAccess {
+                                property: prop.to_string(),
+                                object: Box::new(property_chain),
+                            })
+                        } //make_property_chain()?,
+                        other => bail!("unknow variable: `{other:?}`"),
+                    }
+                }
+            },
+        };
+
+        Ok(val)
+    }
 }
 
 impl PolicyEngine {
@@ -25,17 +149,23 @@ impl PolicyEngine {
         &mut self.store
     }
 
-    /// Returns the filters to be applied to the DB query for reading the entity, if any.
-    pub fn read_fitlers(
+    /// Create an evaluation environment instance with the given parameters
+    pub fn instantiate(
         &self,
         ty_name: &str,
         version: &str,
         ctx: &ChiselRequestContext,
-    ) -> Result<Option<Expr>> {
-        let mut eval_ctx = self.eval_context.borrow_mut();
-        self.store
-            .get_policy(version, ty_name)
-            .and_then(|p| p.compute_read_filter(ctx, &mut eval_ctx).transpose())
-            .transpose()
+    ) -> Result<Option<PolicyEvalInstance>> {
+        match self.store.get_policy(version, ty_name) {
+            Some(policy) => match &policy.policies.read {
+                Some(read_policy) => {
+                    let instance =
+                        PolicyEvalInstance::new(ctx, read_policy, self.eval_context.clone())?;
+                    Ok(Some(instance))
+                }
+                None => Ok(None),
+            },
+            None => Ok(None),
+        }
     }
 }

--- a/server/src/policy/mod.rs
+++ b/server/src/policy/mod.rs
@@ -1,0 +1,3 @@
+pub mod engine;
+pub mod store;
+pub mod type_policy;

--- a/server/src/policy/store.rs
+++ b/server/src/policy/store.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+
+use super::type_policy::TypePolicy;
+
+#[derive(Debug, Default)]
+pub struct Store {
+    versions: HashMap<String, TypePolicyStore>,
+}
+
+impl Store {
+    pub fn get_policy(&self, version: &str, ty_name: &str) -> Option<&TypePolicy> {
+        self.versions.get(version).and_then(|p| p.get(ty_name))
+    }
+
+    pub fn insert(&mut self, version: String, policies: TypePolicyStore) {
+        self.versions.insert(version, policies);
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct TypePolicyStore {
+    policies: HashMap<String, TypePolicy>,
+}
+
+impl TypePolicyStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    fn get(&self, ty_name: &str) -> Option<&TypePolicy> {
+        self.policies.get(ty_name)
+    }
+
+    pub fn insert(&mut self, ty_name: String, policy: TypePolicy) {
+        self.policies.insert(ty_name, policy);
+    }
+}

--- a/server/src/policy/type_policy.rs
+++ b/server/src/policy/type_policy.rs
@@ -177,10 +177,10 @@ impl TypePolicy {
         let module = ctx.parse(code.clone(), false)?;
         let ts = PolicyTypeSystem { version, ts };
         let policies = chiselc::policies::Policies::parse(&module, &ts);
-        dbg!(Ok(Self {
+        Ok(Self {
             policies,
-            source: code
-        }))
+            source: code,
+        })
     }
 
     pub fn compute_read_filter(

--- a/server/src/policy/type_policy.rs
+++ b/server/src/policy/type_policy.rs
@@ -1,16 +1,13 @@
 use std::borrow::Cow;
 
-use crate::datastore::expr::{BinaryExpr, BinaryOp, Expr, PropertyAccess, Value};
-use crate::deno::ChiselRequestContext;
 use crate::types::{Type, TypeSystem};
-use anyhow::{bail, Result};
+use anyhow::Result;
 use chiselc::parse::ParserContext;
-use chiselc::policies::{Cond, PolicyEvalContext, Predicate, Predicates, Values, Var};
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct TypePolicy {
-    policies: chiselc::policies::Policies,
+    pub policies: chiselc::policies::Policies,
     source: String,
 }
 
@@ -76,101 +73,6 @@ impl<'a> chiselc::policies::TypeSystem for PolicyTypeSystem<'a> {
     }
 }
 
-struct ReadFilterEvalCtx<'a> {
-    chisel_ctx: &'a ChiselRequestContext,
-    entity_param_name: &'a str,
-    context_param_name: &'a str,
-    predicates: &'a Predicates,
-    where_conds: &'a Cond,
-    eval_ctx: &'a mut PolicyEvalContext,
-}
-
-impl<'a> ReadFilterEvalCtx<'a> {
-    fn eval(self) -> Result<Expr> {
-        let mut values = Values::new();
-        let ctx_json = serde_json::to_value(self.chisel_ctx)?;
-        values.insert(self.context_param_name.into(), ctx_json);
-        let predicates = self.predicates.substitute(&values);
-        let predicates = predicates.eval(self.eval_ctx);
-        let where_conds = self.where_conds.simplify(&predicates);
-
-        self.cond_to_expr(&where_conds, &predicates)
-    }
-
-    fn cond_to_expr(&self, cond: &Cond, preds: &Predicates) -> Result<Expr> {
-        let val = match cond {
-            Cond::And(left, right) => {
-                let right = self.cond_to_expr(right, preds)?;
-                let left = self.cond_to_expr(left, preds)?;
-                Expr::Binary(BinaryExpr {
-                    left: Box::new(left),
-                    op: BinaryOp::And,
-                    right: Box::new(right),
-                })
-            }
-            Cond::Or(left, right) => {
-                let right = self.cond_to_expr(right, preds)?;
-                let left = self.cond_to_expr(left, preds)?;
-                Expr::Binary(BinaryExpr {
-                    left: Box::new(left),
-                    op: BinaryOp::Or,
-                    right: Box::new(right),
-                })
-            }
-            Cond::Not(cond) => Expr::Not(Box::new(self.cond_to_expr(cond, preds)?)),
-            Cond::Predicate(id) => {
-                let predicate = preds.get(*id);
-                self.predicate_to_expr(predicate)?
-            }
-            Cond::True => Expr::Value {
-                value: Value::Bool(true),
-            },
-            Cond::False => Expr::Value {
-                value: Value::Bool(false),
-            },
-        };
-
-        Ok(val)
-    }
-
-    fn predicate_to_expr(&self, pred: &Predicate) -> Result<Expr> {
-        let val = match pred {
-            Predicate::Bin { op, lhs, rhs } => {
-                let left = Box::new(self.predicate_to_expr(lhs)?);
-                let right = Box::new(self.predicate_to_expr(rhs)?);
-                Expr::Binary(BinaryExpr {
-                    op: BinaryOp::from(*op),
-                    left,
-                    right,
-                })
-            }
-            Predicate::Not(_) => todo!(),
-            Predicate::Lit(val) => Expr::Value {
-                value: Value::from(val),
-            },
-            Predicate::Var(var) => match var {
-                Var::Ident(id) => bail!("unknow variable: `{id}`"),
-                Var::Member(obj, prop) => {
-                    match &**obj {
-                        // at this point, the only unresolved variables should be our entities, and we
-                        // have statically verified that the correct fields are being accessed.
-                        Var::Ident(n) if n == self.entity_param_name => {
-                            let property_chain = Expr::Parameter { position: 0 };
-                            Expr::Property(PropertyAccess {
-                                property: prop.to_string(),
-                                object: Box::new(property_chain),
-                            })
-                        }
-                        other => bail!("unknow variable: `{other:?}`"),
-                    }
-                }
-            },
-        };
-
-        Ok(val)
-    }
-}
-
 impl TypePolicy {
     pub fn from_policy_code(code: String, ts: &TypeSystem, version: String) -> Result<Self> {
         let ctx = ParserContext::new();
@@ -181,36 +83,5 @@ impl TypePolicy {
             policies,
             source: code,
         })
-    }
-
-    pub fn compute_read_filter(
-        &self,
-        chisel_ctx: &ChiselRequestContext,
-        eval_ctx: &mut PolicyEvalContext,
-    ) -> Result<Option<Expr>> {
-        match &self.policies.read {
-            Some(
-                p @ chiselc::policies::Policy {
-                    where_conds: Some(where_conds),
-                    predicates,
-                    ..
-                },
-            ) => {
-                let entity_param_name = p.params().get_positional_param_name(0);
-                let context_param_name = p.params().get_positional_param_name(1);
-
-                let ctx = ReadFilterEvalCtx {
-                    chisel_ctx,
-                    entity_param_name,
-                    context_param_name,
-                    predicates,
-                    where_conds,
-                    eval_ctx,
-                };
-
-                ctx.eval().map(Some)
-            }
-            _ => Ok(None),
-        }
     }
 }

--- a/server/src/policy/type_policy.rs
+++ b/server/src/policy/type_policy.rs
@@ -1,0 +1,216 @@
+use std::borrow::Cow;
+
+use crate::datastore::expr::{BinaryExpr, BinaryOp, Expr, PropertyAccess, Value};
+use crate::deno::ChiselRequestContext;
+use crate::types::{Type, TypeSystem};
+use anyhow::{bail, Result};
+use chiselc::parse::ParserContext;
+use chiselc::policies::{Cond, PolicyEvalContext, Predicate, Predicates, Values, Var};
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct TypePolicy {
+    policies: chiselc::policies::Policies,
+    source: String,
+}
+
+struct PolicyTypeSystem<'a> {
+    version: String,
+    ts: &'a TypeSystem,
+}
+
+enum PolicyType<'a> {
+    Type(&'a TypeSystem, Type),
+    ReqContext,
+    String,
+    Object,
+}
+
+impl<'a> chiselc::policies::Type<'a> for PolicyType<'a> {
+    fn get_field_ty(&self, field_name: &str) -> Option<Box<dyn chiselc::policies::Type<'a> + 'a>> {
+        match self {
+            PolicyType::Type(ts, ty) => match ty {
+                Type::Entity(e) => {
+                    let field = e.get_field(field_name)?;
+                    let field_ty = ts.get(&field.type_id).unwrap();
+
+                    Some(Box::new(PolicyType::Type(ts, field_ty)))
+                }
+                _ => None,
+            },
+            PolicyType::ReqContext => {
+                // TODO: this is not robust at all! need to find a better way.
+                match field_name {
+                    "userId" => Some(Box::new(PolicyType::String)),
+                    "method" => Some(Box::new(PolicyType::String)),
+                    "path" => Some(Box::new(PolicyType::String)),
+                    "apiVersion" => Some(Box::new(PolicyType::String)),
+                    "headers" => Some(Box::new(PolicyType::Object)),
+                    _ => None,
+                }
+            }
+            PolicyType::String | PolicyType::Object => None,
+        }
+    }
+
+    fn name(&self) -> Cow<str> {
+        match self {
+            PolicyType::Type(_, ty) => Cow::Owned(ty.name()),
+            PolicyType::ReqContext => Cow::Borrowed("ReqContext"),
+            PolicyType::String => Cow::Borrowed("string"),
+            PolicyType::Object => Cow::Borrowed("object"),
+        }
+    }
+}
+
+impl<'a> chiselc::policies::TypeSystem for PolicyTypeSystem<'a> {
+    fn get_type<'b>(&'b self, name: &str) -> Box<dyn chiselc::policies::Type<'b> + 'b> {
+        if name == "ReqContext" {
+            Box::new(PolicyType::ReqContext)
+        } else {
+            Box::new(PolicyType::Type(
+                self.ts,
+                self.ts.lookup_type(name, &self.version).unwrap(),
+            ))
+        }
+    }
+}
+
+struct ReadFilterEvalCtx<'a> {
+    chisel_ctx: &'a ChiselRequestContext,
+    entity_param_name: &'a str,
+    context_param_name: &'a str,
+    predicates: &'a Predicates,
+    where_conds: &'a Cond,
+    eval_ctx: &'a mut PolicyEvalContext,
+}
+
+impl<'a> ReadFilterEvalCtx<'a> {
+    fn eval(self) -> Result<Expr> {
+        let mut values = Values::new();
+        let ctx_json = serde_json::to_value(self.chisel_ctx)?;
+        values.insert(self.context_param_name.into(), ctx_json);
+        let predicates = self.predicates.substitute(&values);
+        let predicates = predicates.eval(self.eval_ctx);
+        let where_conds = self.where_conds.simplify(&predicates);
+
+        self.cond_to_expr(&where_conds, &predicates)
+    }
+
+    fn cond_to_expr(&self, cond: &Cond, preds: &Predicates) -> Result<Expr> {
+        let val = match cond {
+            Cond::And(left, right) => {
+                let right = self.cond_to_expr(right, preds)?;
+                let left = self.cond_to_expr(left, preds)?;
+                Expr::Binary(BinaryExpr {
+                    left: Box::new(left),
+                    op: BinaryOp::And,
+                    right: Box::new(right),
+                })
+            }
+            Cond::Or(left, right) => {
+                let right = self.cond_to_expr(right, preds)?;
+                let left = self.cond_to_expr(left, preds)?;
+                Expr::Binary(BinaryExpr {
+                    left: Box::new(left),
+                    op: BinaryOp::Or,
+                    right: Box::new(right),
+                })
+            }
+            Cond::Not(cond) => Expr::Not(Box::new(self.cond_to_expr(cond, preds)?)),
+            Cond::Predicate(id) => {
+                let predicate = preds.get(*id);
+                self.predicate_to_expr(predicate)?
+            }
+            Cond::True => Expr::Value {
+                value: Value::Bool(true),
+            },
+            Cond::False => Expr::Value {
+                value: Value::Bool(false),
+            },
+        };
+
+        Ok(val)
+    }
+
+    fn predicate_to_expr(&self, pred: &Predicate) -> Result<Expr> {
+        let val = match pred {
+            Predicate::Bin { op, lhs, rhs } => {
+                let left = Box::new(self.predicate_to_expr(lhs)?);
+                let right = Box::new(self.predicate_to_expr(rhs)?);
+                Expr::Binary(BinaryExpr {
+                    op: BinaryOp::from(*op),
+                    left,
+                    right,
+                })
+            }
+            Predicate::Not(_) => todo!(),
+            Predicate::Lit(val) => Expr::Value {
+                value: Value::from(val),
+            },
+            Predicate::Var(var) => match var {
+                Var::Ident(id) => bail!("unknow variable: `{id}`"),
+                Var::Member(obj, prop) => {
+                    match &**obj {
+                        // at this point, the only unresolved variables should be our entities, and we
+                        // have statically verified that the correct fields are being accessed.
+                        Var::Ident(n) if n == self.entity_param_name => {
+                            let property_chain = Expr::Parameter { position: 0 };
+                            Expr::Property(PropertyAccess {
+                                property: prop.to_string(),
+                                object: Box::new(property_chain),
+                            })
+                        }
+                        other => bail!("unknow variable: `{other:?}`"),
+                    }
+                }
+            },
+        };
+
+        Ok(val)
+    }
+}
+
+impl TypePolicy {
+    pub fn from_policy_code(code: String, ts: &TypeSystem, version: String) -> Result<Self> {
+        let ctx = ParserContext::new();
+        let module = ctx.parse(code.clone(), false)?;
+        let ts = PolicyTypeSystem { version, ts };
+        let policies = chiselc::policies::Policies::parse(&module, &ts);
+        dbg!(Ok(Self {
+            policies,
+            source: code
+        }))
+    }
+
+    pub fn compute_read_filter(
+        &self,
+        chisel_ctx: &ChiselRequestContext,
+        eval_ctx: &mut PolicyEvalContext,
+    ) -> Result<Option<Expr>> {
+        match &self.policies.read {
+            Some(
+                p @ chiselc::policies::Policy {
+                    where_conds: Some(where_conds),
+                    predicates,
+                    ..
+                },
+            ) => {
+                let entity_param_name = p.params().get_positional_param_name(0);
+                let context_param_name = p.params().get_positional_param_name(1);
+
+                let ctx = ReadFilterEvalCtx {
+                    chisel_ctx,
+                    entity_param_name,
+                    context_param_name,
+                    predicates,
+                    where_conds,
+                    eval_ctx,
+                };
+
+                ctx.eval().map(Some)
+            }
+            _ => Ok(None),
+        }
+    }
+}

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -3,11 +3,11 @@
 use crate::api::{ApiInfo, RequestPath};
 use crate::apply::{self, ApplyResult};
 use crate::datastore::{MetaService, QueryEngine};
-use crate::deno;
 use crate::deno::endpoint_path_from_source_path;
 use crate::deno::mutate_policies;
 use crate::deno::remove_type_version;
 use crate::deno::set_type_system;
+use crate::deno::{self, set_version_type_policies};
 use crate::internal::mark_ready;
 use crate::policies::Policies;
 use crate::prefix_map::PrefixMap;
@@ -284,6 +284,7 @@ impl RpcService {
             type_names_user_order,
             labels,
             version_policy,
+            type_policies,
         } = {
             // help the borrow checker figure out that the borrows below are safe
             let state: &mut GlobalRpcState = &mut state;
@@ -324,6 +325,8 @@ impl RpcService {
                     policies.versions.insert(pol_version, version_policy);
                 })
                 .await;
+
+                set_version_type_policies(api_version.clone(), type_policies).await;
 
                 let runtime = runtime::get();
                 runtime.api.remove_routes(&prefix);

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -3,15 +3,16 @@
 use crate::api::ApiService;
 use crate::datastore::{DbConnection, MetaService, QueryEngine};
 use crate::deno;
-use crate::deno::init_deno;
 use crate::deno::set_meta;
 use crate::deno::set_policies;
 use crate::deno::set_query_engine;
 use crate::deno::set_type_system;
 use crate::deno::update_secrets;
 use crate::deno::{activate_endpoint, activate_event_handler, compile_endpoints};
+use crate::deno::{init_deno, init_type_policies};
 use crate::internal::mark_not_ready;
 use crate::kafka;
+use crate::policy::store::Store;
 use crate::rpc::InitState;
 use crate::rpc::{GlobalRpcState, RpcService};
 use crate::runtime;
@@ -260,6 +261,7 @@ async fn run(state: SharedState, init: InitState, mut cmd: ExecutorChannel) -> R
     set_query_engine(query_engine).await;
     set_policies(policies).await;
     set_meta(meta).await;
+    init_type_policies(Store::default()).await;
 
     // add_endpoints expects a HashMap, not a PrefixMap
     let hashmap = sources

--- a/server/src/types/mod.rs
+++ b/server/src/types/mod.rs
@@ -3,7 +3,6 @@
 pub use self::builtin::BuiltinTypes;
 pub use self::type_system::{TypeSystem, TypeSystemError};
 use crate::datastore::query::truncate_identifier;
-use crate::policies::EntityPolicy;
 use std::collections::BTreeMap;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -39,14 +38,10 @@ impl From<Entity> for Type {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Entity {
     /// User defined Custom entity.
-    Custom {
-        object: Arc<ObjectType>,
-        #[allow(dead_code)]
-        policy: Option<EntityPolicy>,
-    },
+    Custom(Arc<ObjectType>),
     /// Built-in Auth entity.
     Auth(Arc<ObjectType>),
 }
@@ -62,17 +57,7 @@ impl Deref for Entity {
     type Target = ObjectType;
     fn deref(&self) -> &Self::Target {
         match self {
-            Self::Custom { object, .. } | Self::Auth(object) => object,
-        }
-    }
-}
-
-impl PartialEq for Entity {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Entity::Custom { object: o1, .. }, Entity::Custom { object: o2, .. })
-            | (Entity::Auth(o1), Entity::Auth(o2)) => o1 == o2,
-            _ => false,
+            Self::Custom(obj) | Self::Auth(obj) => obj,
         }
     }
 }


### PR DESCRIPTION
This PR apply post-read filters to the CRUD endpoints.

Once the pre-filter have been applied to the to the SQL query, each result  is passed through the post-filter, where the action to be performed on it is determined. Actions are allow, skip, deny and log.

For now this only apply to crud enpoints only, some more work need to be done for it to work with other endpoint, once #1618 gets merged