### PR TITLE
Reject unexpected YAML elements in policy files

### DIFF
--- a/cli/tests/integration_tests/rust_tests/policies_parsing.rs
+++ b/cli/tests/integration_tests/rust_tests/policies_parsing.rs
@@ -109,3 +109,19 @@ pub async fn routes_nonarray(c: TestContext) {
     c.chisel.write("policies/p.yaml", "routes: {}");
     c.chisel.apply_err().await.stderr.read("value for routes");
 }
+
+#[chisel_macros::test(modules = Node)]
+pub async fn route_pathless(c: TestContext) {
+    c.chisel.write("policies/p.yaml", "routes: [{}]");
+    c.chisel
+        .apply_err()
+        .await
+        .stderr
+        .read("route without a path");
+}
+
+#[chisel_macros::test(modules = Node)]
+pub async fn route_invalid_path(c: TestContext) {
+    c.chisel.write("policies/p.yaml", "routes: [{ path: [] }]");
+    c.chisel.apply_err().await.stderr.read("route path isn't a string");
+}

--- a/cli/tests/integration_tests/rust_tests/policies_parsing.rs
+++ b/cli/tests/integration_tests/rust_tests/policies_parsing.rs
@@ -125,3 +125,25 @@ pub async fn route_invalid_path(c: TestContext) {
     c.chisel.write("policies/p.yaml", "routes: [{ path: [] }]");
     c.chisel.apply_err().await.stderr.read("route path isn't a string");
 }
+
+#[chisel_macros::test(modules = Node)]
+pub async fn route_invalid_users(c: TestContext) {
+    c.chisel
+        .write("policies/p.yaml", "routes: [{ path: /, users: false }]");
+    c.chisel
+        .apply_err()
+        .await
+        .stderr
+        .read("route users isn't a string");
+}
+
+#[chisel_macros::test(modules = Node)]
+pub async fn route_unknown_key(c: TestContext) {
+    c.chisel
+        .write("policies/p.yaml", "routes: [{ path: /, randomxyz: 0 }]");
+    c.chisel.apply_err().await.stderr.read("randomxyz");
+
+    c.chisel
+        .write("policies/p.yaml", "routes: [{ path: /, 84390232: 0 }]");
+    c.chisel.apply_err().await.stderr.read("84390232");
+}

--- a/cli/tests/integration_tests/rust_tests/policies_parsing.rs
+++ b/cli/tests/integration_tests/rust_tests/policies_parsing.rs
@@ -56,6 +56,19 @@ pub async fn label_invalid_name(c: TestContext) {
 }
 
 #[chisel_macros::test(modules = Node)]
+pub async fn label_invalid_excepturi(c: TestContext) {
+    c.chisel.write(
+        "policies/p.yaml",
+        "labels: [{ name: a, except_uri: [a, b] }]",
+    );
+    c.chisel
+        .apply_err()
+        .await
+        .stderr
+        .read("except_uri isn't a string");
+}
+
+#[chisel_macros::test(modules = Node)]
 pub async fn label_not_dict(c: TestContext) {
     c.chisel.write("policies/p.yaml", "labels: [abc]");
     c.chisel

--- a/cli/tests/integration_tests/rust_tests/policies_parsing.rs
+++ b/cli/tests/integration_tests/rust_tests/policies_parsing.rs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
+
+use crate::framework::prelude::*;
+
+#[chisel_macros::test(modules = Node)]
+pub async fn top_level_unknown_key(c: TestContext) {
+    c.chisel
+        .write("policies/p.yaml", "neither_labels_nor_routes: 0");
+    c.chisel
+        .apply_err()
+        .await
+        .stderr
+        .read("neither_labels_nor_routes");
+
+    c.chisel.write("policies/p.yaml", "43289204: 0");
+    c.chisel.apply_err().await.stderr.read("43289204");
+}
+
+#[chisel_macros::test(modules = Node)]
+pub async fn top_level_number(c: TestContext) {
+    c.chisel.write("policies/p.yaml", "0");
+    c.chisel.apply_err().await.stderr.read("isn't a dictionary");
+}
+
+#[chisel_macros::test(modules = Node)]
+pub async fn top_level_string(c: TestContext) {
+    c.chisel.write("policies/p.yaml", "abc");
+    c.chisel.apply_err().await.stderr.read("isn't a dictionary");
+}
+
+#[chisel_macros::test(modules = Node)]
+pub async fn labels_nonarray(c: TestContext) {
+    c.chisel.write("policies/p.yaml", "labels: {}");
+    c.chisel.apply_err().await.stderr.read("value for labels");
+}
+
+#[chisel_macros::test(modules = Node)]
+pub async fn routes_nonarray(c: TestContext) {
+    c.chisel.write("policies/p.yaml", "routes: {}");
+    c.chisel.apply_err().await.stderr.read("value for routes");
+}

--- a/cli/tests/integration_tests/rust_tests/policies_parsing.rs
+++ b/cli/tests/integration_tests/rust_tests/policies_parsing.rs
@@ -46,6 +46,16 @@ pub async fn label_nameless(c: TestContext) {
 }
 
 #[chisel_macros::test(modules = Node)]
+pub async fn label_not_dict(c: TestContext) {
+    c.chisel.write("policies/p.yaml", "labels: [abc]");
+    c.chisel
+        .apply_err()
+        .await
+        .stderr
+        .read("label not a dictionary");
+}
+
+#[chisel_macros::test(modules = Node)]
 pub async fn routes_nonarray(c: TestContext) {
     c.chisel.write("policies/p.yaml", "routes: {}");
     c.chisel.apply_err().await.stderr.read("value for routes");

--- a/cli/tests/integration_tests/rust_tests/policies_parsing.rs
+++ b/cli/tests/integration_tests/rust_tests/policies_parsing.rs
@@ -79,6 +79,32 @@ pub async fn label_not_dict(c: TestContext) {
 }
 
 #[chisel_macros::test(modules = Node)]
+pub async fn label_unknown_key(c: TestContext) {
+    c.chisel
+        .write("policies/p.yaml", "labels: [{ name: a, randomxyz: 0 }]");
+    c.chisel.apply_err().await.stderr.read("randomxyz");
+
+    c.chisel
+        .write("policies/p.yaml", "labels: [{ name: a, 84390232: 0 }]");
+    c.chisel.apply_err().await.stderr.read("84390232");
+}
+
+#[chisel_macros::test(modules = Node)]
+pub async fn label_unknown_transform(c: TestContext) {
+    c.chisel.write(
+        "policies/p.yaml",
+        "labels: [{ name: a, transform: rrraaannnddd }]",
+    );
+    c.chisel.apply_err().await.stderr.read("rrraaannnddd");
+
+    c.chisel.write(
+        "policies/p.yaml",
+        "labels: [{ name: a, transform: 309842 }]",
+    );
+    c.chisel.apply_err().await.stderr.read("309842");
+}
+
+#[chisel_macros::test(modules = Node)]
 pub async fn routes_nonarray(c: TestContext) {
     c.chisel.write("policies/p.yaml", "routes: {}");
     c.chisel.apply_err().await.stderr.read("value for routes");

--- a/cli/tests/integration_tests/rust_tests/policies_parsing.rs
+++ b/cli/tests/integration_tests/rust_tests/policies_parsing.rs
@@ -35,6 +35,17 @@ pub async fn labels_nonarray(c: TestContext) {
 }
 
 #[chisel_macros::test(modules = Node)]
+pub async fn label_nameless(c: TestContext) {
+    c.chisel
+        .write("policies/p.yaml", "labels: [{ transform: omit }]");
+    c.chisel
+        .apply_err()
+        .await
+        .stderr
+        .read("label without a name");
+}
+
+#[chisel_macros::test(modules = Node)]
 pub async fn routes_nonarray(c: TestContext) {
     c.chisel.write("policies/p.yaml", "routes: {}");
     c.chisel.apply_err().await.stderr.read("value for routes");

--- a/cli/tests/integration_tests/rust_tests/policies_parsing.rs
+++ b/cli/tests/integration_tests/rust_tests/policies_parsing.rs
@@ -46,6 +46,16 @@ pub async fn label_nameless(c: TestContext) {
 }
 
 #[chisel_macros::test(modules = Node)]
+pub async fn label_invalid_name(c: TestContext) {
+    c.chisel.write("policies/p.yaml", "labels: [{ name: {} }]");
+    c.chisel
+        .apply_err()
+        .await
+        .stderr
+        .read("label name isn't a string");
+}
+
+#[chisel_macros::test(modules = Node)]
 pub async fn label_not_dict(c: TestContext) {
     c.chisel.write("policies/p.yaml", "labels: [abc]");
     c.chisel

--- a/server/src/policies.rs
+++ b/server/src/policies.rs
@@ -225,6 +225,10 @@ impl VersionPolicy {
 
     fn add_labels(&mut self, labels: &[Yaml]) -> Result<()> {
         for label in labels.iter() {
+            if label.as_hash().is_none() {
+                anyhow::bail!("label not a dictionary: {label:?}");
+            }
+
             let name = label["name"].as_str().ok_or_else(|| {
                 anyhow::anyhow!("couldn't parse yaml: label without a name: {:?}", label)
             })?;

--- a/server/src/policies.rs
+++ b/server/src/policies.rs
@@ -229,9 +229,11 @@ impl VersionPolicy {
                 anyhow::bail!("label not a dictionary: {label:?}");
             }
 
-            let name = label["name"].as_str().ok_or_else(|| {
-                anyhow::anyhow!("couldn't parse yaml: label without a name: {:?}", label)
-            })?;
+            let name = match &label["name"] {
+                Yaml::String(s) => s,
+                Yaml::BadValue => anyhow::bail!("label without a name: {label:?}"),
+                x => anyhow::bail!("label name isn't a string: {x:?}"),
+            };
 
             debug!("Applying policy for label {:?}", name);
             let pattern = label["except_uri"].as_str().unwrap_or("^$"); // ^$ never matches; each path has at least a '/' in it.

--- a/server/src/policies.rs
+++ b/server/src/policies.rs
@@ -236,7 +236,11 @@ impl VersionPolicy {
             };
 
             debug!("Applying policy for label {:?}", name);
-            let pattern = label["except_uri"].as_str().unwrap_or("^$"); // ^$ never matches; each path has at least a '/' in it.
+            let pattern = match &label["except_uri"] {
+                Yaml::String(s) => s,
+                Yaml::BadValue => "^$", // ^$ never matches; each path has at least a '/' in it.
+                x => anyhow::bail!("except_uri isn't a string: {x:?}"),
+            };
 
             match label["transform"].as_str() {
                 Some("anonymize") => {


### PR DESCRIPTION
It's too easy to mistype some YAML and fail to apply a policy, without any warning or error.