### PR TITLE
Kafka event publishing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -173,6 +173,7 @@ jobs:
 
     - name: Setup Apache Kafka
       run: |
+          sudo apt-get update
           sudo apt-get install -y openjdk-8-jre-headless
           curl -O https://downloads.apache.org/kafka/3.2.3/kafka_2.12-3.2.3.tgz
           tar xf kafka_2.12-3.2.3.tgz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe0133578c0986e1fe3dfcd4af1cc5b2dd6c3dbf534d69916ce16a2701d40ba"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher 0.4.3",
@@ -90,7 +90,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
 dependencies = [
  "aead 0.5.1",
- "aes 0.8.1",
+ "aes 0.8.2",
  "cipher 0.4.3",
  "ctr 0.9.2",
  "ghash 0.5.0",
@@ -103,7 +103,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
 dependencies = [
- "aes 0.8.1",
+ "aes 0.8.2",
 ]
 
 [[package]]
@@ -112,7 +112,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom 0.2.8",
  "once_cell",
  "version_check",
 ]
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 dependencies = [
  "backtrace",
 ]
@@ -213,7 +213,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "swc_macros_common",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -227,7 +227,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "swc_macros_common",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -257,11 +257,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
 dependencies = [
  "event-listener",
+ "futures-lite",
 ]
 
 [[package]]
@@ -282,7 +283,7 @@ checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -293,7 +294,7 @@ checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -345,9 +346,9 @@ checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64-simd"
@@ -613,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
 dependencies = [
  "jobserver",
 ]
@@ -644,7 +645,7 @@ version = "0.14.0-dev.0"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
  "walkdir",
 ]
 
@@ -654,7 +655,7 @@ version = "0.14.0-dev.0"
 dependencies = [
  "anyhow",
  "bimap",
- "clap 4.0.17",
+ "clap 4.0.18",
  "indexmap",
  "petgraph 0.6.2",
  "quine-mc_cluskey",
@@ -718,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.17"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06badb543e734a2d6568e19a40af66ed5364360b9226184926f89d229b4b4267"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
@@ -733,15 +734,15 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.13"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -761,7 +762,7 @@ dependencies = [
  "base64",
  "bytes",
  "chisel-macros",
- "clap 4.0.17",
+ "clap 4.0.18",
  "colored",
  "enclose",
  "endpoint_tsc",
@@ -795,8 +796,8 @@ dependencies = [
  "swc_ecmascript 0.143.0",
  "tempdir",
  "tempfile",
- "textwrap 0.15.1",
- "time 0.3.15",
+ "textwrap 0.15.2",
+ "time 0.3.16",
  "tokio",
  "toml",
  "tonic",
@@ -1023,7 +1024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1078,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f83d0ebf42c6eafb8d7c52f7e5f2d3003b89c7aa4fd2b79229209459a849af8"
+checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1090,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d050484b55975889284352b0ffc2ecbda25c0c55978017c132b29ba0818a86"
+checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1100,24 +1101,24 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "scratch",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d2199b00553eda8012dfec8d3b1c75fce747cf27c169a270b3b99e3448ab78"
+checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb67a6de1f602736dd7eaead0080cf3435df806c61b24b13328db128c58868f"
+checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1153,12 +1154,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
 dependencies = [
- "darling_core 0.14.1",
- "darling_macro 0.14.1",
+ "darling_core 0.14.2",
+ "darling_macro 0.14.2",
 ]
 
 [[package]]
@@ -1172,7 +1173,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "strsim 0.9.3",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1186,21 +1187,21 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "strsim 0.10.0",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "strsim 0.10.0",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1211,7 +1212,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1222,18 +1223,18 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
- "darling_core 0.14.1",
+ "darling_core 0.14.2",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1246,7 +1247,7 @@ dependencies = [
  "hashbrown",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.4",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1366,7 +1367,7 @@ dependencies = [
  "libc",
  "log",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project",
  "serde",
  "serde_json",
@@ -1380,7 +1381,7 @@ dependencies = [
 name = "deno_crypto"
 version = "0.87.0"
 dependencies = [
- "aes 0.8.1",
+ "aes 0.8.2",
  "aes-gcm 0.10.1",
  "aes-kw",
  "base64",
@@ -1471,7 +1472,7 @@ dependencies = [
  "deno_ast 0.14.1",
  "futures",
  "lazy_static",
- "parking_lot 0.12.1",
+ "parking_lot",
  "regex",
  "ring",
  "serde",
@@ -1545,7 +1546,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "regex",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1709,7 +1710,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "rustc_version 0.4.0",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1834,7 +1835,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1928,7 +1929,7 @@ dependencies = [
  "heck 0.4.0",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1940,7 +1941,7 @@ dependencies = [
  "heck 0.4.0",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1960,7 +1961,7 @@ checksum = "8958699f9359f0b04e691a13850d48b7de329138023876d07cbd024c2c820598"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1972,7 +1973,7 @@ dependencies = [
  "pmutil",
  "proc-macro2 1.0.47",
  "swc_macros_common",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2033,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -2052,14 +2053,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
+checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2163,7 +2164,7 @@ dependencies = [
  "pmutil",
  "proc-macro2 1.0.47",
  "swc_macros_common",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2252,13 +2253,13 @@ dependencies = [
 
 [[package]]
 name = "futures-intrusive"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62007592ac46aa7c2b6416f7deb9a8a8f63a01e0f1d6e1787d5630170db2b63e"
+checksum = "1b6bdbb8c5a42b2bb5ee8dd9dc2c7d73ce3e15d26dfe100fb347ffa3f58c672b"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot 0.11.2",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2268,6 +2269,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,7 +2291,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2344,7 +2360,7 @@ checksum = "60df8444f094ff7885631d80e78eb7d88c3c2361a98daaabb06256e4500db941"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
  "synstructure",
 ]
 
@@ -2380,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -2398,7 +2414,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2429,7 +2445,7 @@ checksum = "eb19fe8de3ea0920d282f7b77dd4227aea6b8b999b42cdf0ca41b2472b14443a"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2527,9 +2543,9 @@ checksum = "ff893cc51ea04f8a3b73fbaf4376c06ebc5a0ccbe86d460896f805d9417c93ea"
 
 [[package]]
 name = "h2"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
 dependencies = [
  "bytes",
  "fnv",
@@ -2686,9 +2702,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2748,9 +2764,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.51"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2912,7 +2928,7 @@ dependencies = [
  "pmutil",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -3095,9 +3111,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libffi"
@@ -3148,9 +3164,9 @@ checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.25.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0455f2c1bc9a7caa792907026e469c1d91761fb0ea37cbb16427c77280cf35"
+checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3250,9 +3266,9 @@ dependencies = [
 
 [[package]]
 name = "lzzzz"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736263997293f91cffd401b5370e2b06805c9796c0f31b9b478e9734cf4d72bc"
+checksum = "8014d1362004776e6a91e4c15a3aa7830d1b6650a075b51a9969ebb6d6af13bc"
 dependencies = [
  "cc",
 ]
@@ -3348,14 +3364,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3398,9 +3414,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -3592,9 +3608,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opaque-debug"
@@ -3625,7 +3641,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -3636,9 +3652,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.76"
+version = "0.9.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
+checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
 dependencies = [
  "autocfg",
  "cc",
@@ -3649,9 +3665,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
 name = "outref"
@@ -3689,15 +3705,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.11.2"
+name = "parking"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -3706,21 +3717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.4",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3819,7 +3816,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -3905,7 +3902,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -3918,7 +3915,7 @@ dependencies = [
  "phf_shared 0.11.1",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -3956,7 +3953,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -3995,9 +3992,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "pmutil"
@@ -4007,7 +4004,7 @@ checksum = "3894e5d549cccbe44afecf72922f277f603cd4bb0219c8342631ef18fffbe004"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -4072,7 +4069,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
  "version_check",
 ]
 
@@ -4175,7 +4172,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -4299,7 +4296,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -4374,7 +4371,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom 0.2.8",
  "redox_syscall",
  "thiserror",
 ]
@@ -4545,12 +4542,12 @@ dependencies = [
  "futures",
  "integer-encoding",
  "lz4",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "rand 0.8.5",
  "snap",
  "thiserror",
- "time 0.3.15",
+ "time 0.3.16",
  "tokio",
  "tracing",
  "zstd",
@@ -4684,9 +4681,9 @@ dependencies = [
 
 [[package]]
 name = "scoped-tls"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4728,7 +4725,7 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
  "thiserror",
 ]
 
@@ -4795,9 +4792,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
@@ -4813,13 +4810,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -4842,7 +4839,7 @@ checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -4882,7 +4879,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.15",
+ "time 0.3.16",
 ]
 
 [[package]]
@@ -4891,17 +4888,17 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
 dependencies = [
- "darling 0.14.1",
+ "darling 0.14.2",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
+checksum = "6d232d893b10de3eb7258ff01974d6ee20663d8e833263c99409d4b13a0209da"
 dependencies = [
  "indexmap",
  "itoa",
@@ -4941,7 +4938,7 @@ dependencies = [
  "log",
  "nix 0.22.3",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "paste",
  "permutation",
  "petgraph 0.6.2",
@@ -4967,6 +4964,7 @@ dependencies = [
  "tempdir",
  "tempfile",
  "thiserror",
+ "time 0.3.16",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -5061,7 +5059,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.15",
+ "time 0.3.16",
 ]
 
 [[package]]
@@ -5282,7 +5280,7 @@ dependencies = [
  "sha2",
  "sqlx-core",
  "sqlx-rt",
- "syn 1.0.102",
+ "syn 1.0.103",
  "url 2.3.1",
 ]
 
@@ -5310,7 +5308,7 @@ checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
@@ -5338,7 +5336,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "swc_macros_common",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -5399,7 +5397,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -5427,7 +5425,7 @@ dependencies = [
  "heck 0.4.0",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -5578,7 +5576,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "swc_macros_common",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -5678,7 +5676,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "swc_macros_common",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -5849,7 +5847,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "swc_macros_common",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -6063,7 +6061,7 @@ dependencies = [
  "pmutil",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -6075,7 +6073,7 @@ dependencies = [
  "pmutil",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -6109,7 +6107,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "swc_macros_common",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -6123,7 +6121,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "swc_macros_common",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -6139,9 +6137,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -6156,7 +6154,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
  "unicode-xid 0.2.4",
 ]
 
@@ -6258,9 +6256,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
 dependencies = [
  "smawk",
  "unicode-linebreak",
@@ -6284,7 +6282,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -6300,22 +6298,32 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
+checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
 dependencies = [
  "itoa",
  "libc",
  "num_threads",
  "serde",
+ "time-core",
  "time-macros",
 ]
 
 [[package]]
-name = "time-macros"
-version = "0.2.4"
+name = "time-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tinyvec"
@@ -6344,7 +6352,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.4.7",
@@ -6370,7 +6378,7 @@ checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -6510,7 +6518,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "prost-build",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -6566,7 +6574,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -6625,7 +6633,7 @@ dependencies = [
  "ipconfig",
  "lazy_static",
  "lru-cache",
- "parking_lot 0.12.1",
+ "parking_lot",
  "resolv-conf",
  "serde",
  "smallvec",
@@ -6933,7 +6941,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -6942,7 +6950,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom 0.2.8",
  "serde",
 ]
 
@@ -7030,6 +7038,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7089,7 +7103,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -7123,7 +7137,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7178,7 +7192,7 @@ dependencies = [
  "fxhash",
  "log",
  "naga",
- "parking_lot 0.12.1",
+ "parking_lot",
  "profiling",
  "ron",
  "serde",
@@ -7216,7 +7230,7 @@ dependencies = [
  "metal",
  "naga",
  "objc",
- "parking_lot 0.12.1",
+ "parking_lot",
  "profiling",
  "range-alloc",
  "raw-window-handle",
@@ -7453,7 +7467,7 @@ checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.102",
+ "syn 1.0.103",
  "synstructure",
 ]
 

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -12,6 +12,7 @@ export {
 } from "./datastore.ts";
 export type { Id } from "./datastore.ts";
 export type { ChiselEvent } from "./kafka.ts";
+export { publishEvent } from "./kafka.ts";
 export { ChiselRequest, Params, Query } from "./request.ts";
 export { RouteMap } from "./routing.ts";
 export type { Handler, MiddlewareHandler, MiddlewareNext } from "./routing.ts";

--- a/cli/tests/integration_tests/rust_tests/kafka.rs
+++ b/cli/tests/integration_tests/rust_tests/kafka.rs
@@ -152,3 +152,78 @@ pub async fn test_kafka_produce_and_consume(c: TestContext) {
         assert_eq!("hello, value", response["results"][0]["value"]);
     }
 }
+
+#[chisel_macros::test(modules = Node, kafka_topics = 1)]
+pub async fn test_kafka_produce_multiple(c: TestContext) {
+    if let Some(ref _kafka_connection) = c.kafka_connection {
+        let kafka_topic = c.kafka_topic(0);
+        c.chisel.write(
+            "models/hello.ts",
+            r##"
+            import { ChiselEntity } from '@chiselstrike/api';
+            export class Hello extends ChiselEntity {
+                seqNo: number;
+                key: string;
+                value: string;
+            }
+        "##,
+        );
+        c.chisel.write(
+            "routes/hello.ts",
+            r##"
+            import { Hello } from "../models/hello.ts";
+            export default Hello.crud();
+        "##,
+        );
+        c.chisel.write(
+            &format!("events/{}.ts", kafka_topic),
+            r##"
+            import { ChiselEvent } from "@chiselstrike/api";
+            import { Hello } from "../models/hello.ts";
+
+            export default async function (event: ChiselEvent) {
+                const seqNo = await Hello.cursor().count();
+                const key = await event.key.text();
+                const value = await event.value.text();
+                await Hello.create({ seqNo, key, value });
+            }
+        "##,
+        );
+        c.chisel.write(
+            "routes/produce.ts",
+            &format!(
+                r##"
+            import {{ publishEvent }} from "@chiselstrike/api";
+            export default async function(request: Request) {{
+                const json = await request.json();
+                const hello = json.hello;
+                await publishEvent({{ topic: "{}", key: "hello, key", value: hello }});
+            }}
+        "##,
+                kafka_topic
+            ),
+        );
+        c.chisel.apply().await.unwrap();
+        for i in 0..10 {
+            let hello = format!("Hello, {}", i);
+            c.chisel.post_json("/dev/produce", json!({ "hello": hello })).await;
+        }
+        let response = c
+            .chisel
+            .get("/dev/hello")
+            .send_retry(|resp| {
+                resp.json()["results"].as_array().unwrap().len() >= 10
+            }).await
+            .json();
+        let mut results = response["results"].as_array().unwrap().clone();
+        assert_eq!(10, results.len());
+        results.sort_by(|a, b| {
+            a["seqNo"].as_f64().partial_cmp(&b["seqNo"].as_f64()).unwrap()
+        });
+        for (i, result) in results.iter().enumerate() {
+            let hello = format!("Hello, {}", i);
+            assert_eq!("hello, key", result["key"]);
+            assert_eq!(hello, result["value"]);
+        }
+    }
+}

--- a/cli/tests/integration_tests/rust_tests/kafka.rs
+++ b/cli/tests/integration_tests/rust_tests/kafka.rs
@@ -93,3 +93,62 @@ pub async fn test_kafka_consume(c: TestContext) {
         assert_eq!("hello kafka", response["results"][0]["value"]);
     }
 }
+
+#[chisel_macros::test(modules = Node, kafka_topics = 1)]
+pub async fn test_kafka_produce_and_consume(c: TestContext) {
+    if let Some(ref _kafka_connection) = c.kafka_connection {
+        let kafka_topic = c.kafka_topic(0);
+        c.chisel.write(
+            "models/hello.ts",
+            r##"
+            import { ChiselEntity } from '@chiselstrike/api';
+            export class Hello extends ChiselEntity {
+                key: string;
+                value: string;
+            }
+        "##,
+        );
+        c.chisel.write(
+            "routes/hello.ts",
+            r##"
+            import { Hello } from "../models/hello.ts";
+            export default Hello.crud();
+        "##,
+        );
+        c.chisel.write(
+            &format!("events/{}.ts", kafka_topic),
+            r##"
+            import { ChiselEvent } from "@chiselstrike/api";
+            import { Hello } from "../models/hello.ts";
+
+            export default async function (event: ChiselEvent) {
+                const key = await event.key.text();
+                const value = await event.value.text();
+                await Hello.create({ key, value });
+            }
+        "##,
+        );
+        c.chisel.write(
+            "routes/produce.ts",
+            &format!(
+                r##"
+            import {{ publishEvent }} from "@chiselstrike/api";
+            export default async function(_request: Request) {{
+                await publishEvent({{ topic: "{}", key: "hello, key", value: "hello, value" }});
+            }}
+        "##,
+                kafka_topic
+            ),
+        );
+        c.chisel.apply().await.unwrap();
+        c.chisel.post("/dev/produce").send().await.assert_ok();
+        let response = c
+            .chisel
+            .get("/dev/hello")
+            .send_retry(|resp| !resp.json()["results"].as_array().unwrap().is_empty())
+            .await
+            .json();
+        assert_eq!("hello, key", response["results"][0]["key"]);
+        assert_eq!("hello, value", response["results"][0]["value"]);
+    }
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -63,6 +63,7 @@ sqlx = { git = "https://github.com/chiselstrike/sqlx.git", rev = "bcfb6ca404f907
 structopt = "0.3.23"
 structopt-toml = "0.5.1"
 thiserror = "1.0"
+time = "0.3.16"
 tokio = { version = "1.11.0", features = ["net", "rt", "time"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.5.2"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -40,6 +40,7 @@ pub(crate) mod module_loader;
 mod nursery;
 pub mod ops;
 pub(crate) mod opt;
+pub(crate) mod outbox;
 pub(crate) mod policies;
 mod policy;
 pub(crate) mod prefix_map;

--- a/server/src/ops/job.rs
+++ b/server/src/ops/job.rs
@@ -28,6 +28,8 @@ enum AcceptedJob {
         event: KafkaEvent,
         ctx_rid: deno_core::ResourceId,
     },
+    #[serde(rename_all = "camelCase")]
+    Outbox { ctx_rid: deno_core::ResourceId },
 }
 
 #[deno_core::op]
@@ -85,6 +87,16 @@ async fn op_chisel_accept_job(
                 state.resource_table.add(ctx)
             };
             AcceptedJob::Kafka { event, ctx_rid }
+        }
+        Some(VersionJob::Outbox) => {
+            let ctx_rid = {
+                let ctx = JobContext {
+                    job_info: Rc::new(JobInfo::KafkaEvent),
+                    current_data_ctx: None.into(),
+                };
+                state.resource_table.add(ctx)
+            };
+            AcceptedJob::Outbox { ctx_rid }
         }
         None => return Ok(None),
     };

--- a/server/src/ops/kafka.rs
+++ b/server/src/ops/kafka.rs
@@ -1,6 +1,18 @@
 use super::WorkerState;
+use crate::datastore::expr::{BinaryExpr, Expr, PropertyAccess, Value};
+use crate::datastore::query::{Mutation, QueryOp, SortBy, SortKey};
+use crate::datastore::QueryEngine;
+use crate::datastore::{
+    query::QueryPlan,
+    value::{EntityMap, EntityValue},
+};
+use crate::ops::job_context::JobContext;
+use crate::outbox::OUTBOX_NAME;
+use crate::policy::PolicyContext;
+use crate::types::Type;
 use anyhow::Result;
 use deno_core::OpState;
+use futures::StreamExt;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -10,5 +22,96 @@ pub fn op_chisel_subscribe_topic(op_state: Rc<RefCell<OpState>>, topic: String) 
     if let Some(ref service) = server.kafka_service {
         service.subscribe_topic(server.clone(), topic);
     }
+    Ok(())
+}
+
+#[deno_core::op]
+pub async fn op_chisel_publish(op_state: Rc<RefCell<OpState>>) -> Result<()> {
+    let server = op_state.borrow().borrow::<WorkerState>().server.clone();
+    if let Some(ref service) = server.kafka_service {
+        service.publish(server.clone()).await?;
+    }
+    Ok(())
+}
+
+#[deno_core::op]
+pub async fn op_chisel_poll_outbox(
+    state: Rc<RefCell<OpState>>,
+    job_ctx_rid: deno_core::ResourceId,
+) -> Result<()> {
+    let server = state.borrow().borrow::<WorkerState>().server.clone();
+    let kafka_service = match &server.kafka_service {
+        Some(kafka_service) => kafka_service.clone(),
+        _ => {
+            return Ok(());
+        }
+    };
+    let _poll_mutex = kafka_service.outbox_poll_mutex.lock().await;
+    let query_engine = server.query_engine.clone();
+    let (data_ctx_future, outbox_type) = {
+        let state = state.borrow();
+        let ctx = state.resource_table.get::<JobContext>(job_ctx_rid)?;
+        let job_info = ctx.job_info.clone();
+        let worker_state = state.borrow::<WorkerState>();
+        let type_system = worker_state.version.type_system.clone();
+        let policy_system = worker_state.version.policy_system.clone();
+        let policy_engine = worker_state.policy_engine.clone();
+        let policy_context = PolicyContext::new(policy_engine, ctx.job_info.clone());
+        let outbox_type = match type_system.lookup_builtin_type(OUTBOX_NAME)? {
+            Type::Entity(entity) => entity,
+            _ => anyhow::bail!("internal error"),
+        };
+        let data_ctx_future =
+            query_engine.create_data_context(type_system, policy_system, policy_context, job_info);
+        (data_ctx_future, outbox_type)
+    };
+    let data_ctx = data_ctx_future.await?;
+    let ops = vec![QueryOp::SortBy(SortBy {
+        keys: vec![SortKey {
+            field_name: "seqNo".to_string(),
+            ascending: true,
+        }],
+    })];
+    let query_plan = QueryPlan::from_ops(&data_ctx, &outbox_type, ops)?;
+    // NOTE! We collect the query results here because if we have the
+    // QueryResults object alive while calling mutate_with_transaction(),
+    // we deadlock.
+    let rows: Vec<Result<EntityMap>> = query_engine
+        .query(data_ctx.txn.clone(), query_plan)?
+        .collect()
+        .await;
+    for row in rows {
+        let row = row?;
+        let topic = match row.get("topic") {
+            Some(EntityValue::String(val)) => val,
+            _ => anyhow::bail!("internal error"),
+        };
+        let key = match row.get("key") {
+            Some(EntityValue::Bytes(val)) => Some(val.to_vec()),
+            _ => None,
+        };
+        let value = match row.get("value") {
+            Some(EntityValue::Bytes(val)) => Some(val.to_vec()),
+            _ => None,
+        };
+        kafka_service.publish_event(topic, key, value).await?;
+        let left = Expr::from(PropertyAccess {
+            object: Box::new(Expr::Parameter { position: 0 }),
+            property: "id".to_string(),
+        });
+        let id = match row.get("id") {
+            Some(EntityValue::String(val)) => val,
+            _ => anyhow::bail!("internal error"),
+        };
+        let right = Expr::from(Value::from(id.to_string()));
+        let expr = BinaryExpr::eq(left, right);
+        let mutation = Mutation::delete_from_expr(&data_ctx, OUTBOX_NAME, &Some(expr))?;
+        let mut delete_txn = query_engine.begin_transaction().await?;
+        query_engine
+            .mutate_with_transaction(mutation, &mut delete_txn)
+            .await?;
+        QueryEngine::commit_transaction(delete_txn).await?;
+    }
+    QueryEngine::commit_transaction_static(data_ctx.txn).await?;
     Ok(())
 }

--- a/server/src/ops/mod.rs
+++ b/server/src/ops/mod.rs
@@ -39,6 +39,8 @@ pub fn extension() -> deno_core::Extension {
             datastore::op_chisel_query_get_value::decl(),
             job::op_chisel_accept_job::decl(),
             job::op_chisel_http_respond::decl(),
+            kafka::op_chisel_poll_outbox::decl(),
+            kafka::op_chisel_publish::decl(),
             kafka::op_chisel_subscribe_topic::decl(),
             type_system::op_chisel_get_type_system::decl(),
         ])

--- a/server/src/ops/mod.rs
+++ b/server/src/ops/mod.rs
@@ -19,6 +19,7 @@ pub fn extension() -> deno_core::Extension {
             op_chisel_get_secret::decl(),
             op_chisel_get_version_id::decl(),
             op_chisel_get_version_info::decl(),
+            op_chisel_get_worker_idx::decl(),
             op_chisel_is_debug::decl(),
             op_format_file_name::decl(),
             datastore::op_chisel_begin_transaction::decl(),
@@ -83,6 +84,11 @@ fn op_chisel_get_version_id(state: &mut deno_core::OpState) -> String {
 #[deno_core::op]
 fn op_chisel_get_version_info(state: &mut deno_core::OpState) -> VersionInfo {
     state.borrow::<WorkerState>().version.info.clone()
+}
+
+#[deno_core::op]
+fn op_chisel_get_worker_idx(state: &mut deno_core::OpState) -> usize {
+    state.borrow::<WorkerState>().worker_idx
 }
 
 #[deno_core::op]

--- a/server/src/outbox.rs
+++ b/server/src/outbox.rs
@@ -1,0 +1,1 @@
+pub const OUTBOX_NAME: &str = "ChiselOutbox";

--- a/server/src/version.rs
+++ b/server/src/version.rs
@@ -59,6 +59,7 @@ pub struct Version {
 pub enum VersionJob {
     Http(HttpRequestResponse),
     Kafka(KafkaEvent),
+    Outbox,
 }
 
 pub async fn spawn(

--- a/server/src/worker.rs
+++ b/server/src/worker.rs
@@ -48,6 +48,7 @@ pub struct WorkerJoinHandle {
 /// This struct is stored in the `op_state` in the Deno runtime, from where we can obtain it in
 /// Deno ops. Every worker runs on its own thread and runs code for a single version.
 pub struct WorkerState {
+    pub worker_idx: usize,
     pub server: Arc<Server>,
     pub version: Arc<Version>,
 
@@ -167,6 +168,7 @@ async fn run(init: WorkerInit) -> Result<()> {
     }
 
     let worker_state = WorkerState {
+        worker_idx: init.worker_idx,
         server: init.server,
         version: init.version.clone(),
         ready_tx: Some(init.ready_tx),


### PR DESCRIPTION
This pull request implements support for publishing events on a Kafka
topic.

The high-level API looks as follows:

```typescript
import { publishEvent } from "@chiselstrike/api";

await publishEvent({
  topic: "topic",
  key: "hello, key",
  value: "hello, value"
});
```

Internally, the `publishEvent()` function writes to an `Outbox` entity.
As the write participates in the same transaction of the call-site, you
essentially get transactional event publishing. If the transaction rolls
back, the event is never sent out. However, if the transaction commits,
events in the `Outbox` entity are eventually published on a Kafka topic.

The way we implement transactional event publishing is called the
"outbox pattern" and it has one downside: instead of Kafka's
exactly-once semantics, outbox pattern only can guarantee at-least-once
semantics. This means that the application has to be ready to
de-duplicate events for cases where processing the same event more than
once times is a problem. If this becomes a big problem, we can think of
ways to automatically de-duplicate events.