### PR TITLE
Import polyfills in place of Node standard modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "third_party/deno"]
 	path = third_party/deno
 	url = https://github.com/denoland/deno.git
+[submodule "third_party/deno_std"]
+	path = third_party/deno_std
+	url = https://github.com/denoland/deno_std.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,37 @@ dependencies = [
  "swc_atoms 0.2.13",
  "swc_common 0.17.25",
  "swc_ecmascript 0.143.0",
- "text_lines",
+ "text_lines 0.4.1",
+ "url 2.3.1",
+]
+
+[[package]]
+name = "deno_ast"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5cf170fd04887b88d88c9951c2c2cb0e1feb1681636987fb3202384db962950"
+dependencies = [
+ "anyhow",
+ "base64 0.13.0",
+ "data-url",
+ "dprint-swc-ext",
+ "serde",
+ "swc_atoms 0.4.10",
+ "swc_common 0.27.13",
+ "swc_ecma_ast 0.90.17",
+ "swc_ecma_codegen 0.123.2",
+ "swc_ecma_codegen_macros",
+ "swc_ecma_loader",
+ "swc_ecma_parser 0.118.7",
+ "swc_ecma_transforms_base 0.106.4",
+ "swc_ecma_transforms_classes",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_transforms_proposal",
+ "swc_ecma_transforms_react 0.148.1",
+ "swc_ecma_transforms_typescript 0.152.1",
+ "swc_ecma_utils 0.101.3",
+ "swc_ecma_visit 0.76.7",
+ "text_lines 0.6.0",
  "url 2.3.1",
 ]
 
@@ -1236,7 +1266,7 @@ dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
  "data-url",
- "deno_ast",
+ "deno_ast 0.14.1",
  "futures",
  "lazy_static",
  "parking_lot 0.12.1",
@@ -1353,6 +1383,16 @@ dependencies = [
  "uuid 1.1.2",
  "winapi",
  "winres",
+]
+
+[[package]]
+name = "deno_std"
+version = "0.13.0-dev.0"
+dependencies = [
+ "anyhow",
+ "deno_ast 0.19.0",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -1539,6 +1579,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da3db6fcad7c1fc4abdd99bf5276a4db30d6a819127903a709ed41e5ff016e84"
 dependencies = [
  "dirs 4.0.0",
+]
+
+[[package]]
+name = "dprint-swc-ext"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c478ec192ebe45411ebe70aef5bd33d22ec54ff7a08885dff16d0bb352525325"
+dependencies = [
+ "bumpalo",
+ "num-bigint",
+ "rustc-hash",
+ "swc_atoms 0.4.10",
+ "swc_common 0.27.13",
+ "swc_ecma_ast 0.90.17",
+ "swc_ecma_parser 0.118.7",
+ "text_lines 0.6.0",
 ]
 
 [[package]]
@@ -3366,6 +3422,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4375,6 +4437,7 @@ dependencies = [
  "chiselc",
  "deno_core",
  "deno_runtime",
+ "deno_std",
  "dirs 4.0.0",
  "enclose",
  "enum-as-inner 0.3.4",
@@ -4895,6 +4958,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_atoms"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb43a79c8affc20f5d52b7db093399585ce87674427adc60843dbc8ec242608"
+dependencies = [
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "string_cache",
+ "string_cache_codegen",
+]
+
+[[package]]
 name = "swc_common"
 version = "0.17.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4940,6 +5016,34 @@ dependencies = [
  "siphasher",
  "string_cache",
  "swc_atoms 0.3.1",
+ "swc_eq_ignore_macros",
+ "swc_visit 0.5.2",
+ "tracing",
+ "unicode-width",
+ "url 2.3.1",
+]
+
+[[package]]
+name = "swc_common"
+version = "0.27.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba38a2f1291fcf3f78f357802b8cec72ecf5e95808e9d937783e60cd3570b93"
+dependencies = [
+ "ahash",
+ "ast_node 0.8.4",
+ "better_scoped_tls",
+ "cfg-if 1.0.0",
+ "debug_unreachable",
+ "either",
+ "from_variant",
+ "num-bigint",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "siphasher",
+ "sourcemap",
+ "string_cache",
+ "swc_atoms 0.4.10",
  "swc_eq_ignore_macros",
  "swc_visit 0.5.2",
  "tracing",
@@ -5006,6 +5110,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_ecma_ast"
+version = "0.90.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41e78ceea39b1dacef1e7cda29488131677224bf6111ed5e853791d81c8a36da"
+dependencies = [
+ "bitflags",
+ "is-macro",
+ "num-bigint",
+ "scoped-tls",
+ "serde",
+ "string_enum",
+ "swc_atoms 0.4.10",
+ "swc_common 0.27.13",
+ "unicode-id",
+]
+
+[[package]]
 name = "swc_ecma_codegen"
 version = "0.119.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5020,6 +5141,25 @@ dependencies = [
  "swc_atoms 0.3.1",
  "swc_common 0.25.0",
  "swc_ecma_ast 0.88.1",
+ "swc_ecma_codegen_macros",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_codegen"
+version = "0.123.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a787c39a5b30c077744c564c533bd294db36d70edfb43d1073e249ca14316b87"
+dependencies = [
+ "memchr",
+ "num-bigint",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "sourcemap",
+ "swc_atoms 0.4.10",
+ "swc_common 0.27.13",
+ "swc_ecma_ast 0.90.17",
  "swc_ecma_codegen_macros",
  "tracing",
 ]
@@ -5047,6 +5187,20 @@ dependencies = [
  "swc_common 0.17.25",
  "swc_ecma_ast 0.75.0",
  "swc_ecma_visit 0.61.0",
+]
+
+[[package]]
+name = "swc_ecma_loader"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece6023a43222e3bd36e3d191fa5289c848245b97fbf0127d9c0923165648d18"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "pathdiff",
+ "serde",
+ "swc_common 0.27.13",
+ "tracing",
 ]
 
 [[package]]
@@ -5089,6 +5243,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_ecma_parser"
+version = "0.118.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b993963c284a2cadf46213ba0f4faa8a5153cfb02437f07ef21ebd90e598cae7"
+dependencies = [
+ "either",
+ "enum_kind",
+ "lexical",
+ "num-bigint",
+ "serde",
+ "smallvec",
+ "swc_atoms 0.4.10",
+ "swc_common 0.27.13",
+ "swc_ecma_ast 0.90.17",
+ "tracing",
+ "typed-arena",
+]
+
+[[package]]
 name = "swc_ecma_transforms"
 version = "0.180.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5097,9 +5270,9 @@ dependencies = [
  "swc_atoms 0.3.1",
  "swc_common 0.25.0",
  "swc_ecma_ast 0.88.1",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_typescript",
- "swc_ecma_utils",
+ "swc_ecma_transforms_base 0.101.1",
+ "swc_ecma_transforms_typescript 0.142.0",
+ "swc_ecma_utils 0.97.0",
  "swc_ecma_visit 0.74.1",
 ]
 
@@ -5121,9 +5294,45 @@ dependencies = [
  "swc_common 0.25.0",
  "swc_ecma_ast 0.88.1",
  "swc_ecma_parser 0.115.1",
- "swc_ecma_utils",
+ "swc_ecma_utils 0.97.0",
  "swc_ecma_visit 0.74.1",
  "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_base"
+version = "0.106.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecfcecd7aad760171c0c392a856bec5291365a33bc03da5a1f24e26eccdffb7e"
+dependencies = [
+ "better_scoped_tls",
+ "bitflags",
+ "once_cell",
+ "phf",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "swc_atoms 0.4.10",
+ "swc_common 0.27.13",
+ "swc_ecma_ast 0.90.17",
+ "swc_ecma_parser 0.118.7",
+ "swc_ecma_utils 0.101.3",
+ "swc_ecma_visit 0.76.7",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_classes"
+version = "0.95.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b748eddc9fe274648f7f6344f405a520a30f8574af76f8fb22c6a59508418382"
+dependencies = [
+ "swc_atoms 0.4.10",
+ "swc_common 0.27.13",
+ "swc_ecma_ast 0.90.17",
+ "swc_ecma_transforms_base 0.106.4",
+ "swc_ecma_utils 0.101.3",
+ "swc_ecma_visit 0.76.7",
 ]
 
 [[package]]
@@ -5137,6 +5346,25 @@ dependencies = [
  "quote 1.0.21",
  "swc_macros_common",
  "syn 1.0.99",
+]
+
+[[package]]
+name = "swc_ecma_transforms_proposal"
+version = "0.137.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bfcb3be3cdf374b53f61a2efdddfccaf6c1261171d02b0eb5838fd44c51223"
+dependencies = [
+ "either",
+ "serde",
+ "smallvec",
+ "swc_atoms 0.4.10",
+ "swc_common 0.27.13",
+ "swc_ecma_ast 0.90.17",
+ "swc_ecma_transforms_base 0.106.4",
+ "swc_ecma_transforms_classes",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils 0.101.3",
+ "swc_ecma_visit 0.76.7",
 ]
 
 [[package]]
@@ -5159,10 +5387,36 @@ dependencies = [
  "swc_config",
  "swc_ecma_ast 0.88.1",
  "swc_ecma_parser 0.115.1",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 0.101.1",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
+ "swc_ecma_utils 0.97.0",
  "swc_ecma_visit 0.74.1",
+]
+
+[[package]]
+name = "swc_ecma_transforms_react"
+version = "0.148.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb912b97e944a4bcf7088823efb068e037f5c64db9e75c94a3138bd8c202578f"
+dependencies = [
+ "ahash",
+ "base64 0.13.0",
+ "dashmap",
+ "indexmap",
+ "once_cell",
+ "regex",
+ "serde",
+ "sha-1 0.10.0",
+ "string_enum",
+ "swc_atoms 0.4.10",
+ "swc_common 0.27.13",
+ "swc_config",
+ "swc_ecma_ast 0.90.17",
+ "swc_ecma_parser 0.118.7",
+ "swc_ecma_transforms_base 0.106.4",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils 0.101.3",
+ "swc_ecma_visit 0.76.7",
 ]
 
 [[package]]
@@ -5175,10 +5429,26 @@ dependencies = [
  "swc_atoms 0.3.1",
  "swc_common 0.25.0",
  "swc_ecma_ast 0.88.1",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_react",
- "swc_ecma_utils",
+ "swc_ecma_transforms_base 0.101.1",
+ "swc_ecma_transforms_react 0.138.0",
+ "swc_ecma_utils 0.97.0",
  "swc_ecma_visit 0.74.1",
+]
+
+[[package]]
+name = "swc_ecma_transforms_typescript"
+version = "0.152.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c919518f8b5f03df0e2c6a55ad44a0a3835125fbf569e5983bd2380b76e2e7c6"
+dependencies = [
+ "serde",
+ "swc_atoms 0.4.10",
+ "swc_common 0.27.13",
+ "swc_ecma_ast 0.90.17",
+ "swc_ecma_transforms_base 0.106.4",
+ "swc_ecma_transforms_react 0.148.1",
+ "swc_ecma_utils 0.101.3",
+ "swc_ecma_visit 0.76.7",
 ]
 
 [[package]]
@@ -5193,6 +5463,23 @@ dependencies = [
  "swc_common 0.25.0",
  "swc_ecma_ast 0.88.1",
  "swc_ecma_visit 0.74.1",
+ "tracing",
+ "unicode-id",
+]
+
+[[package]]
+name = "swc_ecma_utils"
+version = "0.101.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a8a5b246246809b4cf526e838fd1284828ccaca56521d9af19b082862bc845"
+dependencies = [
+ "indexmap",
+ "num_cpus",
+ "once_cell",
+ "swc_atoms 0.4.10",
+ "swc_common 0.27.13",
+ "swc_ecma_ast 0.90.17",
+ "swc_ecma_visit 0.76.7",
  "tracing",
  "unicode-id",
 ]
@@ -5226,6 +5513,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_ecma_visit"
+version = "0.76.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c658568ed63dd13357bae4129999bacb9260d709f260fb49e14a56587ed5dab9"
+dependencies = [
+ "num-bigint",
+ "swc_atoms 0.4.10",
+ "swc_common 0.27.13",
+ "swc_ecma_ast 0.90.17",
+ "swc_visit 0.5.2",
+ "tracing",
+]
+
+[[package]]
 name = "swc_ecmascript"
 version = "0.143.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5243,7 +5544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1f8e9a7b96496f20a426af020190acf4af98976058d6f6e2889be7c5f290f1"
 dependencies = [
  "swc_ecma_ast 0.88.1",
- "swc_ecma_codegen",
+ "swc_ecma_codegen 0.119.2",
  "swc_ecma_parser 0.115.1",
  "swc_ecma_transforms",
  "swc_ecma_visit 0.74.1",
@@ -5423,6 +5724,15 @@ name = "text_lines"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e49e3c53dd04de8b8e8390bc4fab57f6db7af7d33b086fe411803e6351c9f9f9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "text_lines"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd5828de7deaa782e1dd713006ae96b3bee32d3279b79eb67ecf8072c059bcf"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "chiselc",
     "cli",
     "dbgarc",
+    "deno_std",
     "my_tsc",
     "packages",
     "server",

--- a/api/src/main.js
+++ b/api/src/main.js
@@ -6,6 +6,6 @@
 // apply`. This transitively loads all user code.
 import { routeMap, topicMap } from "file:///__root.ts";
 
-/// Continue in TypeScript.
+// Continue in TypeScript.
 import run from "chisel://api/run.ts";
 await run(routeMap, topicMap);

--- a/cli/src/cmd/apply/node.rs
+++ b/cli/src/cmd/apply/node.rs
@@ -131,6 +131,7 @@ pub(crate) async fn apply(
     let banner = concat!(
         "import { createRequire as __createRequire } from 'chisel://deno-std/node/module.ts'; ",
         "var require = __createRequire(import.meta.url);",
+        "var __filename = '__root.ts';",
     );
 
     let bundler_args: Vec<OsString> = vec![

--- a/cli/src/cmd/apply/node.rs
+++ b/cli/src/cmd/apply/node.rs
@@ -128,6 +128,11 @@ pub(crate) async fn apply(
     fs::write(&root_path, root_code)
         .context(format!("Could not write to file {}", root_path.display()))?;
 
+    let banner = concat!(
+        "import { createRequire as __createRequire } from 'chisel://deno-std/node/module.ts'; ",
+        "var require = __createRequire(import.meta.url);",
+    );
+
     let bundler_args: Vec<OsString> = vec![
         root_path.into(),
         "--bundle".into(),
@@ -144,6 +149,7 @@ pub(crate) async fn apply(
             outdir.push(bundler_output_dir.path());
             outdir
         },
+        format!("--banner:js={}", banner).into(),
     ];
 
     let bundler_output = npx("esbuild", &bundler_args)?

--- a/cli/tests/integration_tests/rust_tests/imports.rs
+++ b/cli/tests/integration_tests/rust_tests/imports.rs
@@ -48,12 +48,12 @@ async fn deno_land_module(mut c: TestContext) {
     );
 }
 
-#[self::test(modules = Both)]
-async fn builtin_std(c: TestContext) {
+#[self::test(modules = Node)]
+async fn builtin_deno_std(c: TestContext) {
     c.chisel.write(
         "routes/semver.ts",
         r##"
-        import semver from 'chisel://std/semver/mod.ts';
+        import * as semver from 'chisel://deno-std/semver/mod.ts';
         export default async function () {
             return semver.gt("1.13.1", "1.9.9");
         }"##,
@@ -62,7 +62,7 @@ async fn builtin_std(c: TestContext) {
     c.chisel.write(
         "routes/node_buffer.ts",
         r##"
-        import { Buffer } from 'chisel://std/node/buffer.ts';
+        import { Buffer } from 'chisel://deno-std/node/buffer.ts';
         export default async function () {
             return Buffer.alloc(100).byteLength;
         }"##,
@@ -76,12 +76,12 @@ async fn builtin_std(c: TestContext) {
 }
 
 #[self::test(modules = Node)]
-async fn nodestd(c: TestContext) {
+async fn node(c: TestContext) {
     c.chisel.write(
         "routes/import.ts",
         r##"
         import { Buffer } from 'buffer';
-        import assert, { AssertionError } from 'assert';
+        import * as assert, { AssertionError } from 'assert';
         import { StringDecoder } from 'string_decoder';
 
         export default async function () {
@@ -106,7 +106,7 @@ async fn nodestd(c: TestContext) {
 }
 
 #[self::test(modules = Node)]
-async fn nodestd_dynamic_import(c: TestContext) {
+async fn node_dynamic_import(c: TestContext) {
     c.chisel.write(
         "routes/import.ts",
         r##"
@@ -123,7 +123,7 @@ async fn nodestd_dynamic_import(c: TestContext) {
 }
 
 #[self::test(modules = Node)]
-async fn nodestd_require(c: TestContext) {
+async fn node_require(c: TestContext) {
     c.chisel.write(
         "routes/import.ts",
         r##"

--- a/cli/tests/integration_tests/rust_tests/imports.rs
+++ b/cli/tests/integration_tests/rust_tests/imports.rs
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
-
 use crate::framework::prelude::*;
 
-#[chisel_macros::test(modules = Node)]
-pub async fn http(c: TestContext) {
+#[self::test(modules = Node)]
+async fn http(c: TestContext) {
     c.chisel.write(
         "routes/error.ts",
         r##"
@@ -22,8 +21,8 @@ pub async fn http(c: TestContext) {
         .read("chiseld cannot load module https://foo.bar/ at runtime");
 }
 
-#[chisel_macros::test(modules = Deno)]
-pub async fn deno_land_module(mut c: TestContext) {
+#[self::test(modules = Deno)]
+async fn deno_land_module(mut c: TestContext) {
     c.chisel.write(
         "routes/indented.ts",
         r##"
@@ -35,7 +34,7 @@ pub async fn deno_land_module(mut c: TestContext) {
     "##,
     );
 
-    c.chisel.apply().await.unwrap();
+    c.chisel.apply_ok().await;
     assert_eq!(
         c.chisel.get_text("/dev/indented").await,
         "test    foo"
@@ -47,4 +46,96 @@ pub async fn deno_land_module(mut c: TestContext) {
         c.chisel.get_text("/dev/indented").await,
         "test    foo"
     );
+}
+
+#[self::test(modules = Both)]
+async fn builtin_std(c: TestContext) {
+    c.chisel.write(
+        "routes/semver.ts",
+        r##"
+        import semver from 'chisel://std/semver/mod.ts';
+        export default async function () {
+            return semver.gt("1.13.1", "1.9.9");
+        }"##,
+    );
+
+    c.chisel.write(
+        "routes/node_buffer.ts",
+        r##"
+        import { Buffer } from 'chisel://std/node/buffer.ts';
+        export default async function () {
+            return Buffer.alloc(100).byteLength;
+        }"##,
+    );
+
+    c.chisel.apply_ok().await;
+    c.chisel.get("/dev/semver").send().await
+        .assert_json(json!(true));
+    c.chisel.get("/dev/node_buffer").send().await
+        .assert_json(json!(100));
+}
+
+#[self::test(modules = Node)]
+async fn nodestd(c: TestContext) {
+    c.chisel.write(
+        "routes/import.ts",
+        r##"
+        import { Buffer } from 'buffer';
+        import assert, { AssertionError } from 'assert';
+        import { StringDecoder } from 'string_decoder';
+
+        export default async function () {
+            let assertFailed = false;
+            try {
+                assert.equal(1, 2);
+            } catch (e) {
+                assertFailed = e instanceof AssertionError;
+            }
+
+            const decoder = new StringDecoder('utf-8');
+            const buf = Buffer.from("žluťoučký kůň úpěl ďábelské ódy");
+            const str = decoder.end(buf);
+
+            return [assertFailed, buf.byteLength, str.length];
+        }"##,
+    );
+
+    c.chisel.apply_ok().await;
+    c.chisel.get("/dev/import").send().await
+        .assert_json(json!([true, 43, 31]));
+}
+
+#[self::test(modules = Node)]
+async fn nodestd_dynamic_import(c: TestContext) {
+    c.chisel.write(
+        "routes/import.ts",
+        r##"
+        const buffer = import("buffer");
+
+        export default async function () {
+            return buffer.Buffer.alloc(100).byteLength;
+        }"##,
+    );
+
+    c.chisel.apply_ok().await;
+    c.chisel.get("/dev/import").send().await
+        .assert_json(json!(100));
+}
+
+#[self::test(modules = Node)]
+async fn nodestd_require(c: TestContext) {
+    c.chisel.write(
+        "routes/import.ts",
+        r##"
+        // @ts-expect-error
+        const buffer = require("buffer");
+
+        export default async function () {
+            return buffer.Buffer.alloc(100).byteLength;
+        }"##,
+    );
+
+    c.chisel.apply_ok().await;
+    c.chisel.get("/dev/import").send().await
+        .assert_json(json!(100));
 }

--- a/cli/tests/integration_tests/rust_tests/imports.rs
+++ b/cli/tests/integration_tests/rust_tests/imports.rs
@@ -81,7 +81,7 @@ async fn node(c: TestContext) {
         "routes/import.ts",
         r##"
         import { Buffer } from 'buffer';
-        import * as assert, { AssertionError } from 'assert';
+        import assert, { AssertionError } from 'assert';
         import { StringDecoder } from 'string_decoder';
 
         export default async function () {
@@ -110,7 +110,7 @@ async fn node_dynamic_import(c: TestContext) {
     c.chisel.write(
         "routes/import.ts",
         r##"
-        const buffer = import("buffer");
+        const buffer = await import("buffer");
 
         export default async function () {
             return buffer.Buffer.alloc(100).byteLength;

--- a/deno_std/Cargo.toml
+++ b/deno_std/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "deno_std"
+version = "0.13.0-dev.0"
+authors = ["ChiselStrike"]
+edition = "2021"
+
+[lib]
+name = "deno_std"
+
+[dependencies]
+lazy_static = "1.4"
+
+[build-dependencies]
+anyhow = "1.0"
+deno_ast = {version = "0.19", features = ["transpiling"]}
+lazy_static = "1.4"
+regex = "1"

--- a/deno_std/build.rs
+++ b/deno_std/build.rs
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
+
+use anyhow::{anyhow, Result};
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::{env, fs};
+
+struct Module {
+    path_segments: Vec<String>,
+    transpiled_text: String,
+}
+
+fn main() -> Result<()> {
+    let crate_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let deno_std_dir = crate_dir.join("../third_party/deno_std");
+
+    let mut modules = Vec::new();
+    transpile_dir(&deno_std_dir, &[], &mut modules)?;
+
+    let mut gen_lines = Vec::<String>::new();
+    gen_lines.push("lazy_static! {".into());
+    gen_lines
+        .push("    pub static ref SOURCES_JS: HashMap<&'static str, &'static str> = vec![".into());
+    for (i, module) in modules.iter().enumerate() {
+        let js_file_name = format!("transpiled_{}.js", i);
+        let js_path = Path::new(&env::var_os("OUT_DIR").unwrap()).join(&js_file_name);
+        fs::write(js_path, &module.transpiled_text)?;
+
+        let url_path = module.path_segments.join("/");
+        gen_lines.push(format!(
+            "        ({:?}, include_str!(concat!(env!(\"OUT_DIR\"), \"/\", {:?}))),",
+            url_path, js_file_name,
+        ));
+    }
+    gen_lines.push("    ].into_iter().collect();".into());
+    gen_lines.push("}".into());
+
+    let gen_path = Path::new(&env::var_os("OUT_DIR").unwrap()).join("SOURCES_JS.rs");
+    let gen_text = gen_lines.join("\n");
+    fs::write(gen_path, gen_text)?;
+
+    Ok(())
+}
+
+lazy_static! {
+    static ref SKIP_DIRS: HashSet<&'static str> = vec![
+        "examples",
+        "encoding/testdata",
+        "node/integrationtest",
+        "node/_tools/test",
+        "node/testdata",
+    ]
+    .into_iter()
+    .collect();
+    static ref SKIP_FILE: Regex = Regex::new(r"_test\.ts$").unwrap();
+}
+
+fn transpile_dir(
+    dir_path: &Path,
+    dir_path_segments: &[String],
+    out_modules: &mut Vec<Module>,
+) -> Result<()> {
+    let dir_url_path = dir_path_segments.join("/");
+    if SKIP_DIRS.contains(dir_url_path.as_str()) {
+        return Ok(());
+    }
+
+    for entry in fs::read_dir(dir_path)? {
+        let entry = entry?;
+        let file_name = entry
+            .file_name()
+            .into_string()
+            .map_err(|_| anyhow!("file name is not utf-8"))?;
+
+        if SKIP_FILE.is_match(&file_name) {
+            continue;
+        }
+
+        let file_type = entry.file_type()?;
+
+        let mut entry_path_segments: Vec<_> = dir_path_segments.into();
+        entry_path_segments.push(file_name.clone());
+
+        if file_type.is_dir() {
+            transpile_dir(&entry.path(), &entry_path_segments, out_modules)?;
+        } else if file_type.is_file() {
+            let media_type = if file_name.ends_with(".ts") {
+                Some(deno_ast::MediaType::TypeScript)
+            } else if file_name.ends_with(".js") {
+                Some(deno_ast::MediaType::JavaScript)
+            } else if file_name.ends_with(".mjs") {
+                Some(deno_ast::MediaType::Mjs)
+            } else {
+                None
+            };
+
+            if let Some(media_type) = media_type {
+                let module = transpile_file(&entry.path(), entry_path_segments, media_type)?;
+                out_modules.push(module);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn transpile_file(
+    path: &Path,
+    path_segments: Vec<String>,
+    media_type: deno_ast::MediaType,
+) -> Result<Module> {
+    println!("cargo:rerun-if-changed={}", path.display());
+    let source_bytes = fs::read(path)?;
+    let source_text = String::from_utf8(source_bytes)?;
+    let text_info = deno_ast::SourceTextInfo::from_string(source_text);
+
+    let parse_params = deno_ast::ParseParams {
+        specifier: format!("file://{}", path.display()),
+        text_info,
+        media_type,
+        capture_tokens: false,
+        scope_analysis: false,
+        maybe_syntax: None,
+    };
+    let parsed_source = deno_ast::parse_module(parse_params)?;
+
+    let emit_options = deno_ast::EmitOptions::default();
+    let transpiled_source = parsed_source.transpile(&emit_options)?;
+    Ok(Module {
+        path_segments,
+        transpiled_text: transpiled_source.text,
+    })
+}

--- a/deno_std/src/lib.rs
+++ b/deno_std/src/lib.rs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
+
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+
+// the included file is generated in build.rs
+include!(concat!(env!("OUT_DIR"), "/", "SOURCES_JS.rs"));

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,6 +17,7 @@ base64 = "0.13.0"
 chiselc = { path = "../chiselc" }
 deno_core = { path = "../third_party/deno/core" }
 deno_runtime = { path = "../third_party/deno/runtime" }
+deno_std = { path = "../deno_std" }
 dirs = "4.0.0"
 enclose = "1.1"
 enum-as-inner = "0.3.3"

--- a/server/src/module_loader.rs
+++ b/server/src/module_loader.rs
@@ -60,11 +60,20 @@ impl deno_core::ModuleLoader for ModuleLoader {
 
 fn load_chisel_module(url: Url) -> Result<deno_core::ModuleSource> {
     // note that the module URL may end with ".ts", but we must return the transpiled JavaScript
-    if url.domain() == Some("api") {
-        let path = url.path().trim_start_matches('/').trim_end_matches(".ts");
-        if let Some(code) = api::SOURCES_JS.get(path) {
-            return Ok(source_from_code(&url, code));
+    match url.domain() {
+        Some("api") => {
+            let path = url.path().trim_start_matches('/').trim_end_matches(".ts");
+            if let Some(code) = api::SOURCES_JS.get(path) {
+                return Ok(source_from_code(&url, code));
+            }
         }
+        Some("deno-std") => {
+            let path = url.path().trim_start_matches('/');
+            if let Some(code) = deno_std::SOURCES_JS.get(path) {
+                return Ok(source_from_code(&url, code));
+            }
+        }
+        _ => {}
     }
     bail!("Undefined internal chisel module {}", url)
 }

--- a/server/src/ops/env.rs
+++ b/server/src/ops/env.rs
@@ -1,0 +1,33 @@
+use crate::worker::WorkerState;
+use std::collections::HashMap;
+
+// Overrides a Deno op, which requires a filesystem read permissions, with a dummy implementation.
+// This is needed because some Node libraries (such as `memfs`) use `process.cwd` without
+// restraint, even if they don't try to read anything from the filesystem.
+#[deno_core::op]
+pub fn op_cwd() -> &'static str {
+    "/"
+}
+
+#[deno_core::op]
+pub fn op_set_env(state: &mut deno_core::OpState, key: String, value: String) {
+    state
+        .borrow_mut::<WorkerState>()
+        .fake_env
+        .insert(key, value);
+}
+
+#[deno_core::op]
+pub fn op_env(state: &mut deno_core::OpState) -> HashMap<String, String> {
+    state.borrow::<WorkerState>().fake_env.clone()
+}
+
+#[deno_core::op]
+pub fn op_get_env(state: &mut deno_core::OpState, key: String) -> Option<String> {
+    state.borrow::<WorkerState>().fake_env.get(&key).cloned()
+}
+
+#[deno_core::op]
+pub fn op_delete_env(state: &mut deno_core::OpState, key: String) {
+    state.borrow_mut::<WorkerState>().fake_env.remove(&key);
+}

--- a/server/src/ops/mod.rs
+++ b/server/src/ops/mod.rs
@@ -6,6 +6,7 @@ use anyhow::{bail, Result};
 use deno_core::{serde_v8, v8};
 
 mod datastore;
+mod env;
 mod job;
 
 pub fn extension() -> deno_core::Extension {
@@ -17,7 +18,6 @@ pub fn extension() -> deno_core::Extension {
             op_chisel_get_version_info::decl(),
             op_chisel_is_debug::decl(),
             op_format_file_name::decl(),
-            op_cwd::decl(),
             datastore::op_chisel_begin_transaction::decl(),
             datastore::op_chisel_commit_transaction::decl(),
             datastore::op_chisel_rollback_transaction::decl(),
@@ -27,6 +27,11 @@ pub fn extension() -> deno_core::Extension {
             datastore::op_chisel_crud_query::decl(),
             datastore::op_chisel_relational_query_create::decl(),
             datastore::op_chisel_query_next::decl(),
+            env::op_cwd::decl(),
+            env::op_set_env::decl(),
+            env::op_env::decl(),
+            env::op_get_env::decl(),
+            env::op_delete_env::decl(),
             job::op_chisel_accept_job::decl(),
             job::op_chisel_http_respond::decl(),
         ])
@@ -83,12 +88,4 @@ fn op_chisel_is_debug(state: &mut deno_core::OpState) -> bool {
 #[deno_core::op]
 fn op_format_file_name(file_name: String) -> Result<String> {
     Ok(file_name)
-}
-
-// Overrides a Deno op, which requires a filesystem read permissions, with a dummy implementation.
-// This is needed because some Node libraries (such as `memfs`) use `process.cwd` without
-// restraint, even if they don't try to read anything from the filesystem.
-#[deno_core::op]
-fn op_cwd() -> Result<String> {
-    Ok("/".into())
 }

--- a/server/src/ops/mod.rs
+++ b/server/src/ops/mod.rs
@@ -17,6 +17,7 @@ pub fn extension() -> deno_core::Extension {
             op_chisel_get_version_info::decl(),
             op_chisel_is_debug::decl(),
             op_format_file_name::decl(),
+            op_cwd::decl(),
             datastore::op_chisel_begin_transaction::decl(),
             datastore::op_chisel_commit_transaction::decl(),
             datastore::op_chisel_rollback_transaction::decl(),
@@ -82,4 +83,12 @@ fn op_chisel_is_debug(state: &mut deno_core::OpState) -> bool {
 #[deno_core::op]
 fn op_format_file_name(file_name: String) -> Result<String> {
     Ok(file_name)
+}
+
+// Overrides a Deno op, which requires a filesystem read permissions, with a dummy implementation.
+// This is needed because some Node libraries (such as `memfs`) use `process.cwd` without
+// restraint, even if they don't try to read anything from the filesystem.
+#[deno_core::op]
+fn op_cwd() -> Result<String> {
+    Ok("/".into())
 }

--- a/server/src/worker.rs
+++ b/server/src/worker.rs
@@ -137,6 +137,8 @@ async fn run(init: WorkerInit) -> Result<()> {
     let permissions = Permissions {
         // FIXME: Temporary hack to allow easier testing for now
         net: Permissions::new_net(&Some(vec![]), false).unwrap(),
+        // TODO: Is it wise to allow access to env?
+        env: Permissions::new_env(&Some(vec![]), false).unwrap(),
         ..Permissions::default()
     };
 

--- a/server/src/worker.rs
+++ b/server/src/worker.rs
@@ -66,6 +66,12 @@ pub struct WorkerState {
     ///
     /// To wait on this channel, we temporarily move out of the `Option`.
     pub job_rx: Option<mpsc::Receiver<VersionJob>>,
+
+    /// Fake environment variables.
+    ///
+    /// We don't let the user code read the actual environment variables of this process, but we
+    /// implement `set_env` and `get_env` using this map.
+    pub fake_env: HashMap<String, String>,
 }
 
 pub async fn spawn(init: WorkerInit) -> Result<WorkerJoinHandle> {
@@ -137,8 +143,6 @@ async fn run(init: WorkerInit) -> Result<()> {
     let permissions = Permissions {
         // FIXME: Temporary hack to allow easier testing for now
         net: Permissions::new_net(&Some(vec![]), false).unwrap(),
-        // TODO: Is it wise to allow access to env?
-        env: Permissions::new_env(&Some(vec![]), false).unwrap(),
         ..Permissions::default()
     };
 
@@ -163,6 +167,7 @@ async fn run(init: WorkerInit) -> Result<()> {
         transaction: None,
         ready_tx: Some(init.ready_tx),
         job_rx: Some(init.job_rx),
+        fake_env: HashMap::new(),
     };
     worker.js_runtime.op_state().borrow_mut().put(worker_state);
 


### PR DESCRIPTION
In short, this PR implements `require('buffer')`.

---

In more detail, this PR:

- Embeds the Deno standard library under internal URL `chisel://deno-std/`
- Adds a crate `deno_std`, which transpiles the library using swc (wrapped in `deno_ast` for convenience). I decided to use swc instead of our `tsc_compile`, because swc is faster, simpler and in the future, I would like to use swc in `chisel apply` anyway.
- The sources of the Deno standard library are vendored as a submodule in the repo. We should keep `third_party/deno_std` in sync with `third_party/deno`.
- Resolves Node global imports such as `'buffer'` into Node polyfills from the Deno standard library.
- Implements fake env and cwd, because npm packages often try to read from them.