### PR TITLE
cli/apply: Run "esbuild" without "npx"

### DIFF
--- a/cli/src/cmd/apply/node.rs
+++ b/cli/src/cmd/apply/node.rs
@@ -146,7 +146,7 @@ pub(crate) async fn apply(
         },
     ];
 
-    let bundler_output = npx("esbuild", &bundler_args)?
+    let bundler_output = esbuild(&bundler_args)?
         .wait_with_output()
         .await
         .context("Could not run esbuild")?;
@@ -160,6 +160,17 @@ pub(crate) async fn apply(
     }];
 
     Ok((modules, index_candidates))
+}
+
+fn esbuild<A: AsRef<OsStr>>(args: &[A]) -> Result<tokio::process::Child> {
+    let command = "./node_modules/esbuild/bin/esbuild";
+    let cmd = tokio::process::Command::new(command)
+        .args(args)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .context(format!("Could not start `{}`", command))?;
+    Ok(cmd)
 }
 
 fn npx<A: AsRef<OsStr>>(command: &'static str, args: &[A]) -> Result<tokio::process::Child> {


### PR DESCRIPTION
The "esbuild" program is a native binary. Let's run it without "npx" to eliminate the Node.js dependency in "chisel apply".