### PR TITLE
TS api: runtime check argument type for delete

### DIFF
--- a/api/src/datastore.ts
+++ b/api/src/datastore.ts
@@ -1049,6 +1049,9 @@ export class ChiselEntity {
 function restrictionsToFilterExpr<T extends ChiselEntity>(
     restrictions: Partial<T>,
 ): Record<string, unknown> | undefined {
+    if (typeof restrictions != "object") {
+        throw `expected object, but found ${typeof restrictions} instead`;
+    }
     let expr = undefined;
     for (const key in restrictions) {
         if (restrictions[key] === undefined) {


### PR DESCRIPTION
This PR checks that the type of the argument passed to the `restrictionsToFilterExpr` is in fact an object. If it wasn't it would wipe out the database.
