### PR TITLE
add .ignore file

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,1 @@
+third_party/


### PR DESCRIPTION
The `.ignore` file is used by tools like `fd` or `ripgrep` to ignore path for search. The `third_party` directory clutters the search with useless results, all while making search a lot longer. This is a QOL improvement.
