### PR TITLE
New CRUD API

### DIFF
--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -1,18 +1,6 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
-export {
-    createPathParser,
-    createURLPathParser,
-    crud,
-    standardCRUDMethods,
-} from "./crud.ts";
-export type {
-    CRUDBaseParams,
-    CRUDCreateResponse,
-    CRUDCreateResponses,
-    CRUDMethods,
-    CRUDMethodSignature,
-} from "./crud.ts";
+export { crud } from "./crud.ts";
 export {
     AuthUser,
     ChiselCursor,

--- a/api/src/builtin_root.ts
+++ b/api/src/builtin_root.ts
@@ -19,10 +19,10 @@ export const routeMap = new RouteMap()
     .prefix(
         "/auth",
         new RouteMap()
-            .prefix("/users", RouteMap.convert(AuthUser.crud()))
-            .prefix("/sessions", RouteMap.convert(AuthSession.crud()))
-            .prefix("/tokens", RouteMap.convert(AuthToken.crud()))
-            .prefix("/accounts", RouteMap.convert(AuthAccount.crud()))
+            .prefix("/users", AuthUser.crud())
+            .prefix("/sessions", AuthSession.crud())
+            .prefix("/tokens", AuthToken.crud())
+            .prefix("/accounts", AuthAccount.crud())
             .middleware(authMiddleware),
     );
 

--- a/api/src/crud.ts
+++ b/api/src/crud.ts
@@ -1,184 +1,172 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
-import { ChiselCursor, ChiselEntity, requestContext } from "./datastore.ts";
-import { ChiselRequest } from "./request.ts";
 import { mergeDeep, opAsync, responseFromJson } from "./utils.ts";
-
-// TODO: BEGIN: when module import is fixed:
-//     import { parse as regExParamParse } from "regexparam";
-// or:
-//     import { parse as regExParamParse } from "regexparam";
-// In the meantime, the regExParamParse function is copied from
-// https://deno.land/x/regexparam@v2.0.0/src/index.js under MIT License included
-// below. ChiselStrike added the TS signature and minor cleanups.
-//
-// Copyright (c) Luke Edwards <luke.edwards05@gmail.com> (lukeed.com)
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-function regExParamParse(str: string, loose: boolean) {
-    let tmp, pattern = "";
-    const keys = [], arr = str.split("/");
-    arr[0] || arr.shift();
-
-    while ((tmp = arr.shift())) {
-        const c = tmp[0];
-        if (c === "*") {
-            keys.push("wild");
-            pattern += "/(.*)";
-        } else if (c === ":") {
-            const o = tmp.indexOf("?", 1);
-            const ext = tmp.indexOf(".", 1);
-            keys.push(tmp.substring(1, ~o ? o : ~ext ? ext : tmp.length));
-            pattern += !!~o && !~ext ? "(?:/([^/]+?))?" : "/([^/]+?)";
-            if (~ext) pattern += (~o ? "?" : "") + "\\" + tmp.substring(ext);
-        } else {
-            pattern += "/" + tmp;
-        }
-    }
-
-    return {
-        keys: keys,
-        pattern: new RegExp("^" + pattern + (loose ? "(?=$|/)" : "/?$"), "i"),
-    };
-}
-// TODO: END: when module import is fixed
+import { ChiselEntity, requestContext } from "./datastore.ts";
+import { ChiselRequest } from "./request.ts";
+import { RouteMap } from "./routing.ts";
 
 type ChiselEntityClass<T extends ChiselEntity> = {
     new (): T;
     findOne: (_: { id: string }) => Promise<T | undefined>;
     findMany: (_: Partial<T>) => Promise<T[]>;
     build: (...properties: Record<string, unknown>[]) => T;
-    delete: (restrictions: Partial<T>) => Promise<void>;
-    cursor: () => ChiselCursor<T>;
+    delete: (_: { id: string }) => Promise<void>;
 };
 
-type GenericChiselEntityClass = ChiselEntityClass<ChiselEntity>;
-
 /**
- * Creates a path parser from a template using regexparam.
- *
- * @param pathTemplate the path template such as `/static`, `/param/:id/:otherParam`...
- * @param loose if true, it can match longer paths. False by default
- * @returns function that can parse paths given as string.
- * @see https://deno.land/x/regexparam@v2.0.0
+ * Generates a route map to handle REST methods GET/PUT/POST/DELETE for this entity.
+ * @example
+ * Put this in the file 'routes/comments.ts':
+ * ```typescript
+ * import { Comment } from "../models/comment";
+ * export default crud(Comment);
+ * ```
+ * This results in a /comments endpoint that correctly handles all REST methods over Comment.
+ * @param entity Entity type
+ * @param config Configure the CRUD behavior. Using this parameter is currently experimental, this API is not
+ * yet stabilized.
+ *  - `createResponse`: function to create response from entity or an array of entities. Defaults to
+ *    `responseFromJson()`.
+ *  - `getAll`: should we generate `GET /` route that returns all entities according to filters in the URL
+ *    query parameters? Defaults to true.
+ *  - `getOne`: should we generate `GET /:id` route that returns one entity by id? Defaults to true.
+ *  - `write`: should we generate the routes that write to the database? Defaults to true, and it can be
+ *    overriden on a per-route basis.
+ *  - `post`: should we generate `POST /` route that creates a new entity? Defaults to the value of `write`.
+ *  - `put`: should we generate `PUT /:id` route that creates or updates an entity? Defaults to the
+ *    value of `write`.
+ *  - `patch`: should we generate `PATCH /:id` route that modifies an entity? Defaults to the value of `write`.
+ *  - `deleteAll`: should we generate `DELETE /` route that deletes all entities according to filters in the
+ *    URL query parameters? Defaults to the value of `write`.
+ *  - `deleteOne`: should we generate `DELETE /:id` route that deletes one entity by id? Defaults to the
+ *    value of `write`.
+ * @returns A route map suitable as a default export in a route file.
  */
-export function createPathParser<T extends Record<string, unknown>>(
-    pathTemplate: string,
-    loose = false,
-): (path: string) => T {
-    const { pattern, keys: keysOrFalse } = regExParamParse(pathTemplate, loose);
-    if (typeof keysOrFalse === "boolean") {
-        throw new Error(
-            `invalid pathTemplate=${pathTemplate}, expected string`,
+export function crud<
+    T extends ChiselEntity,
+    E extends ChiselEntityClass<T>,
+>(
+    entity: E,
+    config?: {
+        createResponse?: (
+            body: unknown,
+            status: number,
+        ) => Promise<Response> | Response;
+        getAll?: boolean;
+        getOne?: boolean;
+        write?: boolean;
+        post?: boolean;
+        put?: boolean;
+        patch?: boolean;
+        deleteAll?: boolean;
+        deleteOne?: boolean;
+    },
+): RouteMap {
+    const createResponse = config?.createResponse ?? responseFromJson;
+    const routeMap = new RouteMap();
+
+    // Returns all entities matching the filter in the `filter` URL parameter.
+    async function getAll(req: ChiselRequest): Promise<Response> {
+        return createResponse(
+            await fetchEntitiesCrud(entity, req.path, Array.from(req.query)),
+            200,
         );
     }
-    const keys = keysOrFalse;
-    return function pathParser(path: string): T {
-        const matches = pattern.exec(path);
-        return keys.reduce(
-            (acc: Record<string, unknown>, key: string, index: number) => {
-                acc[key] = matches?.[index + 1];
-                return acc;
-            },
-            {},
-        ) as T;
-    };
+    if (config?.getAll ?? true) {
+        routeMap.get("/", getAll);
+    }
+
+    // Returns a specific entity matching :id
+    async function getOne(req: ChiselRequest): Promise<Response> {
+        const id = req.params.get("id");
+        const u = await entity.findOne({ id });
+        if (u !== undefined) {
+            return createResponse(u, 200);
+        } else {
+            return createResponse("Not found", 404);
+        }
+    }
+    if (config?.getOne ?? true) {
+        routeMap.get("/:id", getOne);
+    }
+
+    // Creates and returns a new entity from the `req` payload. Ignores the payload's id property and assigns a fresh one.
+    async function post(req: ChiselRequest): Promise<Response> {
+        const u = entity.build(await req.json());
+        u.id = undefined;
+        await u.save();
+        return createResponse(u, 200);
+    }
+    if (config?.post ?? config?.write ?? true) {
+        routeMap.post("/", post);
+    }
+
+    // Updates and returns the entity matching :id from the `req` payload.
+    async function put(req: ChiselRequest): Promise<Response> {
+        const u = entity.build(await req.json());
+        u.id = req.params.get("id");
+        await u.save();
+        return createResponse(u, 200);
+    }
+    if (config?.put ?? config?.write ?? true) {
+        routeMap.put("/:id", put);
+    }
+
+    // Modifies an entity matching :id from the `req` payload.
+    async function patch(req: ChiselRequest): Promise<Response> {
+        const orig = await entity.findOne({ id: req.params.get("id") });
+        if (!orig) {
+            return createResponse(
+                "object does not exist, cannot PATCH",
+                404,
+            );
+        }
+        mergeDeep(
+            orig as unknown as Record<string, unknown>,
+            await req.json(),
+        );
+        await orig.save();
+        return createResponse(orig, 200);
+    }
+    if (config?.patch ?? config?.write ?? true) {
+        routeMap.patch("/:id", patch);
+    }
+
+    // Deletes all entities matching the filter in the `filter` URL parameter.
+    async function deleteAll(req: ChiselRequest): Promise<Response> {
+        await deleteEntitiesCrud(entity, Array.from(req.query));
+        return createResponse(
+            `Deleted entities matching ?${req.query.toString()}`,
+            200,
+        );
+    }
+    if (config?.deleteAll ?? config?.write ?? true) {
+        routeMap.delete("/", deleteAll);
+    }
+
+    // Deletes the entity matching :id
+    async function deleteOne(req: ChiselRequest): Promise<Response> {
+        const id = req.params.get("id");
+        await entity.delete({ id });
+        return createResponse(`Deleted ID ${id}`, 200);
+    }
+    if (config?.deleteOne ?? config?.write ?? true) {
+        routeMap.delete("/:id", deleteOne);
+    }
+
+    return routeMap;
 }
 
-/**
- * Creates a path parser from a template using regexparam.
- *
- * @param pathTemplate the path template such as `/static`, `/param/:id/:otherParam`...
- * @param loose if true, it can match longer paths. False by default
- * @returns function that can parse paths given in URL.pathname.
- * @see https://deno.land/x/regexparam@v2.0.0
- */
-export function createURLPathParser<T extends Record<string, unknown>>(
-    pathTemplate: string,
-    loose = false,
-): (url: URL) => T {
-    const pathParser = createPathParser<T>(pathTemplate, loose);
-    return (url: URL): T => pathParser(url.pathname);
-}
-
-/** Creates a Response object from response body and status. */
-export type CRUDCreateResponse = (
-    body: unknown,
-    status: number,
-) => Promise<Response> | Response;
-
-export type CRUDBaseParams = {
-    /** identifier of the object being manipulated, if any */
-    id?: string;
-    /** ChiselStrike's version/branch the server is running,
-     * such as 'dev' for endpoint '/dev/example'
-     * when using 'chisel apply --version dev'
-     */
-    chiselVersion: string;
-};
-
-export type CRUDMethodSignature<
-    T extends ChiselEntity,
-    E extends ChiselEntityClass<T>,
-    P extends CRUDBaseParams = CRUDBaseParams,
-> = (
-    entity: E,
-    req: Request,
-    params: P,
-    url: URL,
-    createResponse: CRUDCreateResponse,
-) => Promise<Response>;
-
-/**
- * A dictionary mapping HTTP methods into corresponding REST methods that process a Request and return a Response.
- */
-export type CRUDMethods<
-    T extends ChiselEntity,
-    E extends ChiselEntityClass<T>,
-    P extends CRUDBaseParams = CRUDBaseParams,
-> = {
-    GET: CRUDMethodSignature<T, E, P>;
-    POST: CRUDMethodSignature<T, E, P>;
-    PUT: CRUDMethodSignature<T, E, P>;
-    PATCH: CRUDMethodSignature<T, E, P>;
-    DELETE: CRUDMethodSignature<T, E, P>;
-};
-
-export type CRUDCreateResponses<
-    T extends ChiselEntity,
-    E extends ChiselEntityClass<T>,
-    P extends CRUDBaseParams = CRUDBaseParams,
-> = {
-    [K in keyof CRUDMethods<T, E, P>]: CRUDCreateResponse;
-};
-
-/**
- * Fetches crud data based on crud `url`.
- */
 async function fetchEntitiesCrud<T extends ChiselEntity>(
     type: { new (): T },
-    url: string,
+    urlPath: string,
+    urlQuery: [string, string][],
 ): Promise<T[]> {
     const results = await opAsync(
         "op_chisel_crud_query",
         {
             typeName: type.name,
-            url,
+            urlPath,
+            urlQuery,
         },
         requestContext,
     );
@@ -187,241 +175,14 @@ async function fetchEntitiesCrud<T extends ChiselEntity>(
 
 async function deleteEntitiesCrud<T extends ChiselEntity>(
     type: { new (): T },
-    url: string,
+    urlQuery: [string, string][],
 ): Promise<void> {
     await opAsync(
         "op_chisel_crud_delete",
         {
             typeName: type.name,
-            url,
+            urlQuery,
         },
         requestContext,
     );
-}
-
-const defaultCrudMethods: CRUDMethods<ChiselEntity, GenericChiselEntityClass> =
-    {
-        // Returns a specific entity matching params.id (if present) or all entities matching the filter in the `filter` URL parameter.
-        GET: async (
-            entity: GenericChiselEntityClass,
-            _req: Request,
-            params: CRUDBaseParams,
-            url: URL,
-            createResponse: CRUDCreateResponse,
-        ) => {
-            const { id } = params;
-            if (id) {
-                const u = await entity.findOne({ id });
-                return createResponse(u ?? "Not found", u ? 200 : 404);
-            } else {
-                return createResponse(
-                    await fetchEntitiesCrud(entity, url.href),
-                    200,
-                );
-            }
-        },
-        // Creates and returns a new entity from the `req` payload. Ignores the payload's id property and assigns a fresh one.
-        POST: async (
-            entity: GenericChiselEntityClass,
-            req: Request,
-            _params: CRUDBaseParams,
-            _url: URL,
-            createResponse: CRUDCreateResponse,
-        ) => {
-            const u = entity.build(await req.json());
-            u.id = undefined;
-            await u.save();
-            return createResponse(u, 200);
-        },
-        // Updates and returns the entity matching params.id (which must be set) from the `req` payload.
-        PUT: async (
-            entity: GenericChiselEntityClass,
-            req: Request,
-            params: CRUDBaseParams,
-            _url: URL,
-            createResponse: CRUDCreateResponse,
-        ) => {
-            const { id } = params;
-            if (!id) {
-                return createResponse(
-                    "PUT requires item ID in the URL",
-                    400,
-                );
-            }
-            const u = entity.build(await req.json());
-            u.id = id;
-            await u.save();
-            return createResponse(u, 200);
-        },
-        PATCH: async (
-            entity: GenericChiselEntityClass,
-            req: Request,
-            params: CRUDBaseParams,
-            _url: URL,
-            createResponse: CRUDCreateResponse,
-        ) => {
-            const { id } = params;
-            if (!id) {
-                return createResponse(
-                    "PATCH requires item ID in the URL",
-                    400,
-                );
-            }
-            const orig = await entity.findOne({ id });
-            if (!orig) {
-                return createResponse(
-                    "object does not exist, cannot PATCH",
-                    404,
-                );
-            }
-            mergeDeep(
-                orig as unknown as Record<string, unknown>,
-                await req.json(),
-            );
-            await orig.save();
-            return createResponse(orig, 200);
-        },
-
-        // Deletes the entity matching params.id (if present) or all entities matching the filter in the `filter` URL parameter. One of the two must be present.
-        DELETE: async (
-            entity: GenericChiselEntityClass,
-            _req: Request,
-            params: CRUDBaseParams,
-            url: URL,
-            createResponse: CRUDCreateResponse,
-        ) => {
-            const { id } = params;
-            if (id) {
-                await entity.delete({ id });
-                return createResponse(`Deleted ID ${id}`, 200);
-            } else {
-                await deleteEntitiesCrud(entity, url.href);
-                return createResponse(
-                    `Deleted entities matching ${url.search}`,
-                    200,
-                );
-            }
-        },
-    } as const;
-
-/**
- * These methods can be used as `customMethods` in `ChiselStrike.crud()`.
- *
- * @example
- * Put this in the file 'endpoints/comments.ts':
- * ```typescript
- * import { Comment } from "../models/comment";
- * export default crud(
- *   Comment,
- *   ':id',
- *   {
- *     PUT: standardCRUDMethods.notFound, // do not update, instead returns 404
- *     DELETE: standardCRUDMethods.methodNotAllowed, // do not delete, instead returns 405
- *   },
- * );
- * ```
- */
-export const standardCRUDMethods = {
-    forbidden: (
-        _entity: GenericChiselEntityClass,
-        _req: Request,
-        _params: CRUDBaseParams,
-        _url: URL,
-        createResponse: CRUDCreateResponse,
-    ) => Promise.resolve(createResponse("Forbidden", 403)),
-    notFound: (
-        _entity: GenericChiselEntityClass,
-        _req: Request,
-        _params: CRUDBaseParams,
-        _url: URL,
-        createResponse: CRUDCreateResponse,
-    ) => Promise.resolve(createResponse("Not Found", 404)),
-    methodNotAllowed: (
-        _entity: GenericChiselEntityClass,
-        _req: Request,
-        _params: CRUDBaseParams,
-        _url: URL,
-        createResponse: CRUDCreateResponse,
-    ) => Promise.resolve(createResponse("Method Not Allowed", 405)),
-} as const;
-
-/**
- * Generates endpoint code to handle REST methods GET/PUT/POST/DELETE for this entity.
- * @example
- * Put this in the file 'endpoints/comments.ts':
- * ```typescript
- * import { Comment } from "../models/comment";
- * export default crud(Comment, ":id");
- * ```
- * This results in a /comments endpoint that correctly handles all REST methods over Comment.
- * @param entity Entity type
- * @param urlTemplateSuffix A suffix to be added to the Request URL (see https://deno.land/x/regexparam for syntax).
- *   Some CRUD methods rely on parts of the URL to identify the resource to apply to. Eg, GET /comments/1234
- *   returns the comment entity with id=1234, while GET /comments returns all comments. This parameter describes
- *   how to find the relevant parts in the URL. Default CRUD methods (see `defaultCrudMethods`) look for the :id
- *   part in this template to identify specific entity instances. If there is no :id in the template, then ':id'
- *   is automatically added to its end. Custom methods can use other named parts.
- * @param config Configure the CRUD behavior:
- *  - `customMethods`: custom request handlers overriding the defaults.
- *     Each present property overrides that method's handler. You can use `standardCRUDMethods` members here to
- *     conveniently reject some actions. When `customMethods` is absent, we use methods from `defaultCrudMethods`.
- *     Note that these default methods look for the `id` property in their `params` argument; if set, its value is
- *     the id of the entity to process. Conveniently, the default `urlTemplate` parser sets this property from the
- *     `:id` pattern.
- *  - `createResponses`: if present, a dictionary of method-specific Response creators.
- *  - `defaultCreateResponse`: default function to create all responses if `createResponses` entry is not provided.
- *     Defaults to `responseFromJson()`.
- *  - `parsePath`: parses the URL path instead of https://deno.land/x/regexparam. The parsing result is passed to
- *     CRUD methods as the `params` argument.
- * @returns A request-handling function suitable as a default export in an endpoint.
- */
-export function crud<
-    T extends ChiselEntity,
-    E extends ChiselEntityClass<T>,
-    P extends CRUDBaseParams = CRUDBaseParams,
->(
-    entity: E,
-    urlTemplateSuffix: string,
-    config?: {
-        customMethods?: Partial<CRUDMethods<T, ChiselEntityClass<T>, P>>;
-        createResponses?: Partial<
-            CRUDCreateResponses<T, ChiselEntityClass<T>, P>
-        >;
-        defaultCreateResponse?: CRUDCreateResponse;
-        parsePath?: (url: URL) => P;
-    },
-): (req: ChiselRequest) => Promise<Response> {
-    const defaultCreateResponse = config?.defaultCreateResponse ||
-        responseFromJson;
-    const localDefaultCrudMethods =
-        defaultCrudMethods as unknown as CRUDMethods<T, E, P>;
-    const methods = config?.customMethods
-        ? { ...localDefaultCrudMethods, ...config?.customMethods }
-        : localDefaultCrudMethods;
-
-    return (req: ChiselRequest): Promise<Response> => {
-        const pathTemplateRaw = "/:chiselVersion" + req.endpoint + "/" +
-            (urlTemplateSuffix.includes(":id")
-                ? urlTemplateSuffix
-                : `${urlTemplateSuffix}/:id`);
-
-        const pathTemplate = pathTemplateRaw.replace(/\/+/g, "/"); // in case we end up with foo///bar somehow.
-
-        const parsePath = config?.parsePath ||
-            createURLPathParser(pathTemplate);
-
-        const methodName = req.method as keyof typeof methods; // assume valid, will be handled gracefully
-        const createResponse = config?.createResponses?.[methodName] ||
-            defaultCreateResponse;
-        const method = methods[methodName];
-        if (!method) {
-            return Promise.resolve(
-                createResponse(`Unsupported HTTP method: ${methodName}`, 405),
-            );
-        }
-
-        const url = new URL(req.url);
-        const params = parsePath(url);
-        return method(entity, req, params, url, createResponse);
-    };
 }

--- a/api/src/datastore.ts
+++ b/api/src/datastore.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
 import { crud } from "./crud.ts";
-import type { Handler } from "./routing.ts";
+import type { RouteMap } from "./routing.ts";
 import { mergeDeep, opAsync, opSync } from "./utils.ts";
 import { SimpleTypeSystem, TypeSystem } from "./type_system.ts";
 
@@ -993,10 +993,10 @@ export class ChiselEntity {
      *
      * If you need more control over which method to generate and their behavior, see the top-level `crud()` function
      *
-     * @returns A function suitable as a default export in a route.
+     * @returns A route map suitable as a default export in a route.
      */
-    static crud(): Handler {
-        return crud(this, "");
+    static crud(): RouteMap {
+        return crud(this);
     }
 
     /**

--- a/cli/tests/integration_tests/lit_tests/crud-custom.node
+++ b/cli/tests/integration_tests/lit_tests/crud-custom.node
@@ -65,24 +65,15 @@ function createResponse(body: unknown, status: number) {
     }
     return responseFromYAML({ error: body, status }, status);
 }
-export default crud(
-    Person,
-    ":id", /* :id can be explicitly provided */
-    {
-        customMethods: {
-            "DELETE": standardCRUDMethods.methodNotAllowed,
-            "PUT": standardCRUDMethods.forbidden,
-        },
-        createResponses: {
-            "DELETE": createResponse,
-            "GET": createResponse,
-            "POST": createResponse,
-        },
-        defaultCreateResponse: (body: unknown, status: number) => { // used by PUT
-            return responseFromYAML({ body: body }, status);
-        },
-    },
-);
+
+export default crud(Person, {
+        createResponse,
+        deleteAll: false,
+        deleteOne: false,
+        put: false,
+    })
+    .delete('*', (req) => createResponse("Method Not Allowed", 405))
+    .put('*', (req) => createResponse("Forbidden", 403));
 EOF
 
 cd "$TEMPDIR"
@@ -212,9 +203,9 @@ $CURL $CHISELD_HOST/dev/persons | grep first_name
 $CURL -X PUT -d '{"age":98422}' $CHISELD_HOST/dev/persons/cef5d492-d7e3-4c45-9a55-5929b9ab8292
 # CHECK: HTTP/1.1 403 Forbidden
 # CHECK: content-type: text/yaml
-# CHECK: body: "Forbidden"
+# CHECK: error: "Forbidden"
 
 $CURL -X PUT -d '{"age":98422}' $CHISELD_HOST/dev/persons/ # PUT without ID.
 # CHECK: HTTP/1.1 403 Forbidden
 # CHECK: content-type: text/yaml
-# CHECK: body: "Forbidden"
+# CHECK: error: "Forbidden"

--- a/cli/tests/integration_tests/lit_tests/delete.deno
+++ b/cli/tests/integration_tests/lit_tests/delete.deno
@@ -49,7 +49,7 @@ $CURL $CHISELD_HOST/dev/user | tr , \\n | sort
 # CHECK: "username": "bob"
 
 $CURL -X DELETE "$CHISELD_HOST/dev/user?.email=bob@bob.me"
-# CHECK: Deleted entities matching ?.email=bob@bob.me
+# CHECK: Deleted entities matching ?.email=bob%40bob.me
 
 $CURL $CHISELD_HOST/dev/user
 # CHECK: "username": "alice"

--- a/cli/tests/integration_tests/lit_tests/echo-endpoint.deno
+++ b/cli/tests/integration_tests/lit_tests/echo-endpoint.deno
@@ -39,7 +39,7 @@ $CURL --data foobar -o - $CHISELD_HOST/dev/echo
 
 # CHECK: {
 # CHECK:     "method": "POST",
-# CHECK:     "url": "http://chiselstrike.com/dev/echo",
+# CHECK:     "url": "https://chiselstrike.com/dev/echo",
 # CHECK:     "headers": {
 # CHECK:         "accept": "*/*",
 # CHECK:         "content-length": "6",
@@ -63,7 +63,7 @@ $CURL -H 'Expect: 100-continue' --data foobar -o - $CHISELD_HOST/dev/echo
 
 # CHECK: {
 # CHECK:     "method": "POST",
-# CHECK:     "url": "http://chiselstrike.com/dev/echo",
+# CHECK:     "url": "https://chiselstrike.com/dev/echo",
 # CHECK:     "headers": {
 # CHECK:         "accept": "*/*",
 # CHECK:         "content-length": "6",

--- a/cli/tests/integration_tests/lit_tests/introspect.node
+++ b/cli/tests/integration_tests/lit_tests/introspect.node
@@ -22,10 +22,10 @@ $CHISEL apply
 $CURL $CHISELD_HOST/__chiselstrike/
 # CHECK: HTTP/1.1 200 OK
 # CHECK: "title": "ChiselStrike Internal API",
-# CHECK: "/__chiselstrike/auth/users/
-# CHECK: "/__chiselstrike/auth/sessions/
-# CHECK: "/__chiselstrike/auth/tokens/
-# CHECK: "/__chiselstrike/auth/accounts/
+# CHECK: "/__chiselstrike/auth/users/"
+# CHECK: "/__chiselstrike/auth/sessions/"
+# CHECK: "/__chiselstrike/auth/tokens/"
+# CHECK: "/__chiselstrike/auth/accounts/"
 
 $CURL $CHISELD_HOST/
 # CHECK: HTTP/1.1 200 OK

--- a/cli/tests/integration_tests/lit_tests/prefix.deno
+++ b/cli/tests/integration_tests/lit_tests/prefix.deno
@@ -22,14 +22,14 @@ $CHISEL apply
 $CURL -o - $CHISELD_HOST/dev/foo
 
 # CHECK: HTTP/1.1 200 OK
-# CHECK: foo with url http://chiselstrike.com/dev/foo
+# CHECK: foo with url https://chiselstrike.com/dev/foo
 
 $CURL -o - $CHISELD_HOST/dev/foo/bar
 
 # CHECK: HTTP/1.1 200 OK
-# CHECK: foo/bar with url http://chiselstrike.com/dev/foo/bar
+# CHECK: foo/bar with url https://chiselstrike.com/dev/foo/bar
 
 $CURL -o - $CHISELD_HOST/dev/foo/zed
 
 # CHECK: HTTP/1.1 200 OK
-# CHECK: foo with url http://chiselstrike.com/dev/foo/zed
+# CHECK: foo with url https://chiselstrike.com/dev/foo/zed

--- a/cli/tests/integration_tests/rust_tests/crud.rs
+++ b/cli/tests/integration_tests/rust_tests/crud.rs
@@ -384,7 +384,7 @@ pub async fn put_with_id(c: TestContext) {
         .json(&*GLAUBER)
         .send()
         .await
-        .assert_status(400);
+        .assert_status(405);
 }
 
 #[chisel_macros::test(modules = Deno)]
@@ -416,7 +416,7 @@ pub async fn patch_with_id(c: TestContext) {
         .json(json!({"height": 34.56}))
         .send()
         .await
-        .assert_status(400);
+        .assert_status(405);
 
     c.chisel
         .patch("/dev/people/foobar")

--- a/server/src/datastore/crud.rs
+++ b/server/src/datastore/crud.rs
@@ -12,13 +12,13 @@ use futures::{Future, StreamExt};
 use guard::guard;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::json;
-use url::Url;
 
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryParams {
     type_name: String,
-    url: Url,
+    url_path: String,
+    url_query: Vec<(String, String)>,
 }
 
 /// Parses CRUD `params` and runs the query with provided `query_engine`.
@@ -38,13 +38,12 @@ fn run_query_impl(
     query_engine: QueryEngine,
     tr: TransactionStatic,
 ) -> Result<impl Future<Output = Result<JsonObject>>> {
-    let host = context.headers.get("host").cloned();
     let base_type = &context
         .ts
         .lookup_entity(&params.type_name)
         .context("unexpected type name as crud query base type")?;
 
-    let query = Query::from_url(base_type, &params.url, context.ts)?;
+    let query = Query::from_url_query(base_type, &params.url_query, context.ts)?;
     let ops = query.make_query_ops()?;
     let query_plan = QueryPlan::from_ops(context, base_type, ops)?;
     let stream = query_engine.query(tr.clone(), query_plan)?;
@@ -74,11 +73,11 @@ fn run_query_impl(
             .collect();
 
         let mut ret = JsonObject::new();
-        let next_page = get_next_page(&params, &query, &host, &results)?;
+        let next_page = get_next_page(&params, &query, &results)?;
         if let Some(next_page) = next_page {
             ret.insert("next_page".into(), json!(next_page));
         }
-        let prev_page = get_prev_page(&params, &query, &host, &results)?;
+        let prev_page = get_prev_page(&params, &query, &results)?;
         if let Some(prev_page) = prev_page {
             ret.insert("prev_page".into(), json!(prev_page));
         }
@@ -94,10 +93,9 @@ fn run_query_impl(
 fn get_next_page(
     params: &QueryParams,
     query: &Query,
-    host: &Option<String>,
     results: &[JsonObject],
-) -> Result<Option<Url>> {
-    get_page(params, query, host, results, true)
+) -> Result<Option<String>> {
+    get_page(params, query, results, true)
 }
 
 /// Evaluates current query circumstances and potentially generates
@@ -106,19 +104,17 @@ fn get_next_page(
 fn get_prev_page(
     params: &QueryParams,
     query: &Query,
-    host: &Option<String>,
     results: &[JsonObject],
-) -> Result<Option<Url>> {
-    get_page(params, query, host, results, false)
+) -> Result<Option<String>> {
+    get_page(params, query, results, false)
 }
 
 fn get_page(
     params: &QueryParams,
     query: &Query,
-    host: &Option<String>,
     results: &[JsonObject],
     forward: bool,
-) -> Result<Option<Url>> {
+) -> Result<Option<String>> {
     if !results.is_empty() {
         let pivot = if forward {
             results.last().unwrap()
@@ -126,13 +122,13 @@ fn get_page(
             results.first().unwrap()
         };
         let cursor = cursor_from_pivot(query, pivot, forward)?;
-        let url = make_page_url(&params.url, host, &cursor)?;
-        return Ok(Some(url));
+        let rel_url = make_page_url(&params.url_path, &params.url_query, &cursor.to_string()?);
+        return Ok(Some(rel_url));
     } else if let Some(cursor) = &query.cursor {
         if cursor.forward != forward {
             let cursor = cursor.reversed();
-            let url = make_page_url(&params.url, host, &cursor)?;
-            return Ok(Some(url));
+            let rel_url = make_page_url(&params.url_path, &params.url_query, &cursor.to_string()?);
+            return Ok(Some(rel_url));
         }
     }
     Ok(None)
@@ -162,38 +158,38 @@ fn cursor_from_pivot(query: &Query, pivot_element: &JsonObject, forward: bool) -
     Ok(cursor)
 }
 
-/// Generates URL that can be used to retrieve previous/next page.
-/// It does this by modifying the current `url`, potentially replacing
-/// host address with `host` and generating url based on the current cursor.
-fn make_page_url(url: &Url, host: &Option<String>, cursor: &Cursor) -> Result<Url> {
-    let cursor = cursor.to_string()?;
-
-    let mut page_url = replace_host_address(url.clone(), host)?;
-    page_url.set_query(Some(""));
-    for (key, value) in url.query_pairs() {
+/// Generates relative URL that can be used to retrieve previous/next page.
+/// It does this by using the path from the current `url` and setting the `cursor` as a query
+/// parameter.
+fn make_page_url(url_path: &str, url_query: &[(String, String)], cursor: &str) -> String {
+    let mut page_query = form_urlencoded::Serializer::new(String::new());
+    for (key, value) in url_query.iter() {
         if key == "cursor" || key == "sort" {
             continue;
         }
-        page_url.query_pairs_mut().append_pair(&key, &value);
+        page_query.append_pair(key, value);
     }
-    page_url.query_pairs_mut().append_pair("cursor", &cursor);
+    page_query.append_pair("cursor", cursor);
 
-    Ok(page_url)
+    format!("{}?{}", url_path, page_query.finish())
 }
 
-/// Constructs Delete Mutation from CRUD url.
-pub fn delete_from_url(c: &RequestContext, type_name: &str, url: &str) -> Result<Mutation> {
+/// Constructs Delete Mutation from CRUD url query.
+pub fn delete_from_url_query(
+    c: &RequestContext,
+    type_name: &str,
+    url_query: &[(String, String)],
+) -> Result<Mutation> {
     let base_entity = match c.ts.lookup_type(type_name) {
         Ok(Type::Entity(ty)) => ty,
         Ok(ty) => anyhow::bail!("Cannot delete scalar type {type_name} ({})", ty.name()),
         Err(_) => anyhow::bail!("Cannot delete from type `{type_name}`, type not found"),
     };
-    let filter_expr = url_to_filter(&base_entity, url, c.ts)
+    let filter_expr = url_query_to_filter(&base_entity, url_query, c.ts)
         .context("failed to convert crud URL to filter expression")?;
     if filter_expr.is_none() {
-        let q = Url::parse(url).with_context(|| format!("failed to parse query string '{url}'"))?;
-        let delete_all = q
-            .query_pairs()
+        let delete_all = url_query
+            .iter()
             .any(|(key, value)| key == "all" && value == "true");
         if !delete_all {
             anyhow::bail!("crud delete requires a filter to be set or `all=true` parameter.")
@@ -228,12 +224,16 @@ impl Query {
         }
     }
 
-    /// Parses provided `url` and builds a `Query` that can be used to build a `QueryPlan`.
-    fn from_url(base_type: &Entity, url: &Url, ts: &TypeSystem) -> Result<Self> {
+    /// Parses provided `url_query` and builds a `Query` that can be used to build a `QueryPlan`.
+    fn from_url_query(
+        base_type: &Entity,
+        url_query: &[(String, String)],
+        ts: &TypeSystem,
+    ) -> Result<Self> {
         let mut q = Query::new();
-        for (param_key, value) in url.query_pairs().into_owned() {
+        for (param_key, value) in url_query.iter() {
             match param_key.as_str() {
-                "sort" => q.sort = parse_sort(base_type, &value)?,
+                "sort" => q.sort = parse_sort(base_type, value)?,
                 "limit" | "page_size" => {
                     q.page_size = value.parse().with_context(|| {
                         format!("failed to parse {param_key}. Expected u64, got '{}'", value)
@@ -250,12 +250,12 @@ impl Query {
                         q.cursor.is_none(),
                         "only one occurrence of cursor is allowed."
                     );
-                    let cursor = Cursor::from_string(&value)?;
+                    let cursor = Cursor::from_string(value)?;
                     q.cursor = Some(cursor);
                 }
                 _ => {
                     if let Some(param_key) = param_key.strip_prefix('.') {
-                        let expr = filter_from_param(base_type, param_key, &value, ts)
+                        let expr = filter_from_param(base_type, param_key, value, ts)
                             .with_context(|| {
                                 format!("failed to parse filter {param_key}={value}")
                             })?;
@@ -273,7 +273,7 @@ impl Query {
         Ok(q)
     }
 
-    /// Makes query ops based on the CRUD parameters that were parsed by `from_url` method.
+    /// Makes query ops based on the CRUD parameters that were parsed by `from_url_query` method.
     /// The query ops can be used to retrieve desired results from the database.
     fn make_query_ops(&self) -> Result<Vec<QueryOp>> {
         let mut ops = vec![QueryOp::SortBy(self.sort.clone())];
@@ -424,14 +424,17 @@ fn json_to_value(field_type: &Type, value: &serde_json::Value) -> Result<Expr> {
     Ok(expr_val.into())
 }
 
-/// Parses all CRUD query-string filters over `base_type` from provided `url`.
-fn url_to_filter(base_type: &Entity, url: &str, ts: &TypeSystem) -> Result<Option<Expr>> {
+/// Parses all CRUD query-string filters over `base_type` from provided `url_query`.
+fn url_query_to_filter(
+    base_type: &Entity,
+    url_query: &[(String, String)],
+    ts: &TypeSystem,
+) -> Result<Option<Expr>> {
     let mut filter = None;
-    let q = Url::parse(url).with_context(|| format!("failed to parse query string '{}'", url))?;
-    for (param_key, value) in q.query_pairs().into_owned() {
+    for (param_key, value) in url_query.iter() {
         let param_key = param_key.to_string();
         if let Some(param_key) = param_key.strip_prefix('.') {
-            let expression = filter_from_param(base_type, param_key, &value, ts)
+            let expression = filter_from_param(base_type, param_key, value, ts)
                 .context("failed to parse filter")?;
 
             filter = filter
@@ -558,26 +561,6 @@ fn convert_operator(op_str: Option<&str>) -> Result<BinaryOp> {
     Ok(op)
 }
 
-fn replace_host_address(mut url: Url, host_address: &Option<String>) -> Result<Url> {
-    if let Some(host_address) = host_address {
-        let address_tokens: Vec<_> = host_address.split(':').collect();
-        anyhow::ensure!(
-            address_tokens.len() <= 2,
-            "unexpected number of tokens in host address"
-        );
-        let host = address_tokens.first().copied();
-        let port: Option<u16> = address_tokens
-            .get(1)
-            .map(|p| p.parse())
-            .transpose()
-            .context("Failed to parse address port")?;
-        url.set_host(host)?;
-        url.set_port(port)
-            .map_err(|_| anyhow::anyhow!("Failed to set url port"))?;
-    }
-    Ok(url)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -661,51 +644,6 @@ mod tests {
     static TYPE_SYSTEM: Lazy<TypeSystem> = Lazy::new(|| make_type_system(&*ENTITIES));
 
     #[test]
-    fn test_replace_host_address() {
-        fn check_replace(url: &str, host_address: &str, expected_url: &str) {
-            let url = Url::parse(url).unwrap();
-            let new_url = replace_host_address(url, &Some(host_address.to_owned())).unwrap();
-            assert_eq!(new_url.as_str(), expected_url);
-        }
-
-        check_replace(
-            "http://example.com/foo",
-            "example.com:999",
-            "http://example.com:999/foo",
-        );
-        check_replace(
-            "http://example.com:777/foo",
-            "example.com:999",
-            "http://example.com:999/foo",
-        );
-        check_replace(
-            "http://example.com/foo",
-            "example.com:999",
-            "http://example.com:999/foo",
-        );
-        check_replace(
-            "http://192.168.1.1:777/foo",
-            "example.com:999",
-            "http://example.com:999/foo",
-        );
-        check_replace(
-            "http://192.168.1.1:777/foo",
-            "example.com",
-            "http://example.com/foo",
-        );
-        check_replace(
-            "http://example.com:777/foo",
-            "192.168.1.1:999",
-            "http://192.168.1.1:999/foo",
-        );
-        check_replace(
-            "http://example.com:777/foo",
-            "192.168.1.1",
-            "http://192.168.1.1/foo",
-        );
-    }
-
-    #[test]
     fn test_parse_filter() {
         let person_type = make_entity(
             "Person",
@@ -775,15 +713,6 @@ mod tests {
     }
 
     async fn run_query(entity_name: &str, url: Url, qe: &QueryEngine) -> Result<JsonObject> {
-        run_query_with_headers(entity_name, url, qe, HashMap::default()).await
-    }
-
-    async fn run_query_with_headers(
-        entity_name: &str,
-        url: Url,
-        qe: &QueryEngine,
-        headers: HashMap<String, String>,
-    ) -> Result<JsonObject> {
         let tr = qe.begin_transaction_static().await.unwrap();
         super::run_query(
             &RequestContext {
@@ -792,11 +721,12 @@ mod tests {
                 version_id: VERSION.to_owned(),
                 user_id: None,
                 path: "".to_string(),
-                headers,
+                headers: HashMap::default(),
             },
             QueryParams {
                 type_name: entity_name.to_owned(),
-                url,
+                url_path: url.path().to_owned(),
+                url_query: url.query_pairs().into_owned().collect(),
             },
             qe.clone(),
             tr,
@@ -922,7 +852,10 @@ mod tests {
         add_row(qe, &PERSON_TY, &alex, &TYPE_SYSTEM).await;
 
         fn get_url(raw: &serde_json::Value) -> Url {
-            Url::parse(raw.as_str().unwrap()).unwrap()
+            Url::parse("http://localhost")
+                .unwrap()
+                .join(raw.as_str().unwrap())
+                .unwrap()
         }
 
         // Simple forward step.
@@ -1051,18 +984,6 @@ mod tests {
             let names = collect_names(&r);
             assert_eq!(names, vec!["Alan", "Alex", "John", "Steve"]);
         }
-        // Check HOST header handling.
-        {
-            let headers = HashMap::<String, String>::from_iter([(
-                "host".to_string(),
-                "myhost.com:666".to_string(),
-            )]);
-            let r = run_query_with_headers("Person", url("page_size=1"), qe, headers)
-                .await
-                .unwrap();
-            let next_page = r["next_page"].as_str().unwrap();
-            assert!(next_page.starts_with("http://myhost.com:666"));
-        }
     }
 
     #[tokio::test]
@@ -1098,12 +1019,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_from_crud_url() {
-        fn url(query_string: &str) -> String {
-            format!("http://wtf?{}", query_string)
-        }
-
-        let delete_from_url = |entity_name: &str, url: &str| {
-            delete_from_url(
+        let delete_from_url_query = |entity_name: &str, query: &str| {
+            let url_query: Vec<_> = form_urlencoded::parse(query.as_bytes())
+                .into_owned()
+                .collect();
+            delete_from_url_query(
                 &RequestContext {
                     ps: &PolicySystem::default(),
                     ts: &make_type_system(&*ENTITIES),
@@ -1113,7 +1033,7 @@ mod tests {
                     headers: HashMap::default(),
                 },
                 entity_name,
-                url,
+                &url_query,
             )
             .unwrap()
         };
@@ -1124,7 +1044,7 @@ mod tests {
             let (qe, _db_file) = setup_clear_db(&*ENTITIES).await;
             add_row(&qe, &PERSON_TY, &john, &TYPE_SYSTEM).await;
 
-            let mutation = delete_from_url("Person", &url(".name=John"));
+            let mutation = delete_from_url_query("Person", ".name=John");
             qe.mutate(mutation).await.unwrap();
 
             assert_eq!(fetch_rows(&qe, &PERSON_TY).await.len(), 0);
@@ -1134,7 +1054,7 @@ mod tests {
             add_row(&qe, &PERSON_TY, &john, &TYPE_SYSTEM).await;
             add_row(&qe, &PERSON_TY, &alan, &TYPE_SYSTEM).await;
 
-            let mutation = delete_from_url("Person", &url(".age=30"));
+            let mutation = delete_from_url_query("Person", ".age=30");
             qe.mutate(mutation).await.unwrap();
 
             let rows = fetch_rows(&qe, &PERSON_TY).await;
@@ -1147,10 +1067,36 @@ mod tests {
             let (qe, _db_file) = setup_clear_db(&*ENTITIES).await;
             add_row(&qe, &COMPANY_TY, &chiselstrike, &TYPE_SYSTEM).await;
 
-            let mutation = delete_from_url("Company", &url(".ceo.name=John"));
+            let mutation = delete_from_url_query("Company", ".ceo.name=John");
             qe.mutate(mutation).await.unwrap();
 
             assert_eq!(fetch_rows(&qe, &COMPANY_TY).await.len(), 0);
         }
+    }
+
+    #[test]
+    fn test_make_page_url() {
+        fn check(url_path: &str, url_query: &str, cursor: &str, expected: &str) {
+            let url_query: Vec<_> = form_urlencoded::parse(url_query.as_bytes())
+                .into_owned()
+                .collect();
+            let actual = make_page_url(url_path, &url_query, cursor);
+            assert_eq!(actual.as_str(), expected);
+        }
+
+        check("/path", "", "abcd", "/path?cursor=abcd");
+        check("/path", "really=no", "xyzw", "/path?really=no&cursor=xyzw");
+        check(
+            "/path",
+            "really=no&foo=bar",
+            "xyzw",
+            "/path?really=no&foo=bar&cursor=xyzw",
+        );
+        check(
+            "/longer/url/path",
+            "",
+            "abcd",
+            "/longer/url/path?cursor=abcd",
+        );
     }
 }

--- a/server/src/ops/datastore.rs
+++ b/server/src/ops/datastore.rs
@@ -191,7 +191,7 @@ pub async fn op_chisel_delete(
 #[serde(rename_all = "camelCase")]
 pub struct CrudDeleteParams {
     type_name: String,
-    url: String,
+    url_query: Vec<(String, String)>,
 }
 
 #[deno_core::op]
@@ -201,10 +201,10 @@ pub async fn op_chisel_crud_delete(
     context: ChiselRequestContext,
 ) -> Result<()> {
     with_transaction(state, move |server, version, transaction| async move {
-        let mutation = crud::delete_from_url(
+        let mutation = crud::delete_from_url_query(
             &RequestContext::new(&version.policy_system, &version.type_system, context),
             &params.type_name,
-            &params.url,
+            &params.url_query,
         )
         .context(
             "failed to construct delete expression from JSON passed to `op_chisel_crud_delete`",

--- a/server/src/worker.rs
+++ b/server/src/worker.rs
@@ -102,7 +102,7 @@ async fn run(init: WorkerInit) -> Result<()> {
         enable_testing_features: false,
         is_tty: false,
         // FIXME: make location a configuration parameter
-        location: Some(Url::parse("http://chiselstrike.com").unwrap()),
+        location: Some(Url::parse("https://chiselstrike.com").unwrap()),
         no_color: true,
         runtime_version: "x".to_string(),
         ts_version: "x".to_string(),


### PR DESCRIPTION
This PR changes the TypeScript CRUD API. The simple `Entity.crud()` call behaves the same, but the customization is now different. Please see the `crud()` function in `crud.ts` for details (the diff is meaningless, please see the new file directly).

It also changes the paging links in the CRUD API to relative, because it is impossible to provide correct absolute URLs in the general case.

This is a follow-up of #1618.