### PR TITLE
add nocapture to test framework

### DIFF
--- a/cli/tests/integration_tests/main.rs
+++ b/cli/tests/integration_tests/main.rs
@@ -71,6 +71,10 @@ pub struct Opt {
     #[structopt(short, long)]
     pub parallel: Option<usize>,
     test_arg: Option<Regex>,
+
+    /// don't capture stdout/stderr of each task, allow printing directly
+    #[structopt(long)]
+    nocapture: bool,
 }
 
 fn main() -> ExitCode {

--- a/cli/tests/integration_tests/rust.rs
+++ b/cli/tests/integration_tests/rust.rs
@@ -110,7 +110,7 @@ async fn setup_test_context(
     ])
     .current_dir(tmp_dir.path());
 
-    let mut chiseld = GuardedChild::new(cmd);
+    let mut chiseld = GuardedChild::new(cmd, !opt.nocapture);
     wait_for_chiseld_startup(&mut chiseld, &chisel).await;
 
     TestContext {


### PR DESCRIPTION
adds a `nocapture` flag to the test framework. This flag is compliant with rust test interface, and can be passed like so:

```
cargo test -- --nocapture
```

When it is raised, all output from chiseld is echoed to stdout.
