### PR TITLE
create-chiselstrike-app: Generate more .gitkeeps

### DIFF
--- a/packages/create-chiselstrike-app/index.ts
+++ b/packages/create-chiselstrike-app/index.ts
@@ -54,7 +54,9 @@ function run(
 
     mkdirpSync(path.join(projectDirectory, ".vscode"));
     mkdirpSync(routesPath);
+    touchSync(path.join(routesPath, ".gitkeep"));
     mkdirpSync(eventsPath);
+    touchSync(path.join(eventsPath, ".gitkeep"));
     mkdirpSync(modelsPath);
     touchSync(path.join(modelsPath, ".gitkeep"));
     mkdirpSync(policiesPath);


### PR DESCRIPTION
We need to generate `.gitkeep` to potentially empty directories so that `git add` adds them to git repositories.