### PR TITLE
Fix Date's storage and replace `mergeDeep` with proper reflection-based building

### DIFF
--- a/api/src/crud.ts
+++ b/api/src/crud.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
-import { mergeDeep, opAsync, responseFromJson } from "./utils.ts";
-import { ChiselEntity, requestContext } from "./datastore.ts";
+import { opAsync, responseFromJson } from "./utils.ts";
+import { ChiselEntity, mergeIntoEntity, requestContext } from "./datastore.ts";
 import { ChiselRequest } from "./request.ts";
 import { RouteMap } from "./routing.ts";
 
@@ -120,8 +120,9 @@ export function crud<
                 404,
             );
         }
-        mergeDeep(
-            orig as unknown as Record<string, unknown>,
+        mergeIntoEntity(
+            entity.name,
+            orig as Record<string, unknown>,
             await req.json(),
         );
         await orig.save();

--- a/api/src/utils.ts
+++ b/api/src/utils.ts
@@ -12,41 +12,6 @@ export function opAsync(
     return Deno.core.opAsync(opName, a, b);
 }
 
-/**
- * Acts the same as Object.assign, but performs deep merge instead of a shallow one.
- */
-export function mergeDeep(
-    target: Record<string, unknown>,
-    ...sources: Record<string, unknown>[]
-): Record<string, unknown> {
-    function isObject(item: unknown): boolean {
-        return (item && typeof item === "object" &&
-            !Array.isArray(item)) as boolean;
-    }
-
-    if (!sources.length) {
-        return target;
-    }
-    const source = sources.shift();
-
-    if (isObject(target) && isObject(source)) {
-        for (const key in source) {
-            if (isObject(source[key])) {
-                if (!target[key]) {
-                    Object.assign(target, { [key]: {} });
-                }
-                mergeDeep(
-                    target[key] as Record<string, unknown>,
-                    source[key] as Record<string, unknown>,
-                );
-            } else {
-                Object.assign(target, { [key]: source[key] });
-            }
-        }
-    }
-    return mergeDeep(target, ...sources);
-}
-
 export type JSONValue =
     | string
     | number

--- a/server/src/datastore/engine.rs
+++ b/server/src/datastore/engine.rs
@@ -691,7 +691,8 @@ impl QueryEngine {
             TypeId::String | TypeId::Id | TypeId::Entity { .. } => {
                 SqlValue::String(convert_json_value!(as_str, String))
             }
-            TypeId::Float | TypeId::JsDate => SqlValue::F64(convert_json_value!(as_f64, f64)),
+            TypeId::Float => SqlValue::F64(convert_json_value!(as_f64, f64)),
+            TypeId::JsDate => SqlValue::F64(convert_json_value!(as_date, f64)),
             TypeId::Boolean => SqlValue::Bool(convert_json_value!(as_bool, bool)),
             TypeId::Array(element_type) => {
                 let val = match fields.get(&field.name) {


### PR DESCRIPTION
The fix seems to break the test which means that the `EntityValue::to_v8` method doesn't work as it should.
It looks that when the `v8::Value` of `Date` gets to our function, it's just a plain Object and we can't tell it apart by `is_date` method :(.

The reason why it worked so far is that because of CRUD - JSON we must accept float as well from there.

The fix consists of replacing all `mergeDeep` with `buildEntity` and `mergeIntoEntity` which are datastore functions leveraging the recently introduced `typeSystem` data to reflect over the types that are being built. Note that the functions are more or less just a copy of the `populateEntity` method, that was already there.