### PR TITLE
Support for Array buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
+ "serde",
  "time 0.1.44",
  "wasm-bindgen",
  "winapi",
@@ -655,6 +656,7 @@ name = "cli"
 version = "0.13.0-dev.0"
 dependencies = [
  "anyhow",
+ "base64",
  "bytes",
  "chisel-macros",
  "colored",
@@ -980,6 +982,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core 0.14.1",
+ "darling_macro 0.14.1",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1020,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "strsim 0.10.0",
+ "syn 1.0.99",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1051,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core 0.14.1",
  "quote 1.0.21",
  "syn 1.0.99",
 ]
@@ -4416,6 +4453,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time 0.3.14",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
+dependencies = [
+ "darling 0.14.1",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4470,6 +4535,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_with",
  "serde_yaml",
  "sha2",
  "socket2 0.3.19",
@@ -5787,8 +5853,10 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
+ "itoa",
  "libc",
  "num_threads",
+ "serde",
 ]
 
 [[package]]

--- a/api/src/datastore.ts
+++ b/api/src/datastore.ts
@@ -73,10 +73,6 @@ abstract class Operator<Input, Output> {
     }
 }
 
-function assertNever(_: never) {
-    return false;
-}
-
 /**
  * Specifies Entity whose elements are to be fetched.
  */
@@ -1193,29 +1189,30 @@ function mergeSourceIntoEntity(
         }
 
         const err = (typeName: string) => {
-            new Error(
+            return new Error(
                 `field ${field.name} of entity ${entityName} is ${typeName}, but provided value ${fieldValue} is of type ${typeof fieldValue}`,
             );
         };
-        if (field.type.name == "string" || field.type.name == "entityId") {
+        const typeName = field.type.name;
+        if (typeName == "string" || typeName == "entityId") {
             if (typeof fieldValue == "string") {
                 target[field.name] = fieldValue;
             } else {
                 throw err("string");
             }
-        } else if (field.type.name == "number") {
+        } else if (typeName == "number") {
             if (typeof fieldValue == "number") {
                 target[field.name] = fieldValue;
             } else {
                 throw err("number");
             }
-        } else if (field.type.name == "boolean") {
+        } else if (typeName == "boolean") {
             if (typeof fieldValue == "boolean") {
                 target[field.name] = fieldValue;
             } else {
                 throw err("boolean");
             }
-        } else if (field.type.name == "jsDate") {
+        } else if (typeName == "jsDate") {
             if (fieldValue instanceof Date) {
                 target[field.name] = fieldValue;
             } else if (
@@ -1227,7 +1224,8 @@ function mergeSourceIntoEntity(
                     `field ${field.name} of entity ${entityName} is Date, but provided value ${fieldValue} is not an instance of Date`,
                 );
             }
-        } else if (field.type.name == "array") {
+        } else if (typeName == "array") {
+            console.log();
             if (Array.isArray(fieldValue)) {
                 target[field.name] = fieldValue;
             } else {
@@ -1235,7 +1233,7 @@ function mergeSourceIntoEntity(
                     `field ${field.name} of entity ${entityName} is Array, but provided value ${fieldValue} is not an instance of Array`,
                 );
             }
-        } else if (field.type.name == "entity") {
+        } else if (typeName == "entity") {
             if (typeof fieldValue == "object") {
                 if (target[field.name] === undefined) {
                     target[field.name] = new ChiselEntity();
@@ -1252,13 +1250,16 @@ function mergeSourceIntoEntity(
                 );
             }
         } else {
-            assertNever(field.type);
+            assertNever(typeName);
             throw new Error(
-                `field ${field.name} of entity ${entityName} has unexpected type ${field
-                    .type as unknown}`,
+                `field '${field.name}' of entity '${entityName}' has unexpected type '${typeName}'`,
             );
         }
     }
+}
+
+function assertNever(_: never) {
+    return false;
 }
 
 export type Id<Entity extends ChiselEntity> = Entity["id"];

--- a/api/src/datastore.ts
+++ b/api/src/datastore.ts
@@ -4,7 +4,6 @@ import { crud } from "./crud.ts";
 import type { RouteMap } from "./routing.ts";
 import { opAsync, opSync } from "./utils.ts";
 import { SimpleTypeSystem, TypeSystem } from "./type_system.ts";
-
 /**
  * Base class for various Operators applicable on `ChiselCursor`. An
  * implementation of Operator<T> processes an AsyncIterable<T> and
@@ -1212,6 +1211,18 @@ function mergeSourceIntoEntity(
             } else {
                 throw err("boolean");
             }
+        } else if (typeName == "arrayBuffer") {
+            // This covers the CRUD path where we get the value in form of a
+            // base64 encoded string.
+            if (typeof fieldValue == "string") {
+                // TODO: Get rid of this when we have deno imports working.
+                target[field.name] = Uint8Array.from(
+                    atob(fieldValue),
+                    (c) => c.charCodeAt(0),
+                );
+            } else {
+                target[field.name] = fieldValue;
+            }
         } else if (typeName == "jsDate") {
             if (fieldValue instanceof Date) {
                 target[field.name] = fieldValue;
@@ -1225,7 +1236,6 @@ function mergeSourceIntoEntity(
                 );
             }
         } else if (typeName == "array") {
-            console.log();
             if (Array.isArray(fieldValue)) {
                 target[field.name] = fieldValue;
             } else {

--- a/api/src/type_system.ts
+++ b/api/src/type_system.ts
@@ -9,6 +9,7 @@ export type Type =
     | { name: "number" }
     | { name: "boolean" }
     | { name: "jsDate" }
+    | { name: "arrayBuffer" }
     | { name: "array"; elementType: Type }
     | { name: "entity"; entityName: string }
     | { name: "entityId"; entityName: string };

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,6 +35,7 @@ tonic-build = { version = "0.5.2", default-features = false, features = ["prost"
 vergen = { version = "6", default-features = false, features = ["git"] }
 
 [dev-dependencies]
+base64 = "0.13.0"
 bytes = "1.2.0"
 chisel-macros = { path = "tests/integration_tests/chisel-macros" }
 colored = "2.0.0"

--- a/cli/src/ts.rs
+++ b/cli/src/ts.rs
@@ -60,6 +60,7 @@ impl fmt::Display for TypeEnum {
             TypeEnum::Number(_) => f.write_str("number"),
             TypeEnum::Bool(_) => f.write_str("boolean"),
             TypeEnum::JsDate(_) => f.write_str("jsDate"),
+            TypeEnum::ArrayBuffer(_) => f.write_str("ArrayBuffer"),
             TypeEnum::Entity(name) => name.fmt(f),
             TypeEnum::EntityId(entity_name) => write!(f, "Id<{entity_name}>"),
             TypeEnum::Array(inner) => {
@@ -141,6 +142,7 @@ fn map_type(handler: &Handler, x: &TsType) -> Result<TypeEnum> {
                 let ident_name = ident_to_string(id);
                 match ident_name.as_str() {
                     "Date" => Ok(TypeEnum::JsDate(true)),
+                    "ArrayBuffer" => Ok(TypeEnum::ArrayBuffer(true)),
                     "Id" => map_entity_id(handler, tr),
                     _ => Ok(TypeEnum::Entity(ident_name)),
                 }

--- a/cli/tests/integration_tests/rust_tests/model_array_buffer.rs
+++ b/cli/tests/integration_tests/rust_tests/model_array_buffer.rs
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
+
+extern crate base64;
+use crate::framework::prelude::*;
+
+static STORAGE_MODEL: &str = r#"
+    import { ChiselEntity } from "@chiselstrike/api";
+
+    export class StorageEntity extends ChiselEntity {
+        data: ArrayBuffer;
+    }
+"#;
+
+static READ_ROUTE: &str = r#"
+    import { StorageEntity } from "../models/storage.ts";
+
+    export default async function chisel(req: Request) {
+        const x = await StorageEntity.findOne({});
+        const view = new Uint8Array(x!.data);
+        const decoder = new TextDecoder('utf-8');
+        return decoder.decode(view);
+    }
+"#;
+
+fn write_files(chisel: &Chisel) {
+    chisel.write("models/storage.ts", STORAGE_MODEL);
+    chisel.write("routes/read.ts", READ_ROUTE);
+    chisel.write(
+        "routes/data.ts",
+        r#"
+        import { StorageEntity } from "../models/storage.ts";
+        export default StorageEntity.crud();
+    "#,
+    );
+}
+
+#[chisel_macros::test(modules = Deno)]
+pub async fn basic(c: TestContext) {
+    write_files(&c.chisel);
+    c.chisel.write(
+        "routes/store.ts",
+        r#"
+        import { StorageEntity } from "../models/storage.ts";
+
+        export default async function chisel(req: Request) {
+            const buff = new ArrayBuffer(5);
+            const view = new Uint8Array(buff);
+            view.set([107, 197, 175, 197, 136], 0);
+            await StorageEntity.build({
+                data: buff
+            }).save();
+        }"#,
+    );
+    c.chisel.apply_ok().await;
+
+    c.chisel.post("/dev/store").send().await.assert_ok();
+    c.chisel
+        .get("/dev/read")
+        .send()
+        .await
+        .assert_ok()
+        .assert_text("kůň");
+
+    let r = c.chisel.get_json("/dev/data").await;
+    let base64_data = r["results"].as_array().unwrap()[0]["data"]
+        .as_str()
+        .unwrap();
+    let text_bytes = base64::decode(base64_data).unwrap();
+    let response_text = String::from_utf8_lossy(&text_bytes);
+    assert_eq!(response_text, "kůň");
+}
+
+#[chisel_macros::test(modules = Deno)]
+pub async fn save_buffer_view_to_buffer(c: TestContext) {
+    write_files(&c.chisel);
+    c.chisel.write(
+        "routes/store.ts",
+        r#"
+        import { StorageEntity } from "../models/storage.ts";
+
+        export default async function chisel(req: Request) {
+            const buff = new ArrayBuffer(5);
+            const view = new Uint8Array(buff);
+            view.set([107, 197, 175, 197, 136], 0);
+            await StorageEntity.build({
+                data: view
+            }).save();
+        }"#,
+    );
+    c.chisel.apply_ok().await;
+
+    c.chisel.post("/dev/store").send().await.assert_ok();
+    c.chisel
+        .get("/dev/read")
+        .send()
+        .await
+        .assert_ok()
+        .assert_text("kůň");
+}
+
+#[chisel_macros::test(modules = Deno)]
+pub async fn crud(c: TestContext) {
+    write_files(&c.chisel);
+    c.chisel.apply_ok().await;
+
+    let encoded_horse = base64::encode("kůň".as_bytes());
+    c.chisel
+        .post_json("/dev/data", json!({ "data": encoded_horse }))
+        .await;
+
+    c.chisel
+        .get("/dev/read")
+        .send()
+        .await
+        .assert_ok()
+        .assert_text("kůň");
+
+    let r = c.chisel.get_json("/dev/data").await;
+    let base64_data = r["results"].as_array().unwrap()[0]["data"]
+        .as_str()
+        .unwrap();
+    let text_bytes = base64::decode(base64_data).unwrap();
+    let response_text = String::from_utf8_lossy(&text_bytes);
+    assert_eq!(response_text, "kůň");
+}
+// TODO: Use when arrays of buffers are implemented.
+// #[chisel_macros::test(modules = Deno)]
+// pub async fn array_of_buffers(c: TestContext) {
+//     c.chisel.write(
+//         "models/storage.ts",
+//         r#"
+//         import { ChiselEntity } from "@chiselstrike/api";
+//         export class StorageEntity extends ChiselEntity {
+//             data: ArrayBuffer[];
+//         }
+//         "#,
+//     );
+//     c.chisel.write(
+//         "routes/store.ts",
+//         r#"
+//         import { StorageEntity } from "../models/storage.ts";
+//         function makeBuffer(bytes: Array<number>) {
+//             const buff = new ArrayBuffer(bytes.length);
+//             const view = new Uint8Array(buff);
+//             view.set(bytes, 0);
+//             return buff;
+//         }
+
+//         export default async function chisel(req: Request) {
+//             const array = [];
+//             array.push(makeBuffer([107, 195, 189, 196, 141]));
+//             array.push(makeBuffer([106, 97, 107]));
+//             array.push(makeBuffer([98, 105, 196, 141]));
+
+//             await StorageEntity.build({
+//                 data: array
+//             }).save();
+//         }"#,
+//     );
+//     c.chisel.write(
+//         "routes/read.ts",
+//         r#"
+//         import { StorageEntity } from "../models/storage.ts";
+
+//         export default async function chisel(req: Request) {
+//             const x = await StorageEntity.findOne({});
+//             return x!.data.map(bytes => {
+//                 const view = new Uint8Array(bytes);
+//                 const decoder = new TextDecoder('utf-8');
+//                 return decoder.decode(view);
+//             });
+//         }"#,
+//     );
+//     c.chisel.write(
+//         "routes/data.ts",
+//         r#"
+//         import { StorageEntity } from "../models/storage.ts";
+//         export default StorageEntity.crud();
+//     "#,
+//     );
+//     c.chisel.apply_ok().await;
+
+//     c.chisel.post("/dev/store").send().await.assert_ok();
+//     c.chisel
+//         .get("/dev/read")
+//         .send()
+//         .await
+//         .assert_ok()
+//         .assert_json(json!(["kýč", "jak", "bič"]));
+// }

--- a/proto/chisel.proto
+++ b/proto/chisel.proto
@@ -47,6 +47,7 @@ message TypeMsg {
     bool number = 2;
     bool bool = 3;
     bool js_date = 6;
+    bool array_buffer = 8;
     string entity = 4;
     string entity_id = 7;
     ContainerType array = 5;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -46,6 +46,7 @@ sea-query = { version = "0.26", features = ["thread-safe"] }
 serde = "1.0.137"
 serde_derive = "1.0.137"
 serde_json = "1.0.81"
+serde_with = { version = "2.0.1", features = ["base64"] }
 serde_yaml = "0.9.13"
 sha2 = "0.10.2"
 socket2 = { version = "0.3.18", features = ["unix", "reuseport"] }

--- a/server/src/apply.rs
+++ b/server/src/apply.rs
@@ -342,9 +342,11 @@ impl ContainerType {
 impl TypeEnum {
     fn is_builtin(&self, ts: &TypeSystem) -> Result<bool> {
         let is_builtin = match self {
-            TypeEnum::String(_) | TypeEnum::Number(_) | TypeEnum::Bool(_) | TypeEnum::JsDate(_) => {
-                true
-            }
+            TypeEnum::String(_)
+            | TypeEnum::Number(_)
+            | TypeEnum::Bool(_)
+            | TypeEnum::JsDate(_)
+            | TypeEnum::ArrayBuffer(_) => true,
             TypeEnum::Entity(name) | TypeEnum::EntityId(name) => {
                 ts.lookup_builtin_type(name).is_ok()
             }
@@ -359,6 +361,7 @@ impl TypeEnum {
             TypeEnum::Number(_) => Type::Float,
             TypeEnum::Bool(_) => Type::Boolean,
             TypeEnum::JsDate(_) => Type::JsDate,
+            TypeEnum::ArrayBuffer(_) => Type::ArrayBuffer,
             TypeEnum::Entity(name) => ts.lookup_builtin_type(name)?,
             TypeEnum::EntityId(entity_name) => Type::EntityId(entity_name.to_owned()),
             TypeEnum::Array(inner) => Type::Array(Box::new(inner.value_type()?.get_builtin(ts)?)),
@@ -374,6 +377,7 @@ impl From<Type> for TypeMsg {
             Type::String => TypeEnum::String(true),
             Type::Boolean => TypeEnum::Bool(true),
             Type::JsDate => TypeEnum::JsDate(true),
+            Type::ArrayBuffer => TypeEnum::ArrayBuffer(true),
             Type::Entity(entity) => TypeEnum::Entity(entity.name().to_owned()),
             Type::EntityId(entity_name) => TypeEnum::EntityId(entity_name),
             Type::Array(elem_type) => {

--- a/server/src/datastore/crud.rs
+++ b/server/src/datastore/crud.rs
@@ -416,7 +416,7 @@ fn json_to_value(field_type: &Type, value: &serde_json::Value) -> Result<Expr> {
         }};
     }
     let expr_val = match field_type {
-        Type::Entity(_) | Type::Array(_) => anyhow::bail!(
+        Type::Entity(_) | Type::Array(_) | Type::ArrayBuffer => anyhow::bail!(
             "trying to filter by property of type '{}' which is not supported",
             field_type.name()
         ),
@@ -500,7 +500,7 @@ fn filter_from_param(
         }
         Type::Boolean => ExprValue::Bool(value.parse::<bool>().with_context(|| err_msg("bool"))?),
         Type::EntityId { .. } => ExprValue::String(value.to_owned()),
-        Type::Entity(_) | Type::Array(_) => anyhow::bail!(
+        Type::Entity(_) | Type::Array(_) | Type::ArrayBuffer => anyhow::bail!(
             "trying to filter by property '{}' of type '{}' which is not supported",
             fields.last().unwrap(),
             field_type.name()

--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -20,6 +20,7 @@ pub enum SqlValue {
     Bool(bool),
     F64(f64),
     String(String),
+    Bytes(Vec<u8>),
 }
 
 impl From<&str> for SqlValue {

--- a/server/src/ops/type_system.rs
+++ b/server/src/ops/type_system.rs
@@ -53,6 +53,7 @@ enum SimpleTypeId {
     Number,
     Boolean,
     JsDate,
+    ArrayBuffer,
     Entity {
         #[serde(rename = "entityName")]
         entity_name: String,
@@ -90,6 +91,7 @@ fn simplify_type_id(ty: &TypeId) -> SimpleTypeId {
         TypeId::Boolean => SimpleTypeId::Boolean,
         TypeId::JsDate => SimpleTypeId::JsDate,
         TypeId::Id => SimpleTypeId::String,
+        TypeId::ArrayBuffer => SimpleTypeId::ArrayBuffer,
         TypeId::Array(element_ty) => SimpleTypeId::Array {
             element_type: simplify_type_id(element_ty).into(),
         },

--- a/server/src/types/builtin.rs
+++ b/server/src/types/builtin.rs
@@ -18,6 +18,7 @@ impl BuiltinTypes {
         types.insert("number".into(), Type::Float);
         types.insert("boolean".into(), Type::Boolean);
         types.insert("jsDate".into(), Type::JsDate);
+        types.insert("ArrayBuffer".into(), Type::ArrayBuffer);
         add_auth_entity(
             &mut types,
             AUTH_USER_NAME,

--- a/server/src/types/mod.rs
+++ b/server/src/types/mod.rs
@@ -18,6 +18,7 @@ pub enum Type {
     Float,
     Boolean,
     JsDate,
+    ArrayBuffer,
     Entity(Entity),
     /// Contains Entity name which this EntityId type refers to
     EntityId(String),
@@ -31,6 +32,7 @@ impl Type {
             Type::String => "string".to_string(),
             Type::Boolean => "boolean".to_string(),
             Type::JsDate => "jsDate".to_string(),
+            Type::ArrayBuffer => "ArrayBuffer".to_string(),
             Type::Entity(ty) => ty.name.to_string(),
             Type::EntityId(entity_name) => format!("Id<{entity_name}>"),
             Type::Array(ty) => format!("Array<{}>", ty.name()),
@@ -223,6 +225,7 @@ pub enum TypeId {
     Boolean,
     /// Represents JavaScript Date class
     JsDate,
+    ArrayBuffer,
     Id,
     /// Contains Entity name which this EntityId type refers to
     EntityId(String),
@@ -240,6 +243,7 @@ impl TypeId {
             TypeId::Float => "number".to_string(),
             TypeId::Boolean => "boolean".to_string(),
             TypeId::JsDate => "jsDate".to_string(),
+            TypeId::ArrayBuffer => "ArrayBuffer".to_string(),
             TypeId::EntityId(entity_name) => format!("Id<{entity_name}>"),
             TypeId::Entity { ref name, .. } => name.to_string(),
             TypeId::Array(elem_type) => format!("Array<{}>", elem_type.name()),
@@ -254,6 +258,7 @@ impl From<Type> for TypeId {
             Type::Float => Self::Float,
             Type::Boolean => Self::Boolean,
             Type::JsDate => Self::JsDate,
+            Type::ArrayBuffer => Self::ArrayBuffer,
             Type::EntityId(entity_name) => Self::EntityId(entity_name),
             Type::Entity(e) => Self::Entity {
                 name: e.name().to_string(),

--- a/server/src/types/type_system.rs
+++ b/server/src/types/type_system.rs
@@ -286,6 +286,7 @@ impl TypeSystem {
             | TypeId::Boolean
             | TypeId::Id
             | TypeId::JsDate
+            | TypeId::ArrayBuffer
             | TypeId::Array(_) => self.lookup_builtin_type(&ty.name()),
             TypeId::Entity { name, version_id } => {
                 if version_id == "__chiselstrike" {


### PR DESCRIPTION
This PR brings the support for `ArrayBuffer` type as Entity field.
Some notes:

- TS is perfectly fine assigning `ArrayBufferView` to `ArrayBuffer`. Luckily I was able to handle that case as well so no problem :relaxed: It's really unexpected behavior though...
- In CRUD, the ArrayBuffer is encoded with `base64`.
- The base64 encoding is handled well on the way out, but in `POST/PUT` endpoints, it's a bit tricky as there, the json goes through `Entity.build(...)` which meant I had to add ugly hack to the `mergeSourceIntoEntity` function. 
- The `mergeSourceIntoEntity` is becoming rather hairy and I think it will be necessary to refactor it in consequent PR.