### PR TITLE
Add _createdAt and _updatedAt fields

### DIFF
--- a/api/src/datastore.ts
+++ b/api/src/datastore.ts
@@ -679,6 +679,16 @@ export class ChiselEntity {
     /** UUID identifying this object. */
     id?: string;
 
+    _updatedAt?: Date;
+    _createdAt?: Date;
+
+    updateMeta() {
+        if (!this._createdAt) {
+            this._createdAt = new Date();
+        }
+        this._updatedAt = new Date();
+    }
+
     /**
      * Builds a new entity.
      *
@@ -721,6 +731,8 @@ export class ChiselEntity {
     /** saves the current object into the backend */
     async save() {
         ensureNotGet();
+        this.updateMeta();
+
         type IdsJson = { id: string; children: Record<string, IdsJson> };
         const jsonIds = await opAsync("op_chisel_store", {
             name: this.constructor.name,


### PR DESCRIPTION
This PR adds _createdAt and _updatedAt fields. We will establish a rule, that we now check, that ChiselStrike internal entities should start with an underscore.