### PR TITLE
Policies: pass SourceMap to emit js

### DIFF
--- a/chiselc/src/parse.rs
+++ b/chiselc/src/parse.rs
@@ -55,7 +55,7 @@ fn canonical_transforms(module: &mut Module) {
 
 #[derive(Default)]
 pub struct ParserContext {
-    sm: Lrc<SourceMap>,
+    pub sm: Lrc<SourceMap>,
     error_buffer: ErrorBuffer,
 }
 


### PR DESCRIPTION
This fixes a bug where swc would panic when emiting code, because it is not passed the `SourceMap` that was used for parsing. This is fixed by passing to the emmiter the same `SourceMap` that was used for parsing.
