### PR TITLE
Introduce DataContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4508,7 +4508,6 @@ dependencies = [
  "api",
  "async-lock",
  "base64",
- "chiselc",
  "deno_core",
  "deno_runtime",
  "deno_std",

--- a/api/src/crud.ts
+++ b/api/src/crud.ts
@@ -169,7 +169,7 @@ async function fetchEntitiesCrud<T extends ChiselEntity>(
             urlPath,
             urlQuery,
         },
-        requestContext,
+        requestContext.rid,
     );
     return results as T[];
 }
@@ -184,6 +184,6 @@ async function deleteEntitiesCrud<T extends ChiselEntity>(
             typeName: type.name,
             urlQuery,
         },
-        requestContext,
+        requestContext.rid,
     );
 }

--- a/api/src/datastore.ts
+++ b/api/src/datastore.ts
@@ -43,7 +43,7 @@ abstract class Operator<Input, Output> {
             opAsync(
                 "op_chisel_relational_query_create",
                 this,
-                requestContext,
+                requestContext.rid,
             ) as Promise<number>;
         const recordToOutput = (rawRecord: unknown) => {
             return this.recordToOutput(rawRecord);
@@ -57,6 +57,7 @@ abstract class Operator<Input, Output> {
                         const properties = opSync(
                             "op_chisel_query_get_value",
                             rid,
+                            requestContext.rid,
                         );
 
                         if (properties === null) {
@@ -729,7 +730,7 @@ export class ChiselEntity {
         const jsonIds = await opAsync("op_chisel_store", {
             name: this.constructor.name,
             value: this,
-        }, requestContext) as IdsJson;
+        }, requestContext.rid) as IdsJson;
         function backfillIds(this_: ChiselEntity, jsonIds: IdsJson) {
             this_.id = jsonIds.id;
             for (const [fieldName, value] of Object.entries(jsonIds.children)) {
@@ -898,7 +899,7 @@ export class ChiselEntity {
         await opAsync("op_chisel_delete", {
             typeName: this.name,
             filterExpr: restrictionsToFilterExpr(restrictions),
-        }, requestContext);
+        }, requestContext.rid);
     }
 
     /**
@@ -1062,18 +1063,12 @@ export function unique(_target: unknown, _name: string): void {
 }
 
 export const requestContext: {
-    versionId: string;
+    rid: number | undefined;
     method: string;
-    headers: [string, string][];
-    path: string;
-    routingPath: string;
     userId: string | undefined;
 } = {
-    versionId: opSync("op_chisel_get_version_id") as string,
+    rid: undefined,
     method: "",
-    headers: [],
-    path: "",
-    routingPath: "",
     userId: undefined,
 };
 

--- a/cli/tests/integration_tests/rust_tests/policies_loggedin.rs
+++ b/cli/tests/integration_tests/rust_tests/policies_loggedin.rs
@@ -347,7 +347,8 @@ async fn transform_match_login_related_entities(c: TestContext) {
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
 fn check_cors_header(response: &Response) -> bool {
     let cors_allow_headers = response.header("access-control-allow-headers");
-    let uids_count = cors_allow_headers.split(',')
+    let uids_count = cors_allow_headers
+        .split(',')
         .filter(|v| *v == "ChiselUID")
         .count();
     uids_count == 1

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = { version = "1.0", features = ["backtrace"] }
 api = { path = "../api" }
 async-lock = "2.5.0"
 base64 = "0.13.0"
-chiselc = { path = "../chiselc" }
 deno_core = { path = "../third_party/deno/core" }
 deno_runtime = { path = "../third_party/deno/runtime" }
 deno_std = { path = "../deno_std" }

--- a/server/src/datastore/expr.rs
+++ b/server/src/datastore/expr.rs
@@ -8,13 +8,18 @@ use serde_derive::{Deserialize, Serialize};
 #[serde(tag = "exprType")]
 pub enum Expr {
     /// A value expression.
-    Value { value: Value },
+    Value {
+        value: Value,
+    },
     /// Expression for addressing function parameters of the current expression
-    Parameter { position: usize },
+    Parameter {
+        position: usize,
+    },
     /// Expression for addressing entity property
     Property(PropertyAccess),
     /// A binary expression.
     Binary(BinaryExpr),
+    Not(Box<Self>),
 }
 
 impl From<Value> for Expr {

--- a/server/src/datastore/meta/mod.rs
+++ b/server/src/datastore/meta/mod.rs
@@ -831,7 +831,7 @@ mod tests {
         .await
         .unwrap();
 
-        let query = QueryEngine::new(conn);
+        let qe = QueryEngine::new(conn);
 
         let mut tss = meta
             .load_type_systems(&Arc::new(BuiltinTypes::new()))
@@ -839,7 +839,8 @@ mod tests {
             .unwrap();
         let ts = tss.remove("dev").unwrap();
         let ty = ts.lookup_custom_type("BlogComment").unwrap();
-        let rows = fetch_rows(&query, &ty).await;
+        let txn = qe.begin_transaction_static().await.unwrap();
+        let rows = fetch_rows(&qe, txn, &ty).await;
         assert_eq!(rows.len(), 10);
         Ok(())
     }

--- a/server/src/datastore/mod.rs
+++ b/server/src/datastore/mod.rs
@@ -110,3 +110,136 @@ impl DataContext {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use futures::Future;
+    use once_cell::sync::Lazy;
+    use url::Url;
+
+    use crate::{
+        types::{self, Entity, Field, ObjectType, Type},
+        JsonObject,
+    };
+
+    use super::{crud::QueryParams, *};
+
+    pub const VERSION: &str = "version_1";
+
+    pub fn make_type_system(entities: &[Entity]) -> TypeSystem {
+        let builtin = Arc::new(types::BuiltinTypes::new());
+        let mut ts = TypeSystem::new(builtin, VERSION.into());
+        for ty in entities {
+            ts.add_custom_type(ty.clone()).unwrap();
+        }
+        ts
+    }
+
+    pub fn make_entity(name: &str, fields: Vec<Field>) -> Entity {
+        let desc = types::NewObject::new(name, VERSION);
+        Entity::Custom(Arc::new(ObjectType::new(&desc, fields, vec![]).unwrap()))
+    }
+
+    pub fn make_field(name: &str, ty: Type) -> Field {
+        let desc = types::NewField::new(name, ty, VERSION).unwrap();
+        Field::new(&desc, vec![], None, false, false)
+    }
+
+    pub static PERSON_TY: Lazy<Entity> = Lazy::new(|| {
+        make_entity(
+            "Person",
+            vec![
+                make_field("name", Type::String),
+                make_field("age", Type::Float),
+            ],
+        )
+    });
+
+    pub static COMPANY_TY: Lazy<Entity> = Lazy::new(|| {
+        make_entity(
+            "Company",
+            vec![
+                make_field("name", Type::String),
+                make_field("ceo", PERSON_TY.clone().into()),
+            ],
+        )
+    });
+
+    pub static ENTITIES: Lazy<[Entity; 2]> = Lazy::new(|| [PERSON_TY.clone(), COMPANY_TY.clone()]);
+    pub static TYPE_SYSTEM: Lazy<TypeSystem> = Lazy::new(|| make_type_system(&*ENTITIES));
+
+    impl QueryEngine {
+        /// creates a dummy context with a transaction, executes f, and then attemps to commit the
+        /// transaction.
+        ///
+        /// f takes ownership of the context and return it so we don't have to deal with closure
+        /// returning futures borrowing their environment
+        pub async fn with_dummy_ctx<Fut>(
+            &self,
+            headers: HashMap<String, String>,
+            f: impl FnOnce(DataContext) -> Fut,
+        ) where
+            Fut: Future<Output = DataContext>,
+        {
+            let job_info = Rc::new(JobInfo::HttpRequest {
+                method: "POST".into(),
+                path: "".into(),
+                headers,
+                user_id: None,
+                response_tx: Default::default(),
+            });
+            let ctx = self
+                .create_data_context(
+                    Arc::new(TYPE_SYSTEM.clone()),
+                    Default::default(),
+                    job_info.clone(),
+                )
+                .await
+                .unwrap();
+
+            let ctx = f(ctx).await;
+
+            QueryEngine::commit_transaction_static(ctx.txn)
+                .await
+                .unwrap();
+        }
+
+        pub async fn run_test_query(
+            &self,
+            ctx: &DataContext,
+            entity_name: &str,
+            url: Url,
+        ) -> anyhow::Result<JsonObject> {
+            self.run_query(
+                ctx,
+                QueryParams {
+                    type_name: entity_name.to_owned(),
+                    url_path: url.path().to_owned(),
+                    url_query: url.query_pairs().into_owned().collect(),
+                },
+            )
+            .await
+        }
+
+        pub async fn run_query_vec(
+            &self,
+            ctx: &DataContext,
+            entity_name: &str,
+            url: Url,
+        ) -> Vec<String> {
+            let r = self.run_test_query(ctx, entity_name, url).await.unwrap();
+            collect_names(&r)
+        }
+    }
+
+    pub fn collect_names(r: &JsonObject) -> Vec<String> {
+        r["results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x["name"].as_str().unwrap().to_string())
+            .collect()
+    }
+}

--- a/server/src/ops/job_context.rs
+++ b/server/src/ops/job_context.rs
@@ -2,7 +2,7 @@ use std::cell::{Ref, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use tokio::sync::oneshot::Sender;
+use tokio::sync::oneshot;
 
 use crate::datastore::DataContext;
 use crate::http::HttpResponse;
@@ -13,7 +13,7 @@ pub enum JobInfo {
         path: String,
         headers: HashMap<String, String>,
         user_id: Option<String>,
-        response_tx: Sender<HttpResponse>,
+        response_tx: RefCell<Option<oneshot::Sender<HttpResponse>>>,
     },
     KafkaEvent,
 }
@@ -52,16 +52,6 @@ impl JobContext {
         let ctx = self.current_data_ctx.borrow();
         anyhow::ensure!(ctx.is_some(), "No transaction in the current context");
         Ok(Ref::map(ctx, |ctx| ctx.as_ref().unwrap()))
-    }
-
-    pub fn into_parts(self: Rc<Self>) -> anyhow::Result<(JobInfo, Option<DataContext>)> {
-        let this = Rc::try_unwrap(self)
-            .map_err(|_| anyhow::anyhow!("Cannot take ownership of job context."))?;
-        let info = Rc::try_unwrap(this.job_info)
-            .map_err(|_| anyhow::anyhow!("Cannot take ownership of job context."))?;
-        let ctx = this.current_data_ctx.into_inner();
-
-        Ok((info, ctx))
     }
 }
 

--- a/server/src/ops/job_context.rs
+++ b/server/src/ops/job_context.rs
@@ -1,0 +1,68 @@
+use std::cell::{Ref, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use tokio::sync::oneshot::Sender;
+
+use crate::datastore::DataContext;
+use crate::http::HttpResponse;
+
+pub enum JobInfo {
+    HttpRequest {
+        method: String,
+        path: String,
+        headers: HashMap<String, String>,
+        user_id: Option<String>,
+        response_tx: Sender<HttpResponse>,
+    },
+    KafkaEvent,
+}
+
+impl JobInfo {
+    pub fn path(&self) -> Option<&str> {
+        match self {
+            JobInfo::HttpRequest { ref path, .. } => Some(path),
+            JobInfo::KafkaEvent => None,
+        }
+    }
+
+    pub fn request_headers(&self) -> Option<&HashMap<String, String>> {
+        match self {
+            JobInfo::HttpRequest { ref headers, .. } => Some(headers),
+            JobInfo::KafkaEvent => None,
+        }
+    }
+
+    pub fn user_id(&self) -> Option<&str> {
+        match self {
+            JobInfo::HttpRequest { ref user_id, .. } => user_id.as_deref(),
+            JobInfo::KafkaEvent => None,
+        }
+    }
+}
+
+pub struct JobContext {
+    pub job_info: Rc<JobInfo>,
+    pub current_data_ctx: RefCell<Option<DataContext>>,
+}
+
+impl JobContext {
+    /// Attempts to return a reference to the current data context.
+    pub fn data_context(&self) -> anyhow::Result<Ref<DataContext>> {
+        let ctx = self.current_data_ctx.borrow();
+        anyhow::ensure!(ctx.is_some(), "No transaction in the current context");
+        Ok(Ref::map(ctx, |ctx| ctx.as_ref().unwrap()))
+    }
+
+    pub fn into_parts(self: Rc<Self>) -> anyhow::Result<(JobInfo, Option<DataContext>)> {
+        let this = Rc::try_unwrap(self)
+            .map_err(|_| anyhow::anyhow!("Cannot take ownership of job context."))?;
+        let info = Rc::try_unwrap(this.job_info)
+            .map_err(|_| anyhow::anyhow!("Cannot take ownership of job context."))?;
+        let ctx = this.current_data_ctx.into_inner();
+
+        Ok((info, ctx))
+    }
+}
+
+impl deno_core::Resource for JobContext {}

--- a/server/src/ops/mod.rs
+++ b/server/src/ops/mod.rs
@@ -8,6 +8,7 @@ use deno_core::{serde_v8, v8};
 mod datastore;
 mod env;
 mod job;
+pub mod job_context;
 mod type_system;
 
 pub fn extension() -> deno_core::Extension {

--- a/server/src/policies.rs
+++ b/server/src/policies.rs
@@ -5,7 +5,6 @@ use crate::prefix_map::PrefixMap;
 use crate::types::ObjectType;
 use crate::JsonObject;
 use anyhow::Result;
-use chiselc::parse::ParserContext;
 use hyper::http;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -185,12 +184,12 @@ impl PolicySystem {
     /// For field of type `ty` creates field policies.
     pub fn make_field_policies(
         &self,
-        user_id: &Option<String>,
+        user_id: Option<&str>,
         current_path: &str,
         ty: &ObjectType,
     ) -> FieldPolicies {
         let mut field_policies = FieldPolicies {
-            current_userid: user_id.clone(),
+            current_userid: user_id.map(Into::into),
             ..Default::default()
         };
 
@@ -276,20 +275,4 @@ fn parse_methods(v: Vec<String>) -> Result<Vec<hyper::Method>> {
 pub fn anonymize(_: EntityValue) -> EntityValue {
     // TODO: use type-specific anonymization.
     EntityValue::String("xxxxx".to_owned())
-}
-
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub struct EntityPolicy {
-    policies: chiselc::policies::Policies,
-}
-
-impl EntityPolicy {
-    #[allow(dead_code)]
-    pub fn from_policy_code(code: String) -> Result<Self> {
-        let ctx = ParserContext::new();
-        let module = ctx.parse(code, true)?;
-        let policies = chiselc::policies::Policies::parse(&module);
-        Ok(Self { policies })
-    }
 }

--- a/server/src/types/builtin.rs
+++ b/server/src/types/builtin.rs
@@ -6,7 +6,7 @@ use crate::datastore::QueryEngine;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BuiltinTypes {
     pub types: HashMap<String, Type>,
 }

--- a/server/src/worker.rs
+++ b/server/src/worker.rs
@@ -1,6 +1,5 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
-use crate::datastore::engine::TransactionStatic;
 use crate::module_loader::ModuleLoader;
 use crate::ops;
 use crate::server::Server;
@@ -49,13 +48,6 @@ pub struct WorkerJoinHandle {
 pub struct WorkerState {
     pub server: Arc<Server>,
     pub version: Arc<Version>,
-
-    /// The implicit global transaction for all data operations.
-    ///
-    /// TODO: the existence of this transaction means that the worker can only handle a single
-    /// job at a time. Unfortunately, to get rid of this, we have to significantly rework the
-    /// TypeScript API.
-    pub transaction: Option<TransactionStatic>,
 
     /// Channel for signaling that the worker is ready to handle jobs.
     ///
@@ -165,7 +157,6 @@ async fn run(init: WorkerInit) -> Result<()> {
     let worker_state = WorkerState {
         server: init.server,
         version: init.version.clone(),
-        transaction: None,
         ready_tx: Some(init.ready_tx),
         job_rx: Some(init.job_rx),
         fake_env: HashMap::new(),


### PR DESCRIPTION
this PR introduces new data structures to decouple the runtime from the data layer. Doing so solves some flaws that the current design presented:
- the `DataContext` represents a transactional unit. It is created when a transaction is started by typescript and lives until it is committed or discarded later. It contains all the necessary data for the data layer to operate.
- The `JobContext` is a deno resource that spans the lifetime of a job and contains the data that a job will need to access in its lifetime. This simplifies the management of resources.
- The SQL transaction is not leaked into the runtime anymore, and the concept of the transaction is abstracted away.
- Implicit transactions are not supported anymore. It is always to the consumer of the data layer APIs to provide one, in the form of a data context, and then commit it.
- by grouping together all the resources for a single job, we make a step toward allowing multiple requests to be handled concurrently by a worker.

Not to the reviewer: I reckon this PR is slightly bigger than I would have liked, but 2 weeks of rebasing got the better of me, and I had to squash it. I tried to cut it into more parts, but ultimately that would make a lot of code changes to just revert it in the next PR, and I need to move on to the following PRs in this series.
