### PR TITLE
create-chiselstrike-app: Generate Dockerfile

### DIFF
--- a/packages/create-chiselstrike-app/index.ts
+++ b/packages/create-chiselstrike-app/index.ts
@@ -48,6 +48,7 @@ function run(projectDirectory: string, chiselVersion: string) {
     fs.closeSync(fs.openSync(path.join(policiesPath, ".gitkeep"), "w"));
     const rootFiles = [
         "Chisel.toml",
+        "Dockerfile",
         "package.json",
         "tsconfig.json",
     ];
@@ -87,6 +88,10 @@ function run(projectDirectory: string, chiselVersion: string) {
     fs.copyFileSync(
         path.join(__dirname, "template", "gitignore"),
         path.join(projectDirectory, "", ".gitignore"),
+    );
+    fs.copyFileSync(
+        path.join(__dirname, "template", "dockerignore"),
+        path.join(projectDirectory, "", ".dockerignore"),
     );
     console.log("Installing packages. This might take a couple of minutes.");
     process.chdir(projectDirectory);

--- a/packages/create-chiselstrike-app/template/Dockerfile
+++ b/packages/create-chiselstrike-app/template/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18-slim
+
+COPY . /opt/app
+
+WORKDIR /opt/app
+
+RUN npm i
+
+EXPOSE 8080/tcp
+
+CMD npm run dev -- -- --api-listen-addr 0.0.0.0:8080

--- a/packages/create-chiselstrike-app/template/README-template.md
+++ b/packages/create-chiselstrike-app/template/README-template.md
@@ -14,3 +14,23 @@ Which starts a local development server of the example code.
 
 For more help in getting started with ChiselStrike development, check out the
 [online documentation](https://docs.chiselstrike.com).
+
+## Docker Support
+
+To build a Docker image of your application, type:
+
+```console
+docker build --tag {{projectName}} .
+```
+
+You can then start a container using the image with:
+
+```
+docker run --name={{projectName}} --network=host {{projectName}}
+```
+
+and access the endpoints:
+
+```
+curl localhost:8080/dev/hello
+```

--- a/packages/create-chiselstrike-app/template/dockerignore
+++ b/packages/create-chiselstrike-app/template/dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+node_modules


### PR DESCRIPTION
This adds Dockerfile generation to `create-chiselstrike-app`, which allows developers to build an image of their application and its dependencies, including ChiselStrike, to easily deploy to applications to Kubernetes, Fly.io, and other services.

Please note that the Dockerfile only exports port 8080, which means that there's no access to the ChiselStrike RPC from outside. We can re-visit the decision once we have TLS support for gRPC:

https://github.com/chiselstrike/chiselstrike/issues/1782

Also note that the generated image is pretty big because we need to run `npm install` to fetch dependencies, which requires Node to be present. The `chisel apply` command also has a hard-coded dependency to `npx`.

Also, we're currently unable to use Alpine Linux, for example, as a super-slim base image because of:

https://github.com/chiselstrike/chiselstrike/issues/1781