### PR TITLE
Migrating from structopt to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,12 +589,12 @@ version = "0.13.0-dev.0"
 dependencies = [
  "anyhow",
  "bimap",
+ "clap 4.0.8",
  "indexmap",
  "petgraph 0.6.2",
  "quine-mc_cluskey",
  "serde",
  "serde_json",
- "structopt",
  "swc_atoms 0.3.1",
  "swc_common 0.25.0",
  "swc_ecmascript 0.185.0",
@@ -651,12 +651,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5840cd9093aabeabf7fd932754c435b7674520fc3ddc935c397837050f0f1e4b"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92289ffc6fb4a85d85c246ddb874c05a87a2e540fb6ad52f7ca07c8c1e1840b1"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "cli"
 version = "0.13.0-dev.0"
 dependencies = [
  "anyhow",
  "bytes",
  "chisel-macros",
+ "clap 4.0.8",
  "colored",
  "enclose",
  "endpoint_tsc",
@@ -686,7 +724,6 @@ dependencies = [
  "serde_json",
  "server",
  "strip-ansi-escapes",
- "structopt",
  "swc_common 0.17.25",
  "swc_ecmascript 0.143.0",
  "tempdir",
@@ -2870,7 +2907,7 @@ name = "lit"
 version = "1.0.4"
 source = "git+https://github.com/chiselstrike/lit?rev=607b0b9#607b0b9af934e55fdf3814e9186468c9b91b7cae"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "error-chain",
  "itertools 0.9.0",
  "lazy_static",
@@ -3327,6 +3364,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "outref"
@@ -4884,7 +4927,7 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -4909,7 +4952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d887e6156acb1f4e2d2968d61d1d3b6c5e102af5f23c3ca606723b5ac2c45cb"
 dependencies = [
  "anyhow",
- "clap",
+ "clap 2.34.0",
  "serde",
  "serde_derive",
  "skeptic",

--- a/chiselc/Cargo.toml
+++ b/chiselc/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.57"
 bimap = "0.6.2"
+clap = { version = "4.0", features = ["derive"] }
 indexmap = "1.8.1"
 petgraph = "0.6.2"
 quine-mc_cluskey = "0.2.4"
 serde = "1.0.137"
 serde_json = "1.0.81"
-structopt = "0.3.26"
 swc_atoms = "0.3.0"
 swc_common = "0.25.0"
 swc_ecmascript = { version = "0.185.0", features = ["visit", "parser", "transforms", "codegen", "typescript"] }

--- a/chiselc/src/main.rs
+++ b/chiselc/src/main.rs
@@ -5,31 +5,31 @@ use std::io::{self, Read, Write};
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use structopt::StructOpt;
+use clap::Parser;
 
 use chiselc::parse::compile;
 use chiselc::rewrite::Target;
 use chiselc::symbols::Symbols;
 
-#[derive(StructOpt)]
-#[structopt(name = "chiselc")]
+#[derive(Parser)]
+#[command(name = "chiselc")]
 struct Opt {
     /// Input file
-    #[structopt(parse(from_os_str))]
+    #[arg(value_parser)]
     input: Option<PathBuf>,
     /// Output file (optional).
-    #[structopt(short, long)]
+    #[arg(short, long)]
     output: Option<PathBuf>,
     /// Entity types
-    #[structopt(short, long)]
+    #[arg(short, long)]
     entities: Vec<String>,
     /// Entity types
-    #[structopt(short, long, default_value = "js")]
+    #[arg(short, long, default_value = "js")]
     target: Target,
 }
 
 fn main() -> Result<()> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     let mut input = match opt.input {
         Some(path) => {
             let file = File::open(path.clone())

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 chisel_server = { package = "server", path = "../server" }
+clap = { version = "4.0", features = ["derive"] }
 endpoint_tsc = { path = "../endpoint_tsc" }
 futures = "0.3.21"
 guard = "0.5"
@@ -19,7 +20,6 @@ regex = "1.5.4"
 serde = "1.0.137"
 serde_derive = "1.0.137"
 serde_json = "1.0.81"
-structopt = "0.3.23"
 swc_common = "0.17.4"
 swc_ecmascript = { version = "0.143.0" }
 tempfile = "3.2.0"

--- a/cli/tests/integration_tests/main.rs
+++ b/cli/tests/integration_tests/main.rs
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com>
 
 use crate::common::{bin_dir, run};
+use clap::Parser;
 use regex::Regex;
 use std::fmt::{Display, Formatter};
 use std::process::ExitCode;
 use std::str::FromStr;
 use std::sync::Arc;
-use structopt::StructOpt;
 
 #[path = "../common/mod.rs"]
 pub mod common;
@@ -47,39 +47,39 @@ impl FromStr for DatabaseKind {
     }
 }
 
-#[derive(Debug, StructOpt, Clone)]
-#[structopt(name = "lit_test", about = "Runs integration tests")]
+#[derive(Debug, Parser, Clone)]
+#[command(name = "lit_test", about = "Runs integration tests")]
 pub struct Opt {
     /// Regex that select tests to run.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     pub test: Option<Regex>,
     /// Database system to test with. Supported values: `sqlite` (default) and `postgres`.
-    #[structopt(long, default_value = "sqlite")]
+    #[arg(long, default_value = "sqlite")]
     pub database: DatabaseKind,
     /// Database host name. Default: `localhost`.
-    #[structopt(long, default_value = "localhost")]
+    #[arg(long, default_value = "localhost")]
     pub database_host: String,
     /// Database username.
-    #[structopt(long)]
+    #[arg(long)]
     pub database_user: Option<String>,
     /// Database password.
-    #[structopt(long)]
+    #[arg(long)]
     pub database_password: Option<String>,
     /// Kafka connection.
-    #[structopt(long)]
+    #[arg(long)]
     pub kafka_connection: Option<String>,
     /// Kafka topic.
-    #[structopt(long)]
+    #[arg(long)]
     pub kafka_topic: Option<String>,
-    #[structopt(long)]
+    #[arg(long)]
     pub optimize: Option<bool>,
     /// Number of Rust tests to run in parallel (does not apply to lit).
-    #[structopt(short, long)]
+    #[arg(short, long)]
     pub parallel: Option<usize>,
     test_arg: Option<Regex>,
 
     /// don't capture stdout/stderr of each task, allow printing directly
-    #[structopt(long)]
+    #[arg(long)]
     nocapture: bool,
 }
 
@@ -108,7 +108,7 @@ fn main() -> ExitCode {
         ],
     );
 
-    let opt = Arc::new(Opt::from_args());
+    let opt = Arc::new(Opt::parse());
 
     let ok = rust::run_tests(opt.clone()) & lit::run_tests(&opt);
     if ok {


### PR DESCRIPTION
This series partially migrates the source code from [structopt](https://crates.io/crates/structopt) (which self-declared itself as maintenance mode only) to [clap](https://crates.io/crates/clap). `server/` path is not yet migrated, because it also relies on `StructOptToml` crate, and we need to preserve the ability to serialize/deserialize toml structs.

Refs #1777