### PR TITLE
add optional filter param for integration

### DIFF
--- a/cli/tests/integration_tests/lit.rs
+++ b/cli/tests/integration_tests/lit.rs
@@ -70,7 +70,7 @@ fn run_tests_inner(opt: &Opt, ports: &AtomicU16, optimize: bool) -> bool {
         .map(|path| std::fs::canonicalize(path.unwrap()).unwrap())
         .collect::<Vec<_>>();
 
-    if let Some(name_regex) = opt.test.as_ref() {
+    if let Some(name_regex) = opt.test.as_ref().or(opt.test_arg.as_ref()) {
         lit_files = lit_files
             .into_iter()
             .filter(|path| name_regex.is_match(path.to_str().unwrap()))

--- a/cli/tests/integration_tests/main.rs
+++ b/cli/tests/integration_tests/main.rs
@@ -70,6 +70,7 @@ pub struct Opt {
     /// Number of Rust tests to run in parallel (does not apply to lit).
     #[structopt(short, long)]
     pub parallel: Option<usize>,
+    test_arg: Option<Regex>,
 }
 
 fn main() -> ExitCode {

--- a/cli/tests/integration_tests/suite.rs
+++ b/cli/tests/integration_tests/suite.rs
@@ -39,7 +39,7 @@ impl TestSuite {
             [true, false]
         )
         .filter_map(|(test_spec, modules, optimize)| {
-            if let Some(name_regex) = opt.test.as_ref() {
+            if let Some(name_regex) = opt.test.as_ref().or(opt.test_arg.as_ref()) {
                 if !name_regex.is_match(test_spec.name) {
                     return None;
                 }

--- a/cli/tests/linters.rs
+++ b/cli/tests/linters.rs
@@ -2,8 +2,7 @@
 
 mod common;
 
-#[cfg(test)]
-mod tests {
+mod linters {
     use crate::common::{repo_dir, run, Command, CHISEL_BIN_DIR};
     use regex::Regex;
     use std::fs::{create_dir_all, File};


### PR DESCRIPTION
This pr adds an optional param to the integration test binary to take a filter expression.

Now you can do

```
cargo t policies
```
instead of
```
cargo t -p cli -- --test policies
```

More than just a convenience, this makes us a bit more compatible with the rust test harness, since the first command used to fail, because integration did not support this interface.

also rename the linters test module from `test` to `linters`, to make filtering easier, if you want to run the  linter tests, you do:
```
cargo t linters
```
