### PR TITLE
Enable jwt in typescript policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,6 +2967,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa4b4af834c6cfd35d8763d359661b90f2e45d8f750a0849156c7f4671af09c"
+dependencies = [
+ "base64",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3739,6 +3753,15 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "pem"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
+dependencies = [
+ "base64",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -4912,6 +4935,7 @@ dependencies = [
  "http",
  "hyper",
  "itertools 0.10.5",
+ "jsonwebtoken",
  "lazy_static",
  "libc",
  "log",
@@ -5026,6 +5050,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
 dependencies = [
  "outref",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time 0.3.15",
 ]
 
 [[package]]
@@ -6272,7 +6308,14 @@ dependencies = [
  "libc",
  "num_threads",
  "serde",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinyvec"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,6 +30,7 @@ guard = "0.5"
 http = "0.2.6"
 hyper = { version = "0.14.16", features = ["server", "tcp", "http1"] }
 itertools = "0.10.1"
+jsonwebtoken = "8.1.1"
 lazy_static = "1.4"
 log = "0.4.14"
 nix = "0.22.2"

--- a/server/src/authentication.rs
+++ b/server/src/authentication.rs
@@ -2,11 +2,17 @@
 use std::fmt;
 
 use anyhow::anyhow;
+use http::request::Parts;
+use jsonwebtoken::{DecodingKey, Validation};
+use parking_lot::RwLock;
+use serde::Serialize;
+use serde_json::Value as JsonValue;
 use sqlx::Row;
 
 use crate::datastore::engine::SqlWithArguments;
 use crate::datastore::query::SqlValue;
 use crate::types::{Entity, Type};
+use crate::JsonObject;
 use crate::{server::Server, version::Version};
 
 type Result<T> = std::result::Result<T, AuthError>;
@@ -77,6 +83,154 @@ pub enum AuthErrorKind {
     Forbbiden,
     BadRequest,
     Internal,
+}
+
+/// Represents a Authenticated user
+#[derive(Debug, Serialize, Clone)]
+pub enum Authentication {
+    /// Claims from a user authenticated through JWT, passed in the `Authorization: Bearer` header.
+    Jwt(JsonValue),
+    /// User id of the authencated user, if he's logged with a user id passed in the header
+    /// ChiselUID
+    UserId(String),
+    /// No authenticated user
+    None,
+}
+
+async fn authenticate_by_user_id(
+    server: &Server,
+    version: &Version,
+    user_id: Option<String>,
+    routing_path: &str,
+) -> Result<Authentication> {
+    let username = get_username_from_id(server, version, user_id.as_deref()).await;
+    if !version
+        .policy_system
+        .user_authorization
+        .is_allowed(username.as_deref(), routing_path)
+    {
+        forbidden!("Unauthorized user");
+    }
+
+    Ok(user_id
+        .map(Authentication::UserId)
+        .unwrap_or(Authentication::None))
+}
+
+/// Takes a string representing a RSA PEM with its header and footer trimmed, and all line breaks
+/// removed, and created a decoding key for decoding a JWT.
+fn decoding_key_from_pem(key: &str) -> Result<DecodingKey> {
+    let header = String::from("-----BEGIN PUBLIC KEY-----\n");
+    let mut key = key
+        .as_bytes()
+        .chunks(64)
+        .try_fold(header, |mut buf, s| -> Result<String> {
+            let line = std::str::from_utf8(s)
+                .map_err(|_| AuthError::internal(anyhow!("JWT signing key is not valid UTF-8")))?;
+            buf.push_str(line);
+            buf.push('\n');
+            Ok(buf)
+        })?;
+    key.push_str("-----END PUBLIC KEY-----");
+
+    let dkey = DecodingKey::from_rsa_pem(key.as_bytes()).map_err(|_| {
+        AuthError::internal(anyhow!("JWT signing key is not a valid RSA PEM string"))
+    })?;
+
+    Ok(dkey)
+}
+
+/// Attempts to authenticate the provided JWT.
+/// First looks for the `CHISEL_JWT_VALIDATION_KEY` in the instance secrets, in a RSA pem format,
+/// with the header and footer trimmed, and all line breaks removed.
+///
+/// Once the key is retrieved, the token is validated with the RS256 algorithm, and the claims are
+/// returned in the Authentication::Jwt enum
+fn authenticate_jwt(secrets: &RwLock<JsonObject>, token: &str) -> Result<Authentication> {
+    // get public signing key.
+    let lock = secrets.read();
+    let secret_value = lock.get("CHISEL_JWT_VALIDATION_KEY").unwrap();
+    match secret_value.as_str() {
+        Some(pem_str) => {
+            let dkey = decoding_key_from_pem(pem_str)?;
+            let json = validate_token(token, dkey)?;
+            Ok(Authentication::Jwt(json))
+        }
+        None => internal!(r#""CHISEL_JWT_VALIDATION_KEY" should be a valid UTF-8 string."#),
+    }
+}
+
+fn validate_token(token: &str, key: DecodingKey) -> Result<JsonValue> {
+    match jsonwebtoken::decode::<JsonValue>(
+        token,
+        &key,
+        &Validation::new(jsonwebtoken::Algorithm::RS256),
+    ) {
+        Ok(token) => Ok(token.claims),
+        Err(e) => forbidden!("invalid token: {e}"),
+    }
+}
+
+async fn authenticate_from_auth_header(
+    server: &Server,
+    header_value: &str,
+) -> Result<Authentication> {
+    let mut split = header_value.split_whitespace();
+    match split.next() {
+        Some("Bearer") => match split.next() {
+            Some(token) => authenticate_jwt(&server.secrets, token),
+            None => bad_request!(r#"missing token after "Bearer""#),
+        },
+        _ => bad_request!("Could not recognize authentication token type."),
+    }
+}
+
+/// Authenticate the user performing the request with choosing from one of the authentication method
+/// provided by ChiselStrike.
+///
+/// This method will first look for a JWT in the `Authorization: Bearer` header. If the header is
+/// no set, it fallback to the user id provided in the `ChiselUID` header. If nothing is found
+/// there, then Authentication::None is returned.
+pub async fn authenticate(
+    req_parts: &Parts,
+    server: &Server,
+    version: &Version,
+    routing_path: &str,
+) -> Result<Authentication> {
+    // Check Authorization header first, and process auth if it exists
+    let maybe_auth_header = req_parts
+        .headers
+        .get("Authorization")
+        .and_then(|h| h.to_str().ok());
+    if let Some(auth_header) = maybe_auth_header {
+        let authentication = authenticate_from_auth_header(server, auth_header).await?;
+        return Ok(authentication);
+    }
+
+    // FIXME: this part of auth is... strange?
+    // TODO: we don't authenticate the user!!!
+    // get the token here instead, and parse jwt
+    let maybe_user_id: Option<String> = req_parts
+        .headers
+        .get("ChiselUID")
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.into());
+
+    let authentication =
+        authenticate_by_user_id(server, version, maybe_user_id, routing_path).await?;
+
+    {
+        let secrets = server.secrets.read();
+        if !version
+            .policy_system
+            .secret_authorization
+            .is_allowed(req_parts, &secrets, routing_path)
+        {
+            forbidden!("Invalid header authentication");
+        }
+    }
+
+    Ok(authentication)
 }
 
 pub const AUTH_USER_NAME: &str = "AuthUser";

--- a/server/src/authentication.rs
+++ b/server/src/authentication.rs
@@ -1,89 +1,13 @@
+use anyhow::Context;
 // SPDX-FileCopyrightText: © 2021 ChiselStrike <info@chiselstrike.com>
-use std::fmt;
-
-use anyhow::anyhow;
 use http::request::Parts;
 use jsonwebtoken::{DecodingKey, Validation};
 use parking_lot::RwLock;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
-use sqlx::Row;
 
-use crate::datastore::engine::SqlWithArguments;
-use crate::datastore::query::SqlValue;
-use crate::types::{Entity, Type};
+use crate::error::{Result, ResultExt};
 use crate::JsonObject;
-use crate::{server::Server, version::Version};
-
-type Result<T> = std::result::Result<T, AuthError>;
-
-macro_rules! bad_request {
-    ($($token:tt)*) => {
-        return Err(AuthError::bad_request(anyhow!($($token)*)))
-    };
-}
-
-macro_rules! forbidden {
-    ($($token:tt)*) => {
-        return Err(AuthError::forbidden(anyhow!($($token)*)))
-    };
-}
-
-macro_rules! internal {
-    ($($token:tt)*) => {
-        return Err(AuthError::forbidden(anyhow!($($token)*)))
-    };
-}
-
-#[derive(Debug)]
-pub struct AuthError {
-    pub inner: anyhow::Error,
-    pub err_kind: AuthErrorKind,
-}
-
-impl fmt::Display for AuthError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let context = match self.err_kind {
-            AuthErrorKind::Forbbiden => "forbidden",
-            AuthErrorKind::BadRequest => "bad request",
-            AuthErrorKind::Internal => "internal error",
-        };
-
-        write!(f, "{context}: {}", self.inner)
-    }
-}
-
-impl std::error::Error for AuthError {}
-
-impl AuthError {
-    fn internal(inner: anyhow::Error) -> Self {
-        Self {
-            inner,
-            err_kind: AuthErrorKind::Internal,
-        }
-    }
-
-    fn forbidden(inner: anyhow::Error) -> Self {
-        Self {
-            inner,
-            err_kind: AuthErrorKind::Forbbiden,
-        }
-    }
-
-    fn bad_request(inner: anyhow::Error) -> Self {
-        Self {
-            inner,
-            err_kind: AuthErrorKind::BadRequest,
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum AuthErrorKind {
-    Forbbiden,
-    BadRequest,
-    Internal,
-}
 
 /// Represents a Authenticated user
 #[derive(Debug, Serialize, Clone)]
@@ -97,24 +21,14 @@ pub enum Authentication {
     None,
 }
 
-async fn authenticate_by_user_id(
-    server: &Server,
-    version: &Version,
-    user_id: Option<String>,
-    routing_path: &str,
-) -> Result<Authentication> {
-    let username = get_username_from_id(server, version, user_id.as_deref()).await;
-    if !version
-        .policy_system
-        .user_authorization
-        .is_allowed(username.as_deref(), routing_path)
-    {
-        forbidden!("Unauthorized user");
+impl Authentication {
+    pub fn user_id(&self) -> Option<&str> {
+        // TODO: maybe extract uid from JWT if JWT contains a `userId` field?
+        match self {
+            Authentication::UserId(ref uid) => Some(uid),
+            _ => None,
+        }
     }
-
-    Ok(user_id
-        .map(Authentication::UserId)
-        .unwrap_or(Authentication::None))
 }
 
 /// Takes a string representing a RSA PEM with its header and footer trimmed, and all line breaks
@@ -126,16 +40,15 @@ fn decoding_key_from_pem(key: &str) -> Result<DecodingKey> {
         .chunks(64)
         .try_fold(header, |mut buf, s| -> Result<String> {
             let line = std::str::from_utf8(s)
-                .map_err(|_| AuthError::internal(anyhow!("JWT signing key is not valid UTF-8")))?;
+                .context("JWT signing key is not valid UTF-8")
+                .err_internal()?;
             buf.push_str(line);
             buf.push('\n');
             Ok(buf)
         })?;
     key.push_str("-----END PUBLIC KEY-----");
 
-    let dkey = DecodingKey::from_rsa_pem(key.as_bytes()).map_err(|_| {
-        AuthError::internal(anyhow!("JWT signing key is not a valid RSA PEM string"))
-    })?;
+    let dkey = DecodingKey::from_rsa_pem(key.as_bytes()).err_internal()?;
 
     Ok(dkey)
 }
@@ -149,7 +62,12 @@ fn decoding_key_from_pem(key: &str) -> Result<DecodingKey> {
 fn authenticate_jwt(secrets: &RwLock<JsonObject>, token: &str) -> Result<Authentication> {
     // get public signing key.
     let lock = secrets.read();
-    let secret_value = lock.get("CHISEL_JWT_VALIDATION_KEY").unwrap();
+    let secret_value = match lock.get("CHISEL_JWT_VALIDATION_KEY") {
+        Some(key) => key,
+        None => internal!(
+            "Missing jwt validation key: please set `CHISEL_JWT_VALIDATION_KEY` in your secrets"
+        ),
+    };
     match secret_value.as_str() {
         Some(pem_str) => {
             let dkey = decoding_key_from_pem(pem_str)?;
@@ -161,41 +79,41 @@ fn authenticate_jwt(secrets: &RwLock<JsonObject>, token: &str) -> Result<Authent
 }
 
 fn validate_token(token: &str, key: DecodingKey) -> Result<JsonValue> {
-    match jsonwebtoken::decode::<JsonValue>(
+    let token = jsonwebtoken::decode::<JsonValue>(
         token,
         &key,
         &Validation::new(jsonwebtoken::Algorithm::RS256),
-    ) {
-        Ok(token) => Ok(token.claims),
-        Err(e) => forbidden!("invalid token: {e}"),
-    }
+    )
+    .err_forbidden()?;
+
+    Ok(token.claims)
 }
 
 async fn authenticate_from_auth_header(
-    server: &Server,
+    secrets: &RwLock<JsonObject>,
     header_value: &str,
 ) -> Result<Authentication> {
     let mut split = header_value.split_whitespace();
     match split.next() {
         Some("Bearer") => match split.next() {
-            Some(token) => authenticate_jwt(&server.secrets, token),
+            Some(token) => authenticate_jwt(secrets, token),
             None => bad_request!(r#"missing token after "Bearer""#),
         },
-        _ => bad_request!("Could not recognize authentication token type."),
+        _ => {
+            bad_request!("Could not recognize authentication token type: expected `Bearer` token.")
+        }
     }
 }
 
-/// Authenticate the user performing the request with choosing from one of the authentication method
+/// Authenticate the user performing the request by choosing from one of the authentication method
 /// provided by ChiselStrike.
 ///
-/// This method will first look for a JWT in the `Authorization: Bearer` header. If the header is
-/// no set, it fallback to the user id provided in the `ChiselUID` header. If nothing is found
+/// This method will first look for a JWT in the `Authorization: Bearer` header. If the header
+/// isn't set, it falls back to the user_id provided in the `ChiselUID` header. If nothing is found
 /// there, then Authentication::None is returned.
 pub async fn authenticate(
     req_parts: &Parts,
-    server: &Server,
-    version: &Version,
-    routing_path: &str,
+    secrets: &RwLock<JsonObject>,
 ) -> Result<Authentication> {
     // Check Authorization header first, and process auth if it exists
     let maybe_auth_header = req_parts
@@ -203,11 +121,10 @@ pub async fn authenticate(
         .get("Authorization")
         .and_then(|h| h.to_str().ok());
     if let Some(auth_header) = maybe_auth_header {
-        let authentication = authenticate_from_auth_header(server, auth_header).await?;
+        let authentication = authenticate_from_auth_header(secrets, auth_header).await?;
         return Ok(authentication);
     }
 
-    // FIXME: this part of auth is... strange?
     // TODO: we don't authenticate the user!!!
     // get the token here instead, and parse jwt
     let maybe_user_id: Option<String> = req_parts
@@ -216,78 +133,5 @@ pub async fn authenticate(
         .and_then(|value| value.to_str().ok())
         .map(|value| value.into());
 
-    let authentication =
-        authenticate_by_user_id(server, version, maybe_user_id, routing_path).await?;
-
-    {
-        let secrets = server.secrets.read();
-        if !version
-            .policy_system
-            .secret_authorization
-            .is_allowed(req_parts, &secrets, routing_path)
-        {
-            forbidden!("Invalid header authentication");
-        }
-    }
-
-    Ok(authentication)
-}
-
-pub const AUTH_USER_NAME: &str = "AuthUser";
-pub const AUTH_SESSION_NAME: &str = "AuthSession";
-pub const AUTH_TOKEN_NAME: &str = "AuthToken";
-pub const AUTH_ACCOUNT_NAME: &str = "AuthAccount";
-
-const AUTH_ENTITY_NAMES: [&str; 4] = [
-    AUTH_USER_NAME,
-    AUTH_SESSION_NAME,
-    AUTH_TOKEN_NAME,
-    AUTH_ACCOUNT_NAME,
-];
-
-pub fn is_auth_entity_name(entity_name: &str) -> bool {
-    AUTH_ENTITY_NAMES.contains(&entity_name)
-}
-
-fn get_auth_user_type(version: &Version) -> Result<Entity> {
-    match version.type_system.lookup_builtin_type(AUTH_USER_NAME) {
-        Ok(Type::Entity(t)) => Ok(t),
-        _ => internal!("type AuthUser not found"),
-    }
-}
-
-/// Extracts the username of the logged-in user, or None if there was no login.
-pub async fn get_username_from_id(
-    server: &Server,
-    version: &Version,
-    user_id: Option<&str>,
-) -> Option<String> {
-    let qeng = server.query_engine.clone();
-    let user_type = get_auth_user_type(version);
-
-    match (user_id, user_type) {
-        (None, _) => None,
-        (Some(_), Err(e)) => {
-            log::warn!("{:?}", e);
-            None
-        }
-        (Some(id), Ok(user_type)) => {
-            match qeng
-                .fetch_one(SqlWithArguments {
-                    sql: format!(
-                        "SELECT email FROM \"{}\" WHERE id=$1", // For now, let's pretend email is username.
-                        user_type.backing_table()
-                    ),
-                    args: vec![SqlValue::String(id.into())],
-                })
-                .await
-            {
-                Err(_e) => {
-                    //warn!("Username query error: {:?}", e);
-                    None
-                }
-                Ok(row) => row.get("email"),
-            }
-        }
-    }
+    Ok(maybe_user_id.map_or(Authentication::None, Authentication::UserId))
 }

--- a/server/src/authentication.rs
+++ b/server/src/authentication.rs
@@ -62,13 +62,13 @@ fn decoding_key_from_pem(key: &str) -> Result<DecodingKey> {
 fn authenticate_jwt(secrets: &RwLock<JsonObject>, token: &str) -> Result<Authentication> {
     // get public signing key.
     let lock = secrets.read();
-    let secret_value = match lock.get("CHISEL_JWT_VALIDATION_KEY") {
-        Some(key) => key,
+    let dkey_json = match lock.get("CHISEL_JWT_VALIDATION_KEY") {
+        Some(json) => json,
         None => internal!(
             "Missing jwt validation key: please set `CHISEL_JWT_VALIDATION_KEY` in your secrets"
         ),
     };
-    match secret_value.as_str() {
+    match dkey_json.as_str() {
         Some(pem_str) => {
             let dkey = decoding_key_from_pem(pem_str)?;
             let json = validate_token(token, dkey)?;

--- a/server/src/authorization.rs
+++ b/server/src/authorization.rs
@@ -1,0 +1,110 @@
+use http::request::Parts;
+use sqlx::Row;
+
+use crate::authentication::Authentication;
+use crate::datastore::engine::SqlWithArguments;
+use crate::datastore::query::SqlValue;
+use crate::error::Result;
+use crate::server::Server;
+use crate::types::Entity;
+use crate::types::Type;
+use crate::version::Version;
+
+pub const AUTH_USER_NAME: &str = "AuthUser";
+pub const AUTH_SESSION_NAME: &str = "AuthSession";
+pub const AUTH_TOKEN_NAME: &str = "AuthToken";
+pub const AUTH_ACCOUNT_NAME: &str = "AuthAccount";
+
+const AUTH_ENTITY_NAMES: [&str; 4] = [
+    AUTH_USER_NAME,
+    AUTH_SESSION_NAME,
+    AUTH_TOKEN_NAME,
+    AUTH_ACCOUNT_NAME,
+];
+
+pub fn is_auth_entity_name(entity_name: &str) -> bool {
+    AUTH_ENTITY_NAMES.contains(&entity_name)
+}
+
+fn get_auth_user_type(version: &Version) -> Result<Entity> {
+    match version.type_system.lookup_builtin_type(AUTH_USER_NAME) {
+        Ok(Type::Entity(t)) => Ok(t),
+        _ => internal!("type AuthUser not found"),
+    }
+}
+
+/// Extracts the username of the logged-in user, or None if there was no login.
+async fn get_username_from_id(
+    server: &Server,
+    version: &Version,
+    user_id: Option<&str>,
+) -> Option<String> {
+    let qeng = server.query_engine.clone();
+    let user_type = get_auth_user_type(version);
+
+    match (user_id, user_type) {
+        (None, _) => None,
+        (Some(_), Err(e)) => {
+            log::warn!("{:?}", e);
+            None
+        }
+        (Some(id), Ok(user_type)) => {
+            match qeng
+                .fetch_one(SqlWithArguments {
+                    sql: format!(
+                        "SELECT email FROM \"{}\" WHERE id=$1", // For now, let's pretend email is username.
+                        user_type.backing_table()
+                    ),
+                    args: vec![SqlValue::String(id.into())],
+                })
+                .await
+            {
+                Err(_e) => {
+                    //warn!("Username query error: {:?}", e);
+                    None
+                }
+                Ok(row) => row.get("email"),
+            }
+        }
+    }
+}
+
+async fn authorize_user_id(
+    server: &Server,
+    version: &Version,
+    authentication: &Authentication,
+    routing_path: &str,
+) -> Result<()> {
+    let user_id = authentication.user_id();
+    let username = get_username_from_id(server, version, user_id).await;
+    if !version
+        .policy_system
+        .user_authorization
+        .is_allowed(username.as_deref(), routing_path)
+    {
+        forbidden!("Unauthorized user");
+    }
+
+    Ok(())
+}
+
+pub async fn authorize(
+    server: &Server,
+    version: &Version,
+    authentication: &Authentication,
+    routing_path: &str,
+    req_parts: &Parts,
+) -> Result<()> {
+    authorize_user_id(server, version, authentication, routing_path).await?;
+
+    let secrets = server.secrets.read();
+    if !version
+        .policy_system
+        .secret_authorization
+        .is_allowed(req_parts, &secrets, routing_path)
+    {
+        forbidden!("Invalid header authentication");
+    }
+
+    Ok(())
+}

--- a/server/src/datastore/mod.rs
+++ b/server/src/datastore/mod.rs
@@ -121,6 +121,7 @@ mod test {
     use url::Url;
 
     use crate::{
+        authentication::Authentication,
         policy::engine::PolicyEngine,
         types::{self, Entity, Field, ObjectType, Type},
         JsonObject,
@@ -189,8 +190,8 @@ mod test {
                 method: "POST".into(),
                 path: "".into(),
                 headers,
-                user_id: None,
                 response_tx: Default::default(),
+                authentication: Authentication::None,
             });
             let policy_context = PolicyContext {
                 cache: Default::default(),

--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Context, Result};
 use enum_as_inner::EnumAsInner;
 use serde_derive::{Deserialize, Serialize};
 
-use crate::authentication::AUTH_USER_NAME;
+use crate::authorization::AUTH_USER_NAME;
 use crate::datastore::expr::{BinaryExpr, Expr, PropertyAccess, Value as ExprValue};
 use crate::feat_typescript_policies;
 use crate::policy::PolicyContext;

--- a/server/src/datastore/query.rs
+++ b/server/src/datastore/query.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Context, Result};
 use enum_as_inner::EnumAsInner;
 use serde_derive::{Deserialize, Serialize};
 
-use crate::auth::AUTH_USER_NAME;
+use crate::authentication::AUTH_USER_NAME;
 use crate::datastore::expr::{BinaryExpr, Expr, PropertyAccess, Value as ExprValue};
 use crate::feat_typescript_policies;
 use crate::policy::PolicyContext;

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -1,0 +1,97 @@
+use std::fmt;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[macro_export]
+macro_rules! bad_request {
+    ($($token:tt)*) => {
+        return Err($crate::error::Error::bad_request(anyhow::anyhow!($($token)*)))
+    };
+}
+
+#[macro_export]
+macro_rules! forbidden {
+    ($($token:tt)*) => {
+        return Err($crate::error::Error::forbidden(anyhow::anyhow!($($token)*)))
+    };
+}
+
+#[macro_export]
+macro_rules! internal {
+    ($($token:tt)*) => {
+        return Err($crate::error::Error::internal(anyhow::anyhow!($($token)*)))
+    };
+}
+
+#[derive(Debug)]
+pub struct Error {
+    pub inner: anyhow::Error,
+    pub err_kind: ErrorKind,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let context = match self.err_kind {
+            ErrorKind::Forbbiden => "forbidden",
+            ErrorKind::BadRequest => "bad request",
+            ErrorKind::Internal => "internal error",
+        };
+
+        write!(f, "{context}: {}", self.inner)
+    }
+}
+
+#[derive(Debug)]
+pub enum ErrorKind {
+    Forbbiden,
+    BadRequest,
+    Internal,
+}
+
+impl std::error::Error for Error {}
+
+pub trait ResultExt<T> {
+    fn err_internal(self) -> Result<T>;
+    fn err_forbidden(self) -> Result<T>;
+    fn err_bad_request(self) -> Result<T>;
+}
+
+impl<T, E> ResultExt<T> for std::result::Result<T, E>
+where
+    E: Into<anyhow::Error>,
+{
+    fn err_internal(self) -> Result<T> {
+        self.map_err(|e| Error::internal(e.into()))
+    }
+
+    fn err_forbidden(self) -> Result<T> {
+        self.map_err(|e| Error::forbidden(e.into()))
+    }
+
+    fn err_bad_request(self) -> Result<T> {
+        self.map_err(|e| Error::bad_request(e.into()))
+    }
+}
+
+impl Error {
+    pub fn internal(inner: anyhow::Error) -> Self {
+        Self {
+            inner,
+            err_kind: ErrorKind::Internal,
+        }
+    }
+
+    pub fn forbidden(inner: anyhow::Error) -> Self {
+        Self {
+            inner,
+            err_kind: ErrorKind::Forbbiden,
+        }
+    }
+
+    pub fn bad_request(inner: anyhow::Error) -> Self {
+        Self {
+            inner,
+            err_kind: ErrorKind::BadRequest,
+        }
+    }
+}

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
-use crate::auth;
+use crate::authentication;
 use crate::server::Server;
 use crate::version::{Version, VersionJob};
 use anyhow::{Context, Error, Result};
@@ -143,7 +143,8 @@ async fn handle_version_request(
         .and_then(|value| value.to_str().ok())
         .map(|value| value.into());
 
-    let username = auth::get_username_from_id(&server, &version, user_id.as_deref()).await;
+    let username =
+        authentication::get_username_from_id(&server, &version, user_id.as_deref()).await;
     if !version
         .policy_system
         .user_authorization

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -2,9 +2,9 @@
 
 use once_cell::sync::OnceCell;
 
-pub use crate::auth::is_auth_entity_name;
 pub use crate::opt::Opt;
 pub use crate::server::run;
+pub use authentication::is_auth_entity_name;
 
 pub(crate) type JsonObject = serde_json::Map<String, serde_json::Value>;
 
@@ -27,7 +27,7 @@ pub struct Features {
 extern crate log;
 
 pub(crate) mod apply;
-pub(crate) mod auth;
+pub(crate) mod authentication;
 pub(crate) mod datastore;
 pub(crate) mod http;
 pub(crate) mod internal;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -4,7 +4,7 @@ use once_cell::sync::OnceCell;
 
 pub use crate::opt::Opt;
 pub use crate::server::run;
-pub use authentication::is_auth_entity_name;
+pub use authorization::is_auth_entity_name;
 
 pub(crate) type JsonObject = serde_json::Map<String, serde_json::Value>;
 
@@ -26,8 +26,12 @@ pub struct Features {
 #[macro_use]
 extern crate log;
 
+#[macro_use]
+pub(crate) mod error;
+
 pub(crate) mod apply;
 pub(crate) mod authentication;
+pub(crate) mod authorization;
 pub(crate) mod datastore;
 pub(crate) mod http;
 pub(crate) mod internal;

--- a/server/src/ops/job.rs
+++ b/server/src/ops/job.rs
@@ -49,21 +49,21 @@ async fn op_chisel_accept_job(
             let HttpRequestResponse {
                 request,
                 response_tx,
+                authentication,
             } = request_response;
 
             let ctx_rid = {
                 let path = request.routing_path.clone();
                 let headers = request.headers.iter().cloned().collect();
                 let method = request.method.clone();
-                let user_id = request.user_id.clone();
                 let response_tx = RefCell::new(Some(response_tx));
 
                 let job_info = Rc::new(JobInfo::HttpRequest {
                     method,
                     path,
                     headers,
-                    user_id,
                     response_tx,
+                    authentication,
                 });
 
                 let ctx = JobContext {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -35,8 +35,7 @@ pub struct Server {
     /// Type system for each version (key is version id), should reflect the state of the "meta"
     /// database.
     pub type_systems: tokio::sync::Mutex<HashMap<String, TypeSystem>>,
-    /// Current secrets, they are periodically refreshed and rewritten. // Todo: this should be an
-    /// async RwLock.
+    /// Current secrets, they are periodically refreshed and rewritten.
     pub secrets: RwLock<JsonObject>,
     /// Handle to an inspector server that allows debugging of JavaScript code from Chrome.
     pub inspector: Option<Arc<deno_runtime::inspector_server::InspectorServer>>,

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -35,7 +35,8 @@ pub struct Server {
     /// Type system for each version (key is version id), should reflect the state of the "meta"
     /// database.
     pub type_systems: tokio::sync::Mutex<HashMap<String, TypeSystem>>,
-    /// Current secrets, they are periodically refreshed and rewritten.
+    /// Current secrets, they are periodically refreshed and rewritten. // Todo: this should be an
+    /// async RwLock.
     pub secrets: RwLock<JsonObject>,
     /// Handle to an inspector server that allows debugging of JavaScript code from Chrome.
     pub inspector: Option<Arc<deno_runtime::inspector_server::InspectorServer>>,

--- a/server/src/types/builtin.rs
+++ b/server/src/types/builtin.rs
@@ -1,9 +1,7 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
 use super::{Entity, Field, InternalObject, ObjectType, Type, TypeId};
-use crate::authentication::{
-    AUTH_ACCOUNT_NAME, AUTH_SESSION_NAME, AUTH_TOKEN_NAME, AUTH_USER_NAME,
-};
+use crate::authorization::{AUTH_ACCOUNT_NAME, AUTH_SESSION_NAME, AUTH_TOKEN_NAME, AUTH_USER_NAME};
 use crate::datastore::QueryEngine;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/server/src/types/builtin.rs
+++ b/server/src/types/builtin.rs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
 use super::{Entity, Field, InternalObject, ObjectType, Type, TypeId};
-use crate::auth::{AUTH_ACCOUNT_NAME, AUTH_SESSION_NAME, AUTH_TOKEN_NAME, AUTH_USER_NAME};
+use crate::authentication::{
+    AUTH_ACCOUNT_NAME, AUTH_SESSION_NAME, AUTH_TOKEN_NAME, AUTH_USER_NAME,
+};
 use crate::datastore::QueryEngine;
 use std::collections::HashMap;
 use std::sync::Arc;


### PR DESCRIPTION
This PR introduces support for JWT in typescript policies.

JWT are passed in the the `Authorization: Bearer <TOKEN>` header of the request.

A public signature verification must be passed in the `CHISEL_JWT_KEY`. The key must be a valid RSA PEM key, that is stripped of its header and footer, and all lines concatenated: eg

```
-----BEGIN PUBLIC KEY-----
kasfgfaksdfjlkajshfasd
fjkhaskldjfhaskljhdfka
-----END PUBLIC KEY-----
```
becomes:

```
kasfgfaksdfjlkajshfasdfjkhaskldjfhaskljhdfka
```

The algorithm being used to sign the keys is `RS256`.

All of these format and algorithm choices have been made to work out of the box with Clerk. Additional algorithm and key format could be added in the future.

The token can contain arbitrary user data.

If the token is validated, then it is accessible to the policy, in the request context:

claims:
```json
{
    "userId": "marin" ,
    "expiresAt": 1982375934
}
```

```typescript
export default {
    read: (entity, ctx) => {
            if ctx.token.userId == "marin" {
                return Action.Allow;
            }
    }
}
```

Expiration of the token is verified from rust.
