### PR TITLE
tests: Create Kafka topic in test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -178,7 +178,6 @@ jobs:
           tar xf kafka_2.12-3.2.3.tgz
           ./kafka_2.12-3.2.3/bin/zookeeper-server-start.sh -daemon kafka_2.12-3.2.3/config/zookeeper.properties
           ./kafka_2.12-3.2.3/bin/kafka-server-start.sh -daemon kafka_2.12-3.2.3/config/server.properties
-          ./kafka_2.12-3.2.3/bin/kafka-topics.sh --create --topic testing --bootstrap-server localhost:9092
 
     - name: Run Kafka integration tests
       uses: actions-rs/cargo@v1

--- a/cli/tests/integration_tests/framework.rs
+++ b/cli/tests/integration_tests/framework.rs
@@ -834,6 +834,7 @@ pub struct TestContext {
     // before we try to drop the database.
     pub _db: Database,
     pub kafka_connection: Option<String>,
+    pub kafka_topics: Vec<String>,
 }
 
 impl TestContext {
@@ -852,6 +853,11 @@ impl TestContext {
     pub async fn start_chiseld(&mut self) {
         self.chiseld.start().await;
         wait_for_chiseld_startup(&mut self.chiseld, &self.chisel).await;
+    }
+
+    /// Returns a Kafka topic for this test case.
+    pub fn kafka_topic(&self, idx: usize) -> String {
+        self.kafka_topics.get(idx).unwrap().clone()
     }
 }
 

--- a/cli/tests/integration_tests/rust_tests/kafka.rs
+++ b/cli/tests/integration_tests/rust_tests/kafka.rs
@@ -30,10 +30,10 @@ pub async fn test_kafka_apply(c: TestContext) {
         .expect("Event handler defined: /dev/test-topic");
 }
 
-#[chisel_macros::test(modules = Node)]
+#[chisel_macros::test(modules = Node, kafka_topics = 1)]
 pub async fn test_kafka_consume(c: TestContext) {
-    if let Some(kafka_connection) = c.kafka_connection {
-        let kafka_topic = "testing";
+    if let Some(ref kafka_connection) = c.kafka_connection {
+        let kafka_topic = c.kafka_topic(0);
         c.chisel.write(
             "models/event.ts",
             r##"
@@ -69,7 +69,7 @@ pub async fn test_kafka_consume(c: TestContext) {
             .await
             .expect(&expected);
     
-        let client = ClientBuilder::new(vec![kafka_connection])
+        let client = ClientBuilder::new(vec![kafka_connection.to_string()])
             .build()
             .await
             .unwrap();

--- a/cli/tests/integration_tests/suite.rs
+++ b/cli/tests/integration_tests/suite.rs
@@ -19,6 +19,7 @@ pub struct TestSpec {
     pub start_chiseld: bool,
     pub test_fn: &'static (dyn TestFn + Sync),
     pub chiseld_args: &'static [&'static str],
+    pub kafka_topics: i32,
 }
 
 pub struct TestInstance {


### PR DESCRIPTION
This paves way for having multiple test cases that use their own topics
for test isolation.

Please note that the created topics are not deleted after test run
because rskafka does not support it:

https://github.com/influxdata/rskafka/issues/190