### PR TITLE
Add `chisel generate` command

### DIFF
--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -10,3 +10,4 @@ macro_rules! execute {
 
 pub(crate) mod apply;
 pub(crate) mod dev;
+pub(crate) mod generate;

--- a/cli/src/cmd/generate.rs
+++ b/cli/src/cmd/generate.rs
@@ -1,0 +1,53 @@
+use crate::proto::chisel_rpc_client::ChiselRpcClient;
+use crate::proto::{type_msg::TypeEnum, DescribeRequest};
+use anyhow::{anyhow, Result};
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+pub(crate) async fn cmd_generate(
+    server_url: String,
+    output: PathBuf,
+    version: String,
+) -> Result<()> {
+    let output = File::create(output)?;
+    let mut client = ChiselRpcClient::connect(server_url).await?;
+    let request = tonic::Request::new(DescribeRequest {});
+    let response = execute!(client.describe(request).await);
+    let version_def = response
+        .version_defs
+        .iter()
+        .find(|def| def.version_id == version);
+    if let Some(version_def) = version_def {
+        for def in &version_def.type_defs {
+            writeln!(&output, "export type {} = {{", def.name)?;
+            writeln!(&output, "    id: string;")?;
+            for field in &def.field_defs {
+                let field_type = field.field_type()?;
+                writeln!(
+                    &output,
+                    "    {}{}: {}{};",
+                    field.name,
+                    if field.is_optional { "?" } else { "" },
+                    field_type,
+                    field
+                        .default_value
+                        .as_ref()
+                        .map(|d| if matches!(field_type, TypeEnum::String(_)) {
+                            format!(r#" = "{}""#, d)
+                        } else {
+                            format!(" = {}", d)
+                        })
+                        .unwrap_or_else(|| "".into()),
+                )?;
+            }
+            writeln!(&output, "}}")?;
+        }
+    }
+    writeln!(&output, "export type Results<T> = {{")?;
+    writeln!(&output, "    next_page: string;")?;
+    writeln!(&output, "    prev_page: string;")?;
+    writeln!(&output, "    results: T[];")?;
+    writeln!(&output, "}}")?;
+    Ok(())
+}


### PR DESCRIPTION
This adds a `chisel generate` command that generates types that can be
used from client code to simplify accessing ChiselStrike endpoints.

Currently, the command generates types based on the entities. For
example, given the following entity:

```typescript
export class Message extends ChiselEntity {
    sender: string;
    body: string;
    timestamp: string;
}
```

The command generates the following types:

```typescript
export type Message = {
    id: string;
    sender: string;
    body: string;
    timestamp: string;
}
export type Results<T> = {
    next_page: string;
    prev_page: string;
    results: T[];
}
```

The `Message` type maps to the `Message` entity directly. The
`Results<T>` type is the output of a CRUD endpoint that returns multiple
entities.

In the future, if we change the endpoint API to have more types, this
command can generate a full-blown RPC-like client with proper typing.