### PR TITLE
tsc_compile_build: Don't remove comments

### DIFF
--- a/tsc_compile/src/lib.rs
+++ b/tsc_compile/src/lib.rs
@@ -546,14 +546,14 @@ mod tests {
         expected.sort_unstable();
         assert_eq!(keys, expected);
         let body = written[path].clone();
-        assert!(body.starts_with("import indent from"));
+        assert!(body.contains("import indent from"));
         assert!(!body.contains("undefined"));
     }
 
     async fn check_test2_ts(path: &str) {
         let written = compile_ts_code(&[path], Default::default()).await.unwrap();
         let body = written[path].clone();
-        assert!(body.starts_with("import { zed } from"));
+        assert!(body.contains("import { zed } from"));
     }
 
     #[tokio::test]

--- a/tsc_compile_build/src/tsc.js
+++ b/tsc_compile_build/src/tsc.js
@@ -118,7 +118,7 @@
             lib: defaultLibs,
             module: ts.ModuleKind.ESNext,
             noImplicitAny: true,
-            removeComments: true,
+            removeComments: false,
             strictPropertyInitialization: false, // we don't support constructors, so don't be strict about this
             strict: true,
             target: ts.ScriptTarget.ESNext,


### PR DESCRIPTION
Fix the tsc_compile_build configuration to not remove comments so that we preserve ChiselStrike API TypeDoc.

Reported by Doug Stevenson.