### PR TITLE
Replace npx with node in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,9 @@ cargo build
 
 That will build the `chiseld` server and `chisel` utility.
 
-You can now use `npx` to install a local version of the API:
+You can now use `create-chiselstrike-app` to install a local version of the API:
 ```console
-npx ./packages/create-chiselstrike-app --chisel-version="file:../packages/chiselstrike-api" my-backend
+node ./packages/create-chiselstrike-app --chisel-version="file:../packages/chiselstrike-api" my-backend
 ```
 
 And then replace instances of `npm run` with direct calls to the new binaries. For example, instead of


### PR DESCRIPTION
npx does not work with paths

In Node 14.x CLI documentation it's unclear that it's valid to pass a path to a package, however I've tested it and it seems to work as documented by Node 16.x documentation:  

	https://nodejs.org/docs/latest-v16.x/api/cli.html#command-line-api