### PR TITLE
Typescript policy engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4102,6 +4102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quine-mc_cluskey"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "boa_engine"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ad1e1e9d5af81e5051138a3a17dade32a899ebca3bf007678ea245bb8ef3fcd"
+dependencies = [
+ "bitflags",
+ "boa_gc",
+ "boa_interner",
+ "boa_profiler",
+ "boa_unicode",
+ "chrono",
+ "dyn-clone",
+ "fast-float",
+ "gc",
+ "indexmap",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "once_cell",
+ "rand 0.8.5",
+ "regress",
+ "rustc-hash",
+ "ryu-js",
+ "serde",
+ "serde_json",
+ "tap",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "boa_gc"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca7b8b2de06b105e2515b4ec1906dfd9ce882d8337e8e10484ced8ba9d8cb83f"
+dependencies = [
+ "gc",
+]
+
+[[package]]
+name = "boa_interner"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45609e07dcbc9315bbd10e2a6499da4469b2caddc1374bcc823ac5720d8b9dc5"
+dependencies = [
+ "phf 0.11.1",
+ "rustc-hash",
+ "static_assertions",
+]
+
+[[package]]
+name = "boa_profiler"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16acab52167770e9e6dc5c5fd3029750830ecaf1e8012575816a214846d22b7c"
+
+[[package]]
+name = "boa_unicode"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f7df6584b38b34a6bdb457bff1c96eadb01362d43420e61a89b301a5f3db2c1"
+dependencies = [
+ "unicode-general-category",
+]
+
+[[package]]
 name = "brotli"
 version = "3.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,7 +1454,7 @@ dependencies = [
  "hyper",
  "mime",
  "percent-encoding 2.2.0",
- "phf",
+ "phf 0.10.1",
  "ring",
  "serde",
  "tokio",
@@ -1891,6 +1956,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fast-float"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,6 +2264,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "gc"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3edaac0f5832202ebc99520cb77c932248010c4645d20be1dc62d6579f5b3752"
+dependencies = [
+ "gc_derive",
+]
+
+[[package]]
+name = "gc_derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60df8444f094ff7885631d80e78eb7d88c3c2361a98daaabb06256e4500db941"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.102",
+ "synstructure",
 ]
 
 [[package]]
@@ -3663,9 +3755,19 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.10.0",
+ "phf_shared 0.10.0",
  "proc-macro-hack",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+dependencies = [
+ "phf_macros 0.11.1",
+ "phf_shared 0.11.1",
 ]
 
 [[package]]
@@ -3674,7 +3776,17 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.10.0",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
+dependencies = [
+ "phf_shared 0.11.1",
  "rand 0.8.5",
 ]
 
@@ -3684,9 +3796,22 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
  "proc-macro-hack",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.102",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
+dependencies = [
+ "phf_generator 0.11.1",
+ "phf_shared 0.11.1",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "syn 1.0.102",
@@ -3697,6 +3822,15 @@ name = "phf_shared"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
 dependencies = [
  "siphasher",
 ]
@@ -4115,6 +4249,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
+name = "regress"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a92ff21fe8026ce3f2627faaf43606f0b67b014dbc9ccf027181a804f75d92e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4353,6 +4496,12 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "ryu-js"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
 
 [[package]]
 name = "same-file"
@@ -4610,6 +4759,8 @@ dependencies = [
  "api",
  "async-lock",
  "base64",
+ "boa_engine",
+ "chiselc",
  "deno_core",
  "deno_runtime",
  "deno_std",
@@ -4630,6 +4781,7 @@ dependencies = [
  "nix 0.22.3",
  "once_cell",
  "parking_lot 0.12.1",
+ "paste",
  "permutation",
  "petgraph 0.6.2",
  "pin-project",
@@ -4985,7 +5137,7 @@ dependencies = [
  "new_debug_unreachable",
  "once_cell",
  "parking_lot 0.12.1",
- "phf_shared",
+ "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
 ]
@@ -4996,8 +5148,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
 ]
@@ -5464,7 +5616,7 @@ dependencies = [
  "bitflags",
  "num_cpus",
  "once_cell",
- "phf",
+ "phf 0.10.1",
  "rustc-hash",
  "serde",
  "smallvec",
@@ -5486,7 +5638,7 @@ dependencies = [
  "better_scoped_tls",
  "bitflags",
  "once_cell",
- "phf",
+ "phf 0.10.1",
  "rustc-hash",
  "serde",
  "smallvec",
@@ -5823,6 +5975,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.102",
+ "unicode-xid 0.2.4",
+]
+
+[[package]]
 name = "sys-info"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5831,6 +5995,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempdir"
@@ -6402,6 +6572,12 @@ name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-general-category"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2281c8c1d221438e373249e065ca4989c4c36952c211ff21a0ee91c44a3869e7"
 
 [[package]]
 name = "unicode-id"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4014,6 +4014,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74605f360ce573babfe43964cbe520294dcb081afbf8c108fc6e23036b4da2df"
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand 0.8.5",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
 name = "prost"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4161,6 +4181,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -4324,7 +4353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
- "quick-error",
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -4490,6 +4519,18 @@ name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -4785,6 +4826,7 @@ dependencies = [
  "permutation",
  "petgraph 0.6.2",
  "pin-project",
+ "proptest",
  "prost",
  "rand 0.8.5",
  "regex",
@@ -6837,6 +6879,15 @@ checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/chiselc/src/policies.rs
+++ b/chiselc/src/policies.rs
@@ -84,7 +84,7 @@ impl FromStr for PolicyName {
             "update" => Ok(Self::Update),
             "onRead" => Ok(Self::OnRead),
             "onSave" => Ok(Self::OnSave),
-            "geoLocation" => Ok(Self::GeoLoc),
+            "geoLoc" => Ok(Self::GeoLoc),
             other => bail!("unknown policy `{other}`"),
         }
     }

--- a/chiselc/src/policies.rs
+++ b/chiselc/src/policies.rs
@@ -435,6 +435,14 @@ impl Predicate {
                         let var = Var::Member(v, id.sym.to_string());
                         Self::Var(env.insert(var))
                     }
+                    MemberProp::Computed(comp) => {
+                        let prop = match &*comp.expr {
+                            Expr::Lit(Lit::Str(prop)) => prop,
+                            _ => panic!("unsupported computed property expression."),
+                        };
+                        let var = Var::Member(v, prop.value.to_string());
+                        Self::Var(env.insert(var))
+                    }
                     _ => panic!("invalid member expression"),
                 },
                 _ => panic!("invalid member expression"),

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,6 +14,8 @@ anyhow = { version = "1.0", features = ["backtrace"] }
 api = { path = "../api" }
 async-lock = "2.5.0"
 base64 = "0.13.0"
+boa_engine = "0.16.0"
+chiselc = { path = "../chiselc" }
 deno_core = { path = "../third_party/deno/core" }
 deno_runtime = { path = "../third_party/deno/runtime" }
 deno_std = { path = "../deno_std" }
@@ -33,6 +35,7 @@ log = "0.4.14"
 nix = "0.22.2"
 once_cell = "1.12.0"
 parking_lot = "0.12"
+paste = "1.0.9"
 permutation = "0.4.0"
 petgraph = "0.6.2"
 pin-project = "1"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -70,6 +70,7 @@ utils = { path = "../utils" }
 uuid = { version = "0.8.2", features = ["v4"] }
 
 [dev-dependencies]
+proptest = "1.0.0"
 tempdir = "0.3.7"
 tempfile = "3.2.0"
 

--- a/server/src/datastore/expr.rs
+++ b/server/src/datastore/expr.rs
@@ -1,6 +1,5 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
-use chiselc::policies::LogicOp;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
@@ -142,21 +141,6 @@ pub enum BinaryOp {
     Or,
     Like,
     NotLike,
-}
-
-impl From<LogicOp> for BinaryOp {
-    fn from(op: LogicOp) -> Self {
-        match op {
-            LogicOp::Eq => BinaryOp::Eq,
-            LogicOp::Neq => BinaryOp::NotEq,
-            LogicOp::Gt => BinaryOp::Gt,
-            LogicOp::Gte => BinaryOp::GtEq,
-            LogicOp::Lt => BinaryOp::Lt,
-            LogicOp::Lte => BinaryOp::LtEq,
-            LogicOp::And => BinaryOp::And,
-            LogicOp::Or => BinaryOp::Or,
-        }
-    }
 }
 
 impl BinaryOp {

--- a/server/src/datastore/expr.rs
+++ b/server/src/datastore/expr.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
+use chiselc::policies::LogicOp;
 use serde_derive::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 
 /// An expression.
 #[cfg_attr(test, derive(PartialEq))]
@@ -51,6 +53,23 @@ pub enum Value {
     F64(f64),
     String(String),
     Null,
+}
+
+impl From<&JsonValue> for Value {
+    fn from(json: &JsonValue) -> Self {
+        match json {
+            JsonValue::Null => Value::Null,
+            JsonValue::Bool(b) => Value::Bool(*b),
+            JsonValue::Number(n) if n.is_i64() => Value::I64(n.as_i64().unwrap()),
+            JsonValue::Number(n) if n.is_u64() => Value::U64(n.as_u64().unwrap()),
+            JsonValue::Number(n) if n.is_f64() => Value::F64(n.as_f64().unwrap()),
+            JsonValue::String(s) => Value::String(s.clone()),
+            JsonValue::Array(_) | JsonValue::Object(_) => {
+                unimplemented!("object and arrays not part of the data model.")
+            }
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl From<bool> for Value {
@@ -123,6 +142,21 @@ pub enum BinaryOp {
     Or,
     Like,
     NotLike,
+}
+
+impl From<LogicOp> for BinaryOp {
+    fn from(op: LogicOp) -> Self {
+        match op {
+            LogicOp::Eq => BinaryOp::Eq,
+            LogicOp::Neq => BinaryOp::NotEq,
+            LogicOp::Gt => BinaryOp::Gt,
+            LogicOp::Gte => BinaryOp::GtEq,
+            LogicOp::Lt => BinaryOp::Lt,
+            LogicOp::Lte => BinaryOp::LtEq,
+            LogicOp::And => BinaryOp::And,
+            LogicOp::Or => BinaryOp::Or,
+        }
+    }
 }
 
 impl BinaryOp {

--- a/server/src/datastore/value.rs
+++ b/server/src/datastore/value.rs
@@ -198,6 +198,21 @@ macro_rules! define_is_method {
     };
 }
 
+macro_rules! try_into {
+    ($method_name:ident, $variant:ident, $typ:ty) => {
+        pub fn $method_name(self) -> Result<$typ> {
+            match self {
+                Self::$variant(v) => Ok(v),
+                _ => bail!(
+                    "tried to convert entity value to {}, but it is of type {}",
+                    stringify!($typ),
+                    self.kind_str(),
+                ),
+            }
+        }
+    };
+}
+
 impl EntityValue {
     define_is_method! {is_string, String}
     define_is_method! {is_f64, Float64}
@@ -248,6 +263,13 @@ impl EntityValue {
     as_ref!(as_bytes, Bytes, [u8]);
     as_ref!(as_array, Array, EntityArray);
     as_ref!(as_map, Map, EntityMap);
+
+    try_into!(try_into_str, String, String);
+    try_into!(try_into_f64, Float64, f64);
+    try_into!(try_into_bool, Boolean, bool);
+    try_into!(try_into_date, JsDate, f64);
+    try_into!(try_into_array, Array, EntityArray);
+    try_into!(try_into_map, Map, EntityMap);
 }
 
 fn eq_f64(value: &EntityValue, other: f64) -> bool {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -19,6 +19,7 @@ pub(crate) mod module_loader;
 pub mod ops;
 pub(crate) mod opt;
 pub(crate) mod policies;
+mod policy;
 pub(crate) mod prefix_map;
 pub(crate) mod rpc;
 pub(crate) mod secrets;

--- a/server/src/policy/engine.rs
+++ b/server/src/policy/engine.rs
@@ -286,7 +286,7 @@ mod test {
         }
 
         fn user_id(&self) -> Option<&str> {
-            self.get("user_id")?.as_str().into()
+            self.get("userId")?.as_str().into()
         }
     }
 

--- a/server/src/policy/engine.rs
+++ b/server/src/policy/engine.rs
@@ -1,0 +1,262 @@
+use std::cell::{Ref, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use anyhow::{bail, Result};
+use boa_engine::object::JsMap;
+use boa_engine::prelude::JsObject;
+use boa_engine::{JsString, JsValue};
+use chiselc::parse::ParserContext;
+use chiselc::policies::{Cond, Environment, PolicyName, Predicate, Predicates, Var};
+use serde_json::Value as JsonValue;
+
+use super::interpreter::{self, InterpreterContext, JsonResolver};
+use super::store::PolicyStore;
+use super::type_policy::{GeoLocPolicy, ReadPolicy, TransformPolicy, TypePolicy, WritePolicy};
+use crate::datastore::expr::{BinaryExpr, BinaryOp, Expr, PropertyAccess, Value};
+
+#[derive(Default)]
+pub struct PolicyEngine {
+    pub boa_ctx: Rc<RefCell<boa_engine::Context>>,
+    pub store: RefCell<PolicyStore>,
+}
+
+pub trait ChiselRequestContext {
+    fn method(&self) -> &str;
+    fn path(&self) -> &str;
+    fn headers(&self) -> &HashMap<String, String>;
+    fn user_id(&self) -> Option<&str>;
+
+    // TODO: need to find a way around using json here.
+    fn to_value(&self) -> JsonValue {
+        serde_json::json!({
+            "method": self.method(),
+            "path": self.path(),
+            "headers": self.headers(),
+            "user_id": self.user_id(),
+        })
+    }
+
+    fn to_js_value(&self, ctx: &mut boa_engine::Context) -> JsValue {
+        let map = JsMap::new(ctx);
+
+        map.set(JsString::from("method"), JsString::from(self.method()), ctx)
+            .unwrap();
+        map.set(JsString::from("path"), JsString::from(self.path()), ctx)
+            .unwrap();
+
+        let user_id = match self.user_id() {
+            Some(val) => JsValue::String(JsString::from(val)),
+            None => JsValue::Null,
+        };
+        map.set(JsString::from("user_id"), user_id, ctx).unwrap();
+
+        let headers = JsMap::new(ctx);
+        for (key, val) in self.headers().iter() {
+            headers
+                .set(JsString::new(key), JsString::new(val), ctx)
+                .unwrap();
+        }
+
+        map.set(JsString::from("headers"), JsObject::from(headers), ctx)
+            .unwrap();
+
+        JsValue::Object(JsObject::from(map))
+    }
+}
+
+#[allow(dead_code)]
+impl PolicyEngine {
+    pub fn new(store: PolicyStore) -> Self {
+        Self {
+            boa_ctx: Default::default(),
+            store: store.into(),
+        }
+    }
+
+    pub fn with_store_mut(&self, f: impl FnOnce(&mut PolicyStore)) {
+        let mut store = self.store.borrow_mut();
+        f(&mut store);
+    }
+
+    pub fn get_policy(&self, ty: &str) -> Option<Ref<TypePolicy>> {
+        let store = self.store.borrow();
+        // this is a trick to get an Option<Ref<T>> from a Option<&T>
+        if store.get(ty).is_some() {
+            Some(Ref::map(store, |s| s.get(ty).unwrap()))
+        } else {
+            None
+        }
+    }
+
+    pub fn register_policy_from_code(&self, ty_name: String, code: &[u8]) -> anyhow::Result<()> {
+        let ctx = ParserContext::new();
+        let module = ctx.parse(std::str::from_utf8(code).unwrap().to_owned(), false)?;
+        let policies = chiselc::policies::Policies::parse(&module)?;
+        let mut type_policy = TypePolicy::default();
+        for (name, policy) in policies.iter() {
+            let function = self.compile_function(policy.code())?;
+            match name {
+                PolicyName::Read => {
+                    let policy = policy.as_filter().unwrap();
+                    let policy = ReadPolicy::new(function, policy);
+                    type_policy.read.replace(policy);
+                }
+                PolicyName::Create => {
+                    let policy = WritePolicy::new(function);
+                    type_policy.create.replace(policy);
+                }
+                PolicyName::Update => {
+                    let policy = WritePolicy::new(function);
+                    type_policy.update.replace(policy);
+                }
+                PolicyName::OnRead => {
+                    let policy = TransformPolicy::new(function);
+                    type_policy.on_read.replace(policy);
+                }
+                PolicyName::OnSave => {
+                    let policy = TransformPolicy::new(function);
+                    type_policy.on_write.replace(policy);
+                }
+                PolicyName::GeoLoc => {
+                    let policy = GeoLocPolicy::new(function);
+                    type_policy.geoloc.replace(policy);
+                }
+            }
+        }
+
+        self.store.borrow_mut().insert(ty_name, type_policy);
+
+        Ok(())
+    }
+
+    pub fn eval_read_policy_expr(
+        &self,
+        policy: &ReadPolicy,
+        chisel_ctx: &dyn ChiselRequestContext,
+    ) -> Result<Option<Expr>> {
+        match policy.filter {
+            Some(ref filter) => {
+                let chisel_ctx = chisel_ctx.to_value();
+                let resolver = JsonResolver {
+                    name: &policy.ctx_param_name,
+                    value: &chisel_ctx,
+                };
+
+                let mut context = InterpreterContext {
+                    env: &policy.env,
+                    resolver: &resolver,
+                    boa: &mut self.boa_ctx.borrow_mut(),
+                };
+
+                let predicates = policy
+                    .predicates
+                    .map(|p| interpreter::eval(p, &mut context));
+                let cond = filter.simplify(&predicates);
+                cond_to_expr(&cond, &predicates, &policy.entity_param_name, &policy.env).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn compile_function(&self, code: &[u8]) -> Result<JsObject> {
+        Ok(self
+            .boa_ctx
+            .borrow_mut()
+            .eval(code)
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .clone())
+    }
+
+    pub fn call(&self, function: JsObject, args: &[JsValue]) -> anyhow::Result<JsValue> {
+        function
+            .call(&JsValue::Null, args, &mut self.boa_ctx.borrow_mut())
+            .map_err(boa_err_to_anyhow)
+    }
+}
+
+fn boa_err_to_anyhow(_e: JsValue) -> anyhow::Error {
+    todo!()
+}
+
+fn cond_to_expr(
+    cond: &Cond,
+    preds: &Predicates,
+    entity_param_name: &str,
+    env: &Environment,
+) -> Result<Expr> {
+    let val = match cond {
+        Cond::And(left, right) => {
+            let right = cond_to_expr(right, preds, entity_param_name, env)?;
+            let left = cond_to_expr(left, preds, entity_param_name, env)?;
+            Expr::Binary(BinaryExpr {
+                left: Box::new(left),
+                op: BinaryOp::And,
+                right: Box::new(right),
+            })
+        }
+        Cond::Or(left, right) => {
+            let right = cond_to_expr(right, preds, entity_param_name, env)?;
+            let left = cond_to_expr(left, preds, entity_param_name, env)?;
+            Expr::Binary(BinaryExpr {
+                left: Box::new(left),
+                op: BinaryOp::Or,
+                right: Box::new(right),
+            })
+        }
+        Cond::Not(cond) => Expr::Not(Box::new(cond_to_expr(cond, preds, entity_param_name, env)?)),
+        Cond::Predicate(id) => {
+            let predicate = preds.get(*id);
+            predicate_to_expr(predicate, entity_param_name, env)?
+        }
+        Cond::True => Expr::Value {
+            value: Value::Bool(true),
+        },
+        Cond::False => Expr::Value {
+            value: Value::Bool(false),
+        },
+    };
+
+    Ok(val)
+}
+
+fn predicate_to_expr(pred: &Predicate, entity_param_name: &str, env: &Environment) -> Result<Expr> {
+    let val = match pred {
+        Predicate::Bin { op, lhs, rhs } => {
+            let left = Box::new(predicate_to_expr(lhs, entity_param_name, env)?);
+            let right = Box::new(predicate_to_expr(rhs, entity_param_name, env)?);
+            Expr::Binary(BinaryExpr {
+                op: BinaryOp::from(*op),
+                left,
+                right,
+            })
+        }
+        Predicate::Not(_) => todo!(),
+        Predicate::Lit(val) => Expr::Value {
+            value: Value::from(val),
+        },
+        Predicate::Var(var) => {
+            let var = env.get(*var);
+            match var {
+                Var::Ident(id) => bail!("unknown variable: `{id}`"),
+                Var::Member(obj, prop) => {
+                    let obj = env.get(*obj);
+                    match obj {
+                        Var::Ident(n) if n == entity_param_name => {
+                            let property_chain = Expr::Parameter { position: 0 };
+                            Expr::Property(PropertyAccess {
+                                property: prop.to_string(),
+                                object: Box::new(property_chain),
+                            })
+                        }
+                        other => bail!("unknown variable: `{other:?}`"),
+                    }
+                }
+            }
+        }
+    };
+
+    Ok(val)
+}

--- a/server/src/policy/instances.rs
+++ b/server/src/policy/instances.rs
@@ -21,7 +21,7 @@ pub struct PolicyEvalInstance {
     create: Option<WritePolicyInstance>,
     update: Option<WritePolicyInstance>,
     on_read: Option<TransformPolicyInstance>,
-    on_write: Option<TransformPolicyInstance>,
+    on_save: Option<TransformPolicyInstance>,
     geoloc: Option<GeoLocPolicyInstance>,
     /// Set of object marked dirty by this instance.
     dirty: HashSet<String>,
@@ -65,7 +65,7 @@ impl PolicyEvalInstance {
             create: None,
             update: None,
             on_read: None,
-            on_write: None,
+            on_save: None,
             geoloc: None,
             chisel_ctx,
         }
@@ -143,7 +143,7 @@ impl PolicyEvalInstance {
     /// This mutates value! therefore value should be set as mutable.
     pub fn transform_on_write(&mut self, ctx: &PolicyContext, val: &JsValue) -> Result<()> {
         let chisel_ctx = self.chisel_ctx.clone();
-        self.get_or_load_on_write_policy_instance(ctx)?
+        self.get_or_load_on_save_policy_instance(ctx)?
             .map(|p| p.transform(ctx, val, &chisel_ctx))
             .transpose()?;
 
@@ -161,7 +161,7 @@ impl PolicyEvalInstance {
     create_get_or_load_instance!(create, WritePolicyInstance);
     create_get_or_load_instance!(update, WritePolicyInstance);
     create_get_or_load_instance!(on_read, TransformPolicyInstance);
-    create_get_or_load_instance!(on_write, TransformPolicyInstance);
+    create_get_or_load_instance!(on_save, TransformPolicyInstance);
     create_get_or_load_instance!(geoloc, GeoLocPolicyInstance);
 }
 

--- a/server/src/policy/instances.rs
+++ b/server/src/policy/instances.rs
@@ -1,0 +1,286 @@
+#![allow(dead_code)]
+use std::collections::HashSet;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use anyhow::Result;
+use boa_engine::prelude::JsObject;
+use boa_engine::JsValue;
+use paste::paste;
+
+use crate::datastore::expr::Expr;
+use crate::types::ObjectType;
+
+use super::type_policy::{GeoLocPolicy, ReadPolicy, TransformPolicy, WritePolicy};
+use super::{Action, Location, PolicyContext};
+
+/// The PolicyEvalInstance contains instances of policy and cache valid for a type in a given
+/// context.
+pub struct PolicyEvalInstance {
+    read: Option<ReadPolicyInstance>,
+    create: Option<WritePolicyInstance>,
+    update: Option<WritePolicyInstance>,
+    on_read: Option<TransformPolicyInstance>,
+    on_write: Option<TransformPolicyInstance>,
+    geoloc: Option<GeoLocPolicyInstance>,
+    /// Set of object marked dirty by this instance.
+    dirty: HashSet<String>,
+    ty: Arc<ObjectType>,
+    chisel_ctx: JsValue,
+}
+
+/// generate a function that gets the action for the given policy
+macro_rules! create_get_or_load_instance {
+    ($policy:ident, $instance_ty:ty) => {
+        paste! {
+            pub fn [<get_or_load_ $policy _policy_instance>](&mut self, ctx: &PolicyContext) -> Result<Option<&mut $instance_ty>> {
+                if let Some(ref mut instance) = self.$policy {
+                    return Ok(Some(instance));
+                }
+
+                match ctx.engine.store.borrow().get(self.ty.name()) {
+                    Some(crate::policy::type_policy::TypePolicy {
+                        $policy: Some(policy),
+                        ..
+                    }) => {
+                        let instance = $instance_ty::new(ctx, policy)?;
+                        self.$policy.replace(instance);
+                        Ok(self.$policy.as_mut())
+                    }
+                        _ => Ok(None),
+                }
+            }
+        }
+    };
+}
+
+impl PolicyEvalInstance {
+    pub fn new(ctx: &PolicyContext, ty: Arc<ObjectType>) -> Self {
+        let mut boa_ctx = ctx.engine.boa_ctx.borrow_mut();
+        let chisel_ctx = ctx.request.to_js_value(&mut boa_ctx);
+        Self {
+            dirty: Default::default(),
+            ty,
+            read: None,
+            create: None,
+            update: None,
+            on_read: None,
+            on_write: None,
+            geoloc: None,
+            chisel_ctx,
+        }
+    }
+
+    pub fn mark_dirty(&mut self, id: &str) {
+        self.dirty.insert(id.to_owned());
+    }
+
+    pub fn is_dirty(&mut self, id: &str) -> bool {
+        self.dirty.contains(id)
+    }
+
+    pub fn make_read_filter_expr(&mut self, ctx: &PolicyContext) -> Result<Option<&Expr>> {
+        Ok(self
+            .get_or_load_read_policy_instance(ctx)?
+            .and_then(|p| p.get_fitler_expr()))
+    }
+
+    pub fn get_read_action(
+        &mut self,
+        ctx: &PolicyContext,
+        val: &JsValue,
+    ) -> Result<Option<Action>> {
+        let chisel_ctx = self.chisel_ctx.clone();
+        self.get_or_load_read_policy_instance(ctx)?
+            .map(|p| p.get_action(ctx, val, &chisel_ctx))
+            .transpose()
+    }
+
+    pub fn get_create_action(
+        &mut self,
+        ctx: &PolicyContext,
+        val: &JsValue,
+    ) -> Result<Option<Action>> {
+        let chisel_ctx = self.chisel_ctx.clone();
+        match self.get_read_action(ctx, &val)? {
+            Some(action) if action.is_restrictive() => Ok(Some(action)),
+            _ => self
+                .get_or_load_create_policy_instance(ctx)?
+                .map(|p| p.get_action(ctx, val, &chisel_ctx))
+                .transpose(),
+        }
+    }
+
+    pub fn get_update_action(
+        &mut self,
+        ctx: &PolicyContext,
+        val: &JsValue,
+    ) -> Result<Option<Action>> {
+        let chisel_ctx = self.chisel_ctx.clone();
+        match self.get_read_action(ctx, &val)? {
+            Some(action) if action.is_restrictive() => Ok(Some(action)),
+            _ => self
+                .get_or_load_update_policy_instance(ctx)?
+                .map(|p| p.get_action(ctx, val, &chisel_ctx))
+                .transpose(),
+        }
+    }
+
+    /// Applies the onRead transform to value.
+    ///
+    /// This mutates value! therefore value should be set as mutable.
+    pub fn transform_on_read(&mut self, ctx: &PolicyContext, val: &JsValue) -> Result<()> {
+        let chisel_ctx = self.chisel_ctx.clone();
+        self.get_or_load_on_read_policy_instance(ctx)?
+            .map(|p| p.transform(ctx, val, &chisel_ctx))
+            .transpose()?;
+
+        Ok(())
+    }
+
+    /// Applies the onRead transform to value.
+    ///
+    /// This mutates value! therefore value should be set as mutable.
+    pub fn transform_on_write(&mut self, ctx: &PolicyContext, val: &JsValue) -> Result<()> {
+        let chisel_ctx = self.chisel_ctx.clone();
+        self.get_or_load_on_write_policy_instance(ctx)?
+            .map(|p| p.transform(ctx, val, &chisel_ctx))
+            .transpose()?;
+
+        Ok(())
+    }
+
+    pub fn geo_loc(&mut self, ctx: &PolicyContext, val: &JsValue) -> Result<Option<Location>> {
+        let chisel_ctx = self.chisel_ctx.clone();
+        self.get_or_load_geoloc_policy_instance(ctx)?
+            .map(|p| p.geo_loc(ctx, val, &chisel_ctx))
+            .transpose()
+    }
+
+    create_get_or_load_instance!(read, ReadPolicyInstance);
+    create_get_or_load_instance!(create, WritePolicyInstance);
+    create_get_or_load_instance!(update, WritePolicyInstance);
+    create_get_or_load_instance!(on_read, TransformPolicyInstance);
+    create_get_or_load_instance!(on_write, TransformPolicyInstance);
+    create_get_or_load_instance!(geoloc, GeoLocPolicyInstance);
+}
+
+/// Trait implemented by types that have a filter funtion that return an action.
+pub trait Filter {
+    fn filter_function(&self) -> JsObject;
+
+    fn get_action(
+        &self,
+        ctx: &PolicyContext,
+        value: &JsValue,
+        chisel_ctx: &JsValue,
+    ) -> Result<Action> {
+        let result = ctx
+            .engine
+            .call(self.filter_function(), &[value.clone(), chisel_ctx.clone()])?;
+        match result {
+            JsValue::Integer(action) => action.try_into(),
+            val => anyhow::bail!("invalid action: {val:?}"),
+        }
+    }
+}
+
+pub struct ReadPolicyInstance {
+    function: JsObject,
+    expr: Option<Expr>,
+}
+
+impl Filter for ReadPolicyInstance {
+    fn filter_function(&self) -> JsObject {
+        self.function.clone()
+    }
+}
+
+impl ReadPolicyInstance {
+    pub fn new(ctx: &PolicyContext, policy: &ReadPolicy) -> Result<Self> {
+        let expr = ctx.engine.eval_read_policy_expr(policy, &*ctx.request)?;
+        Ok(Self {
+            function: policy.function.clone(),
+            expr,
+        })
+    }
+
+    /// Returns the filter Expr for that Filter.
+    pub fn get_fitler_expr(&self) -> Option<&Expr> {
+        self.expr.as_ref()
+    }
+}
+
+pub struct WritePolicyInstance {
+    function: JsObject,
+}
+
+impl WritePolicyInstance {
+    // ctx is just here to help with codegen
+    pub fn new(_ctx: &PolicyContext, policy: &WritePolicy) -> Result<Self> {
+        Ok(Self {
+            function: policy.function.clone(),
+        })
+    }
+}
+
+impl Filter for WritePolicyInstance {
+    fn filter_function(&self) -> JsObject {
+        self.function.clone()
+    }
+}
+
+pub struct TransformPolicyInstance {
+    // object containing the transform js function
+    function: JsObject,
+}
+
+impl TransformPolicyInstance {
+    /// applies the transform to value.
+    pub fn transform(
+        &self,
+        ctx: &PolicyContext,
+        value: &JsValue,
+        chisel_ctx: &JsValue,
+    ) -> Result<()> {
+        ctx.engine
+            .call(self.function.clone(), &[value.clone(), chisel_ctx.clone()])?;
+
+        Ok(())
+    }
+
+    pub fn new(_ctx: &PolicyContext, p: &TransformPolicy) -> Result<Self> {
+        Ok(Self {
+            function: p.function.clone(),
+        })
+    }
+}
+
+pub struct GeoLocPolicyInstance {
+    // object containing the transform js function
+    function: JsObject,
+}
+
+impl GeoLocPolicyInstance {
+    pub fn new(_ctx: &PolicyContext, p: &GeoLocPolicy) -> Result<Self> {
+        Ok(Self {
+            function: p.function.clone(),
+        })
+    }
+
+    pub fn geo_loc(
+        &mut self,
+        ctx: &PolicyContext,
+        value: &JsValue,
+        chisel_ctx: &JsValue,
+    ) -> Result<Location> {
+        let result = ctx
+            .engine
+            .call(self.function.clone(), &[value.clone(), chisel_ctx.clone()])?;
+
+        match result {
+            JsValue::String(ref s) => Location::from_str(&s),
+            _ => anyhow::bail!("Expected geolocation to return a string."),
+        }
+    }
+}

--- a/server/src/policy/instances.rs
+++ b/server/src/policy/instances.rs
@@ -102,7 +102,7 @@ impl PolicyEvalInstance {
         val: &JsValue,
     ) -> Result<Option<Action>> {
         let chisel_ctx = self.chisel_ctx.clone();
-        match self.get_read_action(ctx, &val)? {
+        match self.get_read_action(ctx, val)? {
             Some(action) if action.is_restrictive() => Ok(Some(action)),
             _ => self
                 .get_or_load_create_policy_instance(ctx)?
@@ -117,7 +117,7 @@ impl PolicyEvalInstance {
         val: &JsValue,
     ) -> Result<Option<Action>> {
         let chisel_ctx = self.chisel_ctx.clone();
-        match self.get_read_action(ctx, &val)? {
+        match self.get_read_action(ctx, val)? {
             Some(action) if action.is_restrictive() => Ok(Some(action)),
             _ => self
                 .get_or_load_update_policy_instance(ctx)?
@@ -279,7 +279,7 @@ impl GeoLocPolicyInstance {
             .call(self.function.clone(), &[value.clone(), chisel_ctx.clone()])?;
 
         match result {
-            JsValue::String(ref s) => Location::from_str(&s),
+            JsValue::String(ref s) => Location::from_str(s),
             _ => anyhow::bail!("Expected geolocation to return a string."),
         }
     }

--- a/server/src/policy/instances.rs
+++ b/server/src/policy/instances.rs
@@ -321,17 +321,17 @@ mod test {
         let req_js = policy_ctx
             .request
             .to_js_value(&mut policy_ctx.engine.boa_ctx.borrow_mut());
-        let function = compile(&policy_ctx, code);
+        let function = compile(policy_ctx, code);
         let filter = WritePolicyInstance { function };
 
-        filter.get_action(&policy_ctx, value, &req_js).unwrap()
+        filter.get_action(policy_ctx, value, &req_js).unwrap()
     }
 
     fn transform(policy_ctx: &PolicyContext, code: &[u8], value: &JsValue) {
         let req_js = policy_ctx
             .request
             .to_js_value(&mut policy_ctx.engine.boa_ctx.borrow_mut());
-        let function = compile(&policy_ctx, code);
+        let function = compile(policy_ctx, code);
         let filter = TransformPolicyInstance { function };
 
         filter.transform(policy_ctx, value, &req_js).unwrap()

--- a/server/src/policy/interpreter.rs
+++ b/server/src/policy/interpreter.rs
@@ -1,0 +1,107 @@
+use boa_engine::JsValue;
+use chiselc::policies::{Environment, LogicOp, Predicate, Var, VarId};
+use serde_json::Value as JsonValue;
+
+use super::utils::json_to_js_value;
+
+pub trait VarResolver {
+    fn resolve(&self, env: &Environment, var: &Var) -> Option<JsonValue>;
+}
+
+#[derive(Debug)]
+pub struct JsonResolver<'a> {
+    pub name: &'a str,
+    pub value: &'a JsonValue,
+}
+
+// TODO: this could be better: we don't *really* need to convert to JSON first...
+impl JsonResolver<'_> {
+    fn get_value(&self, env: &Environment, var: &Var) -> Option<&JsonValue> {
+        match var {
+            Var::Ident(ref s) if self.name == s => Some(self.value),
+            Var::Member(obj, prop) => {
+                let obj = env.get(*obj);
+                let value = self.get_value(env, obj)?;
+                value.get(prop)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl VarResolver for JsonResolver<'_> {
+    fn resolve(&self, env: &Environment, var: &Var) -> Option<JsonValue> {
+        self.get_value(env, var).cloned()
+    }
+}
+
+pub struct InterpreterContext<'a> {
+    pub env: &'a Environment,
+    pub resolver: &'a dyn VarResolver,
+    pub boa: &'a mut boa_engine::Context,
+}
+
+impl InterpreterContext<'_> {
+    fn var_to_value(&self, id: VarId) -> Option<JsonValue> {
+        let var = self.env.get(id);
+        self.resolver.resolve(self.env, var)
+    }
+}
+
+pub fn eval(predicate: &Predicate, ctx: &mut InterpreterContext) -> Predicate {
+    match predicate {
+        Predicate::Bin { op, lhs, rhs } => {
+            let lhs = eval(lhs, ctx);
+            let rhs = eval(rhs, ctx);
+            let lhs_val = maybe_js_value(ctx.boa, &lhs);
+            let rhs_val = maybe_js_value(ctx.boa, &rhs);
+            match lhs_val.zip(rhs_val) {
+                Some((lhs, rhs)) => eval_bin_lit(ctx.boa, *op, &lhs, &rhs),
+                None => Predicate::Bin {
+                    op: *op,
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
+                },
+            }
+        }
+        Predicate::Not(p) => {
+            let p_eval = eval(p, ctx);
+            match maybe_js_value(ctx.boa, &p_eval) {
+                Some(value) => Predicate::Lit(JsonValue::Bool(value.not(ctx.boa).unwrap())),
+                None => Predicate::Not(Box::new(p_eval)),
+            }
+        }
+        Predicate::Var(i) => match ctx.var_to_value(*i) {
+            Some(value) => Predicate::Lit(value),
+            None => predicate.clone(),
+        },
+        _ => predicate.clone(),
+    }
+}
+
+fn eval_bin_lit(
+    boa: &mut boa_engine::Context,
+    op: LogicOp,
+    lhs: &JsValue,
+    rhs: &JsValue,
+) -> Predicate {
+    let value = match op {
+        LogicOp::Eq => JsonValue::Bool(lhs.equals(rhs, boa).unwrap()),
+        LogicOp::Neq => JsonValue::Bool(!lhs.equals(rhs, boa).unwrap()),
+        LogicOp::Gt => JsonValue::Bool(lhs.gt(rhs, boa).unwrap()),
+        LogicOp::Gte => JsonValue::Bool(lhs.ge(rhs, boa).unwrap()),
+        LogicOp::Lt => JsonValue::Bool(lhs.lt(rhs, boa).unwrap()),
+        LogicOp::Lte => JsonValue::Bool(lhs.le(rhs, boa).unwrap()),
+        LogicOp::And => JsonValue::Bool(lhs.as_boolean().unwrap() && rhs.as_boolean().unwrap()),
+        LogicOp::Or => JsonValue::Bool(lhs.as_boolean().unwrap() || rhs.as_boolean().unwrap()),
+    };
+
+    Predicate::Lit(value)
+}
+
+pub fn maybe_js_value(boa: &mut boa_engine::Context, predicate: &Predicate) -> Option<JsValue> {
+    match predicate {
+        Predicate::Lit(val) => Some(json_to_js_value(boa, val)),
+        _ => None,
+    }
+}

--- a/server/src/policy/mod.rs
+++ b/server/src/policy/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Result};
 use std::str::FromStr;
+pub mod engine;
 mod instances;
 mod interpreter;
 pub mod type_policy;

--- a/server/src/policy/mod.rs
+++ b/server/src/policy/mod.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Result};
 use std::str::FromStr;
 mod instances;
+mod interpreter;
 pub mod type_policy;
 
 mod utils;

--- a/server/src/policy/mod.rs
+++ b/server/src/policy/mod.rs
@@ -4,7 +4,6 @@ pub mod engine;
 mod instances;
 mod interpreter;
 pub mod type_policy;
-
 mod utils;
 #[derive(Debug)]
 #[repr(u8)]

--- a/server/src/policy/mod.rs
+++ b/server/src/policy/mod.rs
@@ -1,0 +1,1 @@
+pub mod type_policy;

--- a/server/src/policy/mod.rs
+++ b/server/src/policy/mod.rs
@@ -6,11 +6,13 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::{bail, Result};
+use boa_engine::prelude::JsObject;
+use boa_engine::JsValue;
 
 use crate::datastore::value::{EntityMap, EntityValue};
 use crate::types::ObjectType;
 
-use self::engine::{ChiselRequestContext, PolicyEngine};
+use self::engine::{boa_err_to_anyhow, ChiselRequestContext, PolicyEngine};
 use self::instances::PolicyEvalInstance;
 use self::utils::{entity_map_to_js_value, js_value_to_entity_value};
 

--- a/server/src/policy/mod.rs
+++ b/server/src/policy/mod.rs
@@ -48,13 +48,30 @@ pub enum PolicyError {
     DirtyEntity(Arc<ObjectType>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[repr(u8)]
 pub enum Action {
     Allow = 0,
     Deny = 1,
     Skip = 2,
     Log = 3,
+}
+
+impl Action {
+    fn js_value(ctx: &mut boa_engine::Context) -> Result<JsValue> {
+        let map = JsObject::empty();
+
+        map.set("Allow", 0, false, ctx)
+            .map_err(|e| boa_err_to_anyhow(e, ctx))?;
+        map.set("Deny", 1, false, ctx)
+            .map_err(|e| boa_err_to_anyhow(e, ctx))?;
+        map.set("Skip", 2, false, ctx)
+            .map_err(|e| boa_err_to_anyhow(e, ctx))?;
+        map.set("Log", 3, false, ctx)
+            .map_err(|e| boa_err_to_anyhow(e, ctx))?;
+
+        Ok(JsValue::from(map))
+    }
 }
 
 impl TryFrom<i32> for Action {

--- a/server/src/policy/mod.rs
+++ b/server/src/policy/mod.rs
@@ -50,7 +50,7 @@ pub enum PolicyError {
     DirtyEntity(Arc<ObjectType>),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Action {
     /// Allow, and perform the action
     Allow = 0,

--- a/server/src/policy/mod.rs
+++ b/server/src/policy/mod.rs
@@ -1,1 +1,59 @@
+use anyhow::{bail, Result};
+use std::str::FromStr;
+mod instances;
 pub mod type_policy;
+
+mod utils;
+#[derive(Debug)]
+#[repr(u8)]
+pub enum Action {
+    Allow = 0,
+    Deny = 1,
+    Skip = 2,
+    Log = 3,
+}
+
+impl TryFrom<i32> for Action {
+    type Error = anyhow::Error;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Allow),
+            1 => Ok(Self::Deny),
+            2 => Ok(Self::Skip),
+            3 => Ok(Self::Log),
+            _ => bail!("invalid Action"),
+        }
+    }
+}
+
+impl Action {
+    pub fn is_restrictive(&self) -> bool {
+        match self {
+            Action::Deny | Action::Skip => true,
+            Action::Allow | Action::Log => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Location {
+    UsEast1,
+    UsWest,
+    London,
+    Germany,
+}
+
+impl FromStr for Location {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self, Self::Err> {
+        match s {
+            "us-east-1" => Ok(Self::UsEast1),
+            "us-west" => Ok(Self::UsWest),
+            "london" => Ok(Self::London),
+            "germany" => Ok(Self::Germany),
+            other => bail!("unknown region {other}"),
+        }
+    }
+}

--- a/server/src/policy/mod.rs
+++ b/server/src/policy/mod.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 pub mod engine;
 mod instances;
 mod interpreter;
+pub mod store;
 pub mod type_policy;
 mod utils;
 #[derive(Debug)]

--- a/server/src/policy/store.rs
+++ b/server/src/policy/store.rs
@@ -1,0 +1,22 @@
+use std::collections::HashMap;
+
+use super::type_policy::TypePolicy;
+
+#[derive(Debug, Default, Clone)]
+pub struct PolicyStore {
+    policies: HashMap<String, TypePolicy>,
+}
+
+impl PolicyStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get(&self, ty_name: &str) -> Option<&TypePolicy> {
+        self.policies.get(ty_name)
+    }
+
+    pub fn insert(&mut self, ty_name: String, policy: TypePolicy) {
+        self.policies.insert(ty_name, policy);
+    }
+}

--- a/server/src/policy/type_policy.rs
+++ b/server/src/policy/type_policy.rs
@@ -1,0 +1,72 @@
+use std::sync::Arc;
+
+use boa_engine::prelude::JsObject;
+use chiselc::policies::{Cond, Environment, FilterPolicy, Predicates};
+
+#[derive(Debug, Clone)]
+pub struct ReadPolicy {
+    pub filter: Option<Cond>,
+    pub predicates: Predicates,
+    pub env: Arc<Environment>,
+    pub ctx_param_name: String,
+    pub entity_param_name: String,
+    pub function: JsObject,
+}
+
+impl ReadPolicy {
+    pub fn new(function: JsObject, policy: &FilterPolicy) -> Self {
+        let entity_param_name = policy.params().get_positional_param_name(0).to_owned();
+        let ctx_param_name = policy.params().get_positional_param_name(1).to_owned();
+        Self {
+            predicates: policy.predicates.clone(),
+            filter: policy.where_conds.clone(),
+            env: policy.env.clone(),
+            ctx_param_name,
+            entity_param_name,
+            function,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WritePolicy {
+    pub function: JsObject,
+}
+
+impl WritePolicy {
+    pub fn new(function: JsObject) -> Self {
+        Self { function }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GeoLocPolicy {
+    pub function: JsObject,
+}
+
+impl GeoLocPolicy {
+    pub fn new(function: JsObject) -> Self {
+        Self { function }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TransformPolicy {
+    pub function: JsObject,
+}
+
+impl TransformPolicy {
+    pub fn new(function: JsObject) -> Self {
+        Self { function }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TypePolicy {
+    pub read: Option<ReadPolicy>,
+    pub create: Option<WritePolicy>,
+    pub update: Option<WritePolicy>,
+    pub geoloc: Option<GeoLocPolicy>,
+    pub on_read: Option<TransformPolicy>,
+    pub on_write: Option<TransformPolicy>,
+}

--- a/server/src/policy/type_policy.rs
+++ b/server/src/policy/type_policy.rs
@@ -68,5 +68,5 @@ pub struct TypePolicy {
     pub update: Option<WritePolicy>,
     pub geoloc: Option<GeoLocPolicy>,
     pub on_read: Option<TransformPolicy>,
-    pub on_write: Option<TransformPolicy>,
+    pub on_save: Option<TransformPolicy>,
 }

--- a/server/src/policy/utils.rs
+++ b/server/src/policy/utils.rs
@@ -1,0 +1,153 @@
+use std::collections::HashMap;
+
+use boa_engine::object::{JsArray, JsMap};
+use boa_engine::prelude::JsObject;
+use boa_engine::{JsString, JsValue};
+use itertools::Itertools;
+use serde_json::{Map, Value as JsonValue};
+
+use crate::datastore::value::{EntityMap, EntityValue};
+
+pub fn json_map_to_js_value(
+    ctx: &mut boa_engine::Context,
+    map: &Map<String, JsonValue>,
+) -> JsValue {
+    let obj = JsMap::new(ctx);
+    for (k, v) in map.iter() {
+        obj.set(JsString::from(k.as_str()), json_to_js_value(ctx, v), ctx)
+            .unwrap();
+    }
+
+    JsValue::Object(JsObject::from(obj))
+}
+
+pub fn json_to_js_value(ctx: &mut boa_engine::Context, json: &JsonValue) -> JsValue {
+    match json {
+        JsonValue::Null => JsValue::Null,
+        JsonValue::Bool(b) => JsValue::Boolean(*b),
+        JsonValue::Number(n) if n.is_u64() => JsValue::Integer(n.as_u64().unwrap() as i32),
+        JsonValue::Number(n) if n.is_i64() => JsValue::Integer(n.as_i64().unwrap() as i32),
+        JsonValue::Number(n) if n.is_f64() => JsValue::Rational(n.as_f64().unwrap() as f64),
+        JsonValue::String(s) => JsValue::String(JsString::new(s)),
+        JsonValue::Array(arr) => {
+            let obj = JsArray::new(ctx);
+            for val in arr.iter() {
+                let val = json_to_js_value(ctx, val);
+                obj.push(val, ctx).unwrap();
+            }
+
+            JsValue::Object(JsObject::from(obj))
+        }
+        JsonValue::Object(ref map) => json_map_to_js_value(ctx, map),
+        _ => unreachable!(),
+    }
+}
+
+pub fn entity_value_to_js_value(
+    ctx: &mut boa_engine::Context,
+    val: &EntityValue,
+    writable: bool,
+) -> JsValue {
+    match val {
+        EntityValue::Null => JsValue::Null,
+        EntityValue::String(s) => JsValue::String(JsString::new(s)),
+        EntityValue::Float64(f) => JsValue::Rational(*f),
+        EntityValue::Boolean(b) => JsValue::Boolean(*b),
+        // TODO: v8 and boa handle date quite differently, need to think how to handle those.
+        EntityValue::JsDate(_) => todo!("dates not yet handled"),
+        EntityValue::Array(arr) => {
+            let obj = JsArray::new(ctx);
+            for val in arr.iter() {
+                obj.push(entity_value_to_js_value(ctx, val, writable), ctx)
+                    .unwrap();
+            }
+
+            JsValue::Object(JsObject::from(obj))
+        }
+        EntityValue::Map(map) => entity_map_to_js_value(ctx, map, writable),
+    }
+}
+
+pub fn entity_map_to_js_value(
+    ctx: &mut boa_engine::Context,
+    map: &EntityMap,
+    writable: bool,
+) -> JsValue {
+    let object = JsMap::new(ctx);
+
+    for (prop, value) in map.iter() {
+        object
+            .set(
+                JsString::new(prop),
+                entity_value_to_js_value(ctx, value, writable),
+                ctx,
+            )
+            .unwrap();
+    }
+
+    JsValue::Object(JsObject::from(object))
+}
+
+pub fn js_value_to_entity_value(val: &JsValue) -> EntityValue {
+    match val {
+        JsValue::Null => EntityValue::Null,
+        JsValue::Undefined => EntityValue::Null,
+        JsValue::Boolean(b) => EntityValue::Boolean(*b),
+        JsValue::String(ref s) => EntityValue::String(s.to_string()),
+        JsValue::Rational(f) => EntityValue::Float64(*f),
+        JsValue::Integer(n) => EntityValue::Float64(*n as _),
+        JsValue::BigInt(_) => todo!("big int not supported"),
+        JsValue::Object(ref o) if o.borrow().is_date() => todo!("handle date"),
+        JsValue::Object(ref o) => {
+            let o = o.borrow();
+
+            if let Some(js_map) = o.as_map_ref() {
+                let mut map = HashMap::new();
+                for (k, v) in js_map.iter() {
+                    map.insert(
+                        k.as_string().unwrap().to_string(),
+                        js_value_to_entity_value(v),
+                    );
+                }
+
+                EntityValue::Map(map)
+            } else if o.is_array() {
+                let arr = o
+                    .properties()
+                    .index_properties()
+                    .sorted_by_key(|(i, _)| *i)
+                    .map(|(_, desc)| {
+                        desc.value()
+                            .map(js_value_to_entity_value)
+                            .unwrap_or(EntityValue::Null)
+                    })
+                    .collect();
+
+                EntityValue::Array(arr)
+            } else {
+                panic!("unexpected object type");
+            }
+        }
+        JsValue::Symbol(_) => todo!(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::datastore::value::EntityValue;
+
+    use super::*;
+
+    #[test]
+    fn test_convert_array_round_trip() {
+        let mut ctx = boa_engine::Context::default();
+        let entity = EntityValue::Array(vec![
+            EntityValue::Boolean(true),
+            EntityValue::Boolean(false),
+        ]);
+
+        let js_value = entity_value_to_js_value(&mut ctx, &entity, true);
+        let entity_back = js_value_to_entity_value(&js_value);
+        assert_eq!(entity, entity_back);
+    }
+}

--- a/server/src/policy/utils.rs
+++ b/server/src/policy/utils.rs
@@ -175,7 +175,7 @@ mod test {
                 prop_oneof![
                     // Take the inner strategy and make the two recursive cases.
                     prop::collection::vec(inner.clone(), 0..10).prop_map(EntityValue::Array),
-                    prop::collection::hash_map(".*", inner, 0..10).prop_map(EntityValue::Map),
+                    prop::collection::hash_map(".+", inner, 0..10).prop_map(EntityValue::Map),
                 ]
             },
         )

--- a/server/src/policy/utils.rs
+++ b/server/src/policy/utils.rs
@@ -4,7 +4,7 @@ use boa_engine::builtins::date::Date;
 use boa_engine::object::{JsArray, JsArrayBuffer, ObjectData};
 use boa_engine::prelude::JsObject;
 use boa_engine::property::PropertyKey;
-use boa_engine::{JsString, JsValue};
+use boa_engine::{JsBigInt, JsString, JsValue};
 use itertools::Itertools;
 use serde_json::{Map, Value as JsonValue};
 
@@ -85,6 +85,7 @@ pub fn entity_value_to_js_value(
             let ab = JsArrayBuffer::from_byte_block(bytes.clone(), ctx).unwrap();
             ab.into()
         }
+        EntityValue::Int64(i) => JsValue::BigInt(JsBigInt::new(*i)),
     }
 }
 
@@ -117,7 +118,7 @@ pub fn js_value_to_entity_value(val: &JsValue) -> EntityValue {
         JsValue::String(ref s) => EntityValue::String(s.to_string()),
         JsValue::Rational(f) => EntityValue::Float64(*f),
         JsValue::Integer(n) => EntityValue::Float64(*n as _),
-        JsValue::BigInt(_) => todo!("big int not supported"),
+        JsValue::BigInt(i) => EntityValue::Int64(i.to_string().parse().unwrap()),
         JsValue::Object(ref o) if o.borrow().is_date() => {
             let time = o.borrow().as_date().unwrap().get_time();
             EntityValue::JsDate(time)


### PR DESCRIPTION
This pr introduces the Typescript policy engine.

Right now, this is not connected to anything, so it does nothing.

### How it works

Internally, the policy engine has two interpreters:
- the boa interpreter: a lightweigth js runtime
- the predicate interpreter, that transforms predicate expressions into `datastore::Expr`.

The `PolicyEngine` is not `Sync` nor `Send`, therefore, each worker has to instanciate it's own, and load it from the policy sources.

Policies for a type are lazily loaded into a `PolicyEvalInstance`. Such instances are cached for the duration of the `PolicyContext`.

The `PolicyProcessor` is used to evaluate a policy on an `EntityValue` instance.
