### PR TITLE
server: Reset `last_try_was_failure` on success

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -257,6 +257,8 @@ async fn refresh_secrets(server: Arc<Server>) -> Result<()> {
                 log::warn!("Could not re-read secrets: {:?}", err);
             }
             last_try_was_failure = true;
+        } else {
+            last_try_was_failure = false;
         }
         tokio::time::sleep(Duration::from_millis(1000)).await;
     }


### PR DESCRIPTION
`last_try_was_failure` variable was supposed to be used to avoid spamming logs with warnings about failed secrets updates. This was achieved by not logging a warning if the previous try to update the secrets was also a failure.
The problem is that the variable is never set to `false` again while it should be after a successful secrets update. That means the warning won't me logged more than once even in situation like this:

update failed, 1000 x update succeeded, update failed

Signed-off-by: Piotr Jastrzebski <piotr@chiselstrike.com>