### PR TITLE
Propagate TypeSystem to JavaScript and add Date support.

### DIFF
--- a/api/build.rs
+++ b/api/build.rs
@@ -47,6 +47,7 @@ async fn main() -> Result<()> {
     compile("routing").await?;
     compile("run").await?;
     compile("special").await?;
+    compile("type_system").await?;
     compile("utils").await?;
 
     Ok(())

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -33,6 +33,7 @@ lazy_static! {
         source_js!("routing"),
         source_js!("run"),
         source_js!("special"),
+        source_js!("type_system"),
         source_js!("utils"),
         ("main.js", include_str!("main.js")),
     ]
@@ -49,6 +50,7 @@ lazy_static! {
         source_d_ts!("routing"),
         source_d_ts!("run"),
         source_d_ts!("special"),
+        source_d_ts!("type_system"),
         source_d_ts!("utils"),
     ]
     .into_iter()

--- a/api/src/type_system.ts
+++ b/api/src/type_system.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
+
+export type SimpleTypeSystem = {
+    entities: Record<string, Entity>;
+};
+
+export type Type =
+    | { name: "string" }
+    | { name: "number" }
+    | { name: "boolean" }
+    | { name: "jsDate" }
+    | { name: "array"; elementType: Type }
+    | { name: "entity"; entityName: string };
+
+export type Field = {
+    name: string;
+    type: Type;
+    isOptional: boolean;
+    isUnique: boolean;
+};
+
+export type Entity = {
+    name: string;
+    fields: Field[];
+};
+
+export class TypeSystem {
+    constructor(public ts: SimpleTypeSystem) {}
+
+    public findEntity(name: string): Entity | undefined {
+        return this.ts.entities[name];
+    }
+}

--- a/cli/src/ts.rs
+++ b/cli/src/ts.rs
@@ -59,6 +59,7 @@ impl fmt::Display for TypeEnum {
             TypeEnum::String(_) => f.write_str("string"),
             TypeEnum::Number(_) => f.write_str("number"),
             TypeEnum::Bool(_) => f.write_str("boolean"),
+            TypeEnum::JsDate(_) => f.write_str("jsDate"),
             TypeEnum::Entity(name) => name.fmt(f),
             TypeEnum::Array(inner) => {
                 let inner = inner.value_type().unwrap();
@@ -123,7 +124,10 @@ fn map_type(handler: &Handler, x: &TsType) -> Result<TypeEnum> {
         TsType::TsTypeRef(tr) => match &tr.type_name {
             TsEntityName::Ident(id) => {
                 let ident_name = ident_to_string(id);
-                Ok(TypeEnum::Entity(ident_name))
+                match ident_name.as_str() {
+                    "Date" => Ok(TypeEnum::JsDate(true)),
+                    _ => Ok(TypeEnum::Entity(ident_name)),
+                }
             }
             TsEntityName::TsQualifiedName(_) => Err(anyhow!("qualified names are not supported")),
         },

--- a/cli/tests/integration_tests/rust_tests/model_date.rs
+++ b/cli/tests/integration_tests/rust_tests/model_date.rs
@@ -1,0 +1,112 @@
+use crate::framework::prelude::*;
+
+#[chisel_macros::test(modules = Deno)]
+pub async fn store_and_load(c: TestContext) {
+    c.chisel.write(
+        "models/dated.ts",
+        r#"
+        import { ChiselEntity } from "@chiselstrike/api"
+        export class Dated extends ChiselEntity {
+            date: Date;
+        }"#,
+    );
+    c.chisel.write(
+        "routes/store.ts",
+        r#"
+        import { Dated } from "../models/dated.ts";
+        export default async function chisel(req: Request) {
+            await Dated.create({
+                date: Date.parse('01 Sep 2022 12:13:14 GMT'),
+            });
+        }
+        "#,
+    );
+    c.chisel.write(
+        "routes/read.ts",
+        r#"
+        import { Dated } from "../models/dated.ts";
+        export default async function chisel(req: Request) {
+            let dated = (await Dated.findOne({}))!;
+            return dated.date.toUTCString();
+        }
+        "#,
+    );
+    c.chisel.apply_ok().await;
+    c.chisel.post_json("/dev/store", json!({})).await;
+    c.chisel
+        .get("/dev/read")
+        .send()
+        .await
+        .assert_text("Thu, 01 Sep 2022 12:13:14 GMT");
+}
+
+#[chisel_macros::test(modules = Deno)]
+pub async fn crud(c: TestContext) {
+    c.chisel.write(
+        "models/dated.ts",
+        r#"
+        import { ChiselEntity } from "@chiselstrike/api"
+        export class Dated extends ChiselEntity {
+            date: Date;
+        }"#,
+    );
+    c.chisel.write(
+        "routes/dates.ts",
+        r#"
+        import { Dated } from "../models/dated.ts";
+        export default Dated.crud();
+        "#,
+    );
+    c.chisel.write(
+        "routes/read.ts",
+        r#"
+        import { Dated } from "../models/dated.ts";
+        export default async function chisel(req: Request) {
+            let dated = (await Dated.findOne({}))!;
+            return dated.date.toUTCString();
+        }
+        "#,
+    );
+    c.chisel.apply_ok().await;
+    c.chisel
+        .post_json(
+            "/dev/dates",
+            json!({
+                "date": 1662624988000i64
+            }),
+        )
+        .await;
+    assert_eq!(
+        c.chisel.get_text("/dev/read").await,
+        "Thu, 08 Sep 2022 08:16:28 GMT"
+    );
+    json_is_subset(
+        &c.chisel.get_json("/dev/dates?all=true").await,
+        &json!({
+            "results": [{
+                "date": 1662624988000i64
+            }]
+        }),
+    )
+    .unwrap();
+
+    json_is_subset(
+        &c.chisel.get_json("/dev/dates?.date=1662624988000").await,
+        &json!({
+            "results": [{
+                "date": 1662624988000i64
+            }]
+        }),
+    )
+    .unwrap();
+
+    json_is_subset(
+        &c.chisel.get_json("/dev/dates?.date=1662624988000.0").await,
+        &json!({
+            "results": [{
+                "date": 1662624988000i64
+            }]
+        }),
+    )
+    .unwrap();
+}

--- a/proto/chisel.proto
+++ b/proto/chisel.proto
@@ -46,6 +46,7 @@ message TypeMsg {
     bool string = 1;
     bool number = 2;
     bool bool = 3;
+    bool js_date = 6;
     string entity = 4;
     ContainerType array = 5;
   };

--- a/server/src/apply.rs
+++ b/server/src/apply.rs
@@ -363,7 +363,9 @@ impl ContainerType {
 impl TypeEnum {
     fn is_builtin(&self, ts: &TypeSystem) -> Result<bool> {
         let is_builtin = match self {
-            TypeEnum::String(_) | TypeEnum::Number(_) | TypeEnum::Bool(_) => true,
+            TypeEnum::String(_) | TypeEnum::Number(_) | TypeEnum::Bool(_) | TypeEnum::JsDate(_) => {
+                true
+            }
             TypeEnum::Entity(name) => ts.lookup_builtin_type(name).is_ok(),
             TypeEnum::Array(inner) => inner.value_type()?.is_builtin(ts)?,
         };
@@ -375,6 +377,7 @@ impl TypeEnum {
             TypeEnum::String(_) => Type::String,
             TypeEnum::Number(_) => Type::Float,
             TypeEnum::Bool(_) => Type::Boolean,
+            TypeEnum::JsDate(_) => Type::JsDate,
             TypeEnum::Entity(name) => ts.lookup_builtin_type(name)?,
             TypeEnum::Array(inner) => Type::Array(Box::new(inner.value_type()?.get_builtin(ts)?)),
         };
@@ -388,6 +391,7 @@ impl From<Type> for TypeMsg {
             Type::Float => TypeEnum::Number(true),
             Type::String => TypeEnum::String(true),
             Type::Boolean => TypeEnum::Bool(true),
+            Type::JsDate => TypeEnum::JsDate(true),
             Type::Entity(entity) => TypeEnum::Entity(entity.name().to_owned()),
             Type::Array(elem_type) => {
                 let inner_msg = (*elem_type).into();

--- a/server/src/datastore/crud.rs
+++ b/server/src/datastore/crud.rs
@@ -409,7 +409,7 @@ fn json_to_value(field_type: &Type, value: &serde_json::Value) -> Result<Expr> {
             field_type.name()
         ),
         Type::String => ExprValue::String(convert!(as_str, "string")),
-        Type::Float => ExprValue::F64(convert!(as_f64, "float")),
+        Type::Float | Type::JsDate => ExprValue::F64(convert!(as_f64, "float")),
         Type::Boolean => ExprValue::Bool(convert!(as_bool, "bool")),
     };
     Ok(expr_val.into())
@@ -479,7 +479,9 @@ fn filter_from_param(
     let err_msg = |ty_name| format!("failed to convert filter value '{}' to {}", value, ty_name);
     let expr_value = match &field_type {
         Type::String => ExprValue::String(value.to_owned()),
-        Type::Float => ExprValue::F64(value.parse::<f64>().with_context(|| err_msg("f64"))?),
+        Type::Float | Type::JsDate => {
+            ExprValue::F64(value.parse::<f64>().with_context(|| err_msg("f64"))?)
+        }
         Type::Boolean => ExprValue::Bool(value.parse::<bool>().with_context(|| err_msg("bool"))?),
         Type::Entity(_) | Type::Array(_) => anyhow::bail!(
             "trying to filter by property '{}' of type '{}' which is not supported",

--- a/server/src/datastore/engine.rs
+++ b/server/src/datastore/engine.rs
@@ -97,7 +97,7 @@ impl TryFrom<&Field> for ColumnDef {
         match field.type_id {
             TypeId::String => column_def.text(),
             TypeId::Id => column_def.text().primary_key(),
-            TypeId::Float => column_def.double(),
+            TypeId::Float | TypeId::JsDate => column_def.double(),
             TypeId::Boolean => column_def.boolean(),
             TypeId::Entity { .. } => column_def.text(), // Foreign key, must the be same type as Type::Id
             TypeId::Array(_) => column_def.text(),      // Arrays are stored as serialized JSONs.
@@ -396,7 +396,7 @@ impl QueryEngine {
                         }};
                     }
                     let mut val = match type_id {
-                        TypeId::Float => {
+                        TypeId::Float | TypeId::JsDate => {
                             // https://github.com/launchbadge/sqlx/issues/1596
                             // sqlx gets confused if the float doesn't have decimal points.
                             let val: f64 = row.get_unchecked(column_idx);
@@ -687,7 +687,7 @@ impl QueryEngine {
             TypeId::String | TypeId::Id | TypeId::Entity { .. } => {
                 SqlValue::String(convert_json_value!(as_str, String))
             }
-            TypeId::Float => SqlValue::F64(convert_json_value!(as_f64, f64)),
+            TypeId::Float | TypeId::JsDate => SqlValue::F64(convert_json_value!(as_f64, f64)),
             TypeId::Boolean => SqlValue::Bool(convert_json_value!(as_bool, bool)),
             TypeId::Array(element_type) => {
                 let val = match ty_value.get(&field.name) {
@@ -719,7 +719,7 @@ impl QueryEngine {
                 }
                 match element_type {
                     TypeId::String | TypeId::Id => maybe_bail!(is_string),
-                    TypeId::Float => maybe_bail!(is_number),
+                    TypeId::Float | TypeId::JsDate => maybe_bail!(is_number),
                     TypeId::Boolean => maybe_bail!(is_boolean),
                     TypeId::Array(inner_element) => self
                         .validate_array(inner_element, e)

--- a/server/src/ops/mod.rs
+++ b/server/src/ops/mod.rs
@@ -7,6 +7,7 @@ use deno_core::{serde_v8, v8};
 
 mod datastore;
 mod job;
+mod type_system;
 
 pub fn extension() -> deno_core::Extension {
     deno_core::Extension::builder()
@@ -28,6 +29,7 @@ pub fn extension() -> deno_core::Extension {
             datastore::op_chisel_query_next::decl(),
             job::op_chisel_accept_job::decl(),
             job::op_chisel_http_respond::decl(),
+            type_system::op_chisel_get_type_system::decl(),
         ])
         .build()
 }

--- a/server/src/ops/type_system.rs
+++ b/server/src/ops/type_system.rs
@@ -1,0 +1,96 @@
+use crate::types::{ObjectType, Type, TypeId};
+use crate::worker::WorkerState;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[deno_core::op]
+fn op_chisel_get_type_system(state: &mut deno_core::OpState) -> SimpleTypeSystem {
+    let ts = state.borrow::<WorkerState>().version.type_system.clone();
+    let mut entities: HashMap<_, _> = ts
+        .custom_types
+        .iter()
+        .map(|(name, ty)| (name.to_owned(), simplify_object_type(ty.object_type())))
+        .collect();
+    for (name, ty) in &ts.builtin.types {
+        if let Type::Entity(entity) = ty {
+            entities.insert(name.to_owned(), simplify_object_type(entity.object_type()));
+        }
+    }
+    SimpleTypeSystem { entities }
+}
+
+/// Simplified version of our type system dedicated for internal use in our TypeScript
+/// API. Hopefully, this structure is just temporary and will go away with the new
+/// data model.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SimpleTypeSystem {
+    entities: HashMap<String, SimpleEntity>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SimpleEntity {
+    name: String,
+    fields: Vec<SimpleField>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SimpleField {
+    name: String,
+    #[serde(rename = "type")]
+    field_type: SimpleTypeId,
+    is_optional: bool,
+    is_unique: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase", tag = "name")]
+enum SimpleTypeId {
+    String,
+    Number,
+    Boolean,
+    JsDate,
+    Entity {
+        #[serde(rename = "entityName")]
+        entity_name: String,
+    },
+    Array {
+        #[serde(rename = "elementType")]
+        element_type: Box<SimpleTypeId>,
+    },
+}
+
+fn simplify_object_type(obj: &Arc<ObjectType>) -> SimpleEntity {
+    let fields = obj
+        .all_fields()
+        .map(|f| SimpleField {
+            name: f.name.to_owned(),
+            field_type: simplify_type_id(&f.type_id),
+            is_optional: f.is_optional,
+            is_unique: f.is_unique,
+        })
+        .collect();
+    SimpleEntity {
+        name: obj.name().to_owned(),
+        fields,
+    }
+}
+
+fn simplify_type_id(ty: &TypeId) -> SimpleTypeId {
+    match ty {
+        TypeId::String => SimpleTypeId::String,
+        TypeId::Float => SimpleTypeId::Number,
+        TypeId::Boolean => SimpleTypeId::Boolean,
+        TypeId::JsDate => SimpleTypeId::JsDate,
+        TypeId::Id => SimpleTypeId::String,
+        TypeId::Array(element_ty) => SimpleTypeId::Array {
+            element_type: simplify_type_id(element_ty).into(),
+        },
+        TypeId::Entity { name, .. } => SimpleTypeId::Entity {
+            entity_name: name.to_owned(),
+        },
+    }
+}

--- a/server/src/types/builtin.rs
+++ b/server/src/types/builtin.rs
@@ -17,6 +17,7 @@ impl BuiltinTypes {
         types.insert("string".into(), Type::String);
         types.insert("number".into(), Type::Float);
         types.insert("boolean".into(), Type::Boolean);
+        types.insert("jsDate".into(), Type::JsDate);
         add_auth_entity(
             &mut types,
             AUTH_USER_NAME,

--- a/server/src/types/mod.rs
+++ b/server/src/types/mod.rs
@@ -18,6 +18,7 @@ pub enum Type {
     String,
     Float,
     Boolean,
+    JsDate,
     Entity(Entity),
     Array(Box<Type>),
 }
@@ -28,6 +29,7 @@ impl Type {
             Type::Float => "number".to_string(),
             Type::String => "string".to_string(),
             Type::Boolean => "boolean".to_string(),
+            Type::JsDate => "jsDate".to_string(),
             Type::Entity(ty) => ty.name.to_string(),
             Type::Array(ty) => format!("Array<{}>", ty.name()),
         }
@@ -56,6 +58,13 @@ impl Entity {
     /// Checks whether `Entity` is Auth builtin type.
     pub fn is_auth(&self) -> bool {
         matches!(self, Entity::Auth(_))
+    }
+
+    pub fn object_type(&self) -> &Arc<ObjectType> {
+        match self {
+            Entity::Custom { object, .. } => object,
+            Entity::Auth(object) => object,
+        }
     }
 }
 
@@ -224,8 +233,13 @@ pub enum TypeId {
     String,
     Float,
     Boolean,
+    /// Represents JavaScript Date class
+    JsDate,
     Id,
-    Entity { name: String, version_id: String },
+    Entity {
+        name: String,
+        version_id: String,
+    },
     Array(Box<TypeId>),
 }
 
@@ -235,6 +249,7 @@ impl TypeId {
             TypeId::Id | TypeId::String => "string".to_string(),
             TypeId::Float => "number".to_string(),
             TypeId::Boolean => "boolean".to_string(),
+            TypeId::JsDate => "jsDate".to_string(),
             TypeId::Entity { ref name, .. } => name.to_string(),
             TypeId::Array(elem_type) => format!("Array<{}>", elem_type.name()),
         }
@@ -247,6 +262,7 @@ impl From<Type> for TypeId {
             Type::String => Self::String,
             Type::Float => Self::Float,
             Type::Boolean => Self::Boolean,
+            Type::JsDate => Self::JsDate,
             Type::Entity(e) => Self::Entity {
                 name: e.name().to_string(),
                 version_id: e.version_id.clone(),

--- a/server/src/types/type_system.rs
+++ b/server/src/types/type_system.rs
@@ -269,9 +269,12 @@ impl TypeSystem {
 
     pub fn get(&self, ty: &TypeId) -> Result<Type, TypeSystemError> {
         match ty {
-            TypeId::String | TypeId::Float | TypeId::Boolean | TypeId::Id | TypeId::Array(_) => {
-                self.lookup_builtin_type(&ty.name())
-            }
+            TypeId::String
+            | TypeId::Float
+            | TypeId::Boolean
+            | TypeId::Id
+            | TypeId::JsDate
+            | TypeId::Array(_) => self.lookup_builtin_type(&ty.name()),
             TypeId::Entity { name, version_id } => {
                 if version_id == "__chiselstrike" {
                     self.lookup_builtin_type(name)


### PR DESCRIPTION
This PR can perhaps be simplified if we merge https://github.com/chiselstrike/chiselstrike/pull/1780 first :thinking: 
That would completely remove the necessity to propagate the type system to TypeScript... Although it feels kinda beneficial anyway because of the proper initialization of nested entities. But it still might be better to decouple the two.