### PR TITLE
fix stream-db.deno test

### DIFF
--- a/cli/tests/integration_tests/lit_tests/stream-db.deno
+++ b/cli/tests/integration_tests/lit_tests/stream-db.deno
@@ -28,7 +28,7 @@ export default async function chisel(req: Request) {
     }
     await Promise.all(promises);
 
-    let cursor = Data.cursor();
+    let cursor = Data.cursor().sortBy("num");
     let asyncIter = cursor[Symbol.asyncIterator]();
     let read_one = false;
     let stream = new ReadableStream({


### PR DESCRIPTION
This PR fixes the stream-db.deno test by making sure that all the writes are performed sequentially.

I found this when working on an implementation of `add_row` that had more than one `await` point. Awaiting the promises concurrently gives no guarantees that the insert will be performed in order. 
