### PR TITLE
Don't visibly log when a canary version is ready

### DIFF
--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -219,6 +219,7 @@ async fn apply(server: Arc<Server>, request: ApplyRequest) -> Result<ApplyRespon
         policy_system: Arc::new(result.policy_system),
         worker_count: server.opt.worker_threads,
         ready_tx,
+        is_canary: false,
     };
 
     let (version, job_tx, mut version_task) = version::spawn(init).await?;
@@ -262,6 +263,7 @@ async fn validate_modules(
         policy_system: Arc::new(policy_system),
         worker_count: 1,
         ready_tx,
+        is_canary: true,
     };
 
     let (_version, _job_tx, mut version_task) = version::spawn(init).await?;

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -203,6 +203,7 @@ async fn start_versions(server: Arc<Server>) -> Result<()> {
             policy_system: Arc::new(policy_system),
             worker_count: server.opt.worker_threads,
             ready_tx,
+            is_canary: false,
         };
 
         let (version, job_tx, version_task) = version::spawn(init).await?;
@@ -240,6 +241,7 @@ async fn start_builtin_version(server: Arc<Server>) -> Result<()> {
         policy_system: Arc::new(policy_system),
         worker_count: 1,
         ready_tx,
+        is_canary: false,
     };
 
     let (version, job_tx, version_task) = version::spawn(init).await?;


### PR DESCRIPTION
Before this change, `chiseld` would print "Version X is ready" two times during each apply, which is confusing. Let's log the first message, from the "canary" version, as debug, so that it's not shown by default.