### PR TITLE
Policies: expose debug function

### DIFF
--- a/server/src/policy/debug.rs
+++ b/server/src/policy/debug.rs
@@ -1,6 +1,3 @@
-use std::fmt::Write as _;
-
-use anyhow::Result;
 use boa_engine::{prelude::JsObject, JsValue};
 use itertools::Itertools;
 
@@ -11,72 +8,57 @@ pub fn debug(
     _ctx: &mut boa_engine::Context,
 ) -> std::result::Result<JsValue, JsValue> {
     let value = &args[0];
-    let mut out = String::new();
-    write_value_to_string(value, &mut out).unwrap();
-
-    println!("{out}");
+    println!("{}", write_value_to_string(value));
     Ok(JsValue::Null)
 }
 
-fn write_value_to_string(value: &JsValue, out: &mut String) -> Result<()> {
+fn write_value_to_string(value: &JsValue) -> String {
     match value {
-        JsValue::Null => out.push_str("null"),
-        JsValue::Undefined => out.push_str("undefined"),
-        JsValue::Boolean(true) => out.push_str("true"),
-        JsValue::Boolean(false) => out.push_str("false"),
-        JsValue::String(s) => out.push_str(s.as_str()),
-        JsValue::Rational(f) => write!(out, "{f}")?,
-        JsValue::Integer(i) => write!(out, "{i}")?,
-        JsValue::BigInt(bi) => write!(out, "{bi}")?,
+        JsValue::Null => "null".to_string(),
+        JsValue::Undefined => "undefined".to_string(),
+        JsValue::Boolean(true) => "true".to_string(),
+        JsValue::Boolean(false) => "false".to_string(),
+        JsValue::String(s) => s.as_str().to_string(),
+        JsValue::Rational(f) => f.to_string(),
+        JsValue::Integer(i) => i.to_string(),
+        JsValue::BigInt(bi) => bi.to_string(),
         JsValue::Object(o) => {
             if o.is_array() {
-                write_value_array_to_string(o, out)?;
+                write_value_array_to_string(o)
             } else if o.is_function() {
-                out.push_str("<function>");
+                "<function>".to_string()
             } else {
-                write_obj_value_to_string(o, out)?;
+                write_obj_value_to_string(o)
             }
         }
-        JsValue::Symbol(s) => write!(out, "<{s}>")?,
+        JsValue::Symbol(s) => format!("<{s}>"),
     }
-
-    Ok(())
 }
 
-fn write_obj_value_to_string(o: &JsObject, out: &mut String) -> Result<()> {
-    out.push('{');
-    o.borrow()
+fn write_obj_value_to_string(o: &JsObject) -> String {
+    let content = o
+        .borrow()
         .properties()
         .string_properties()
-        .try_for_each(|(k, v)| -> Result<()> {
-            out.push_str(k.as_str());
-            out.push_str(": ");
-            let v = v.value().unwrap_or(&JsValue::Null);
-            write_value_to_string(v, out)?;
-            out.push(',');
+        .map(|(k, v)| {
+            format!(
+                "{k}: {}",
+                write_value_to_string(v.value().unwrap_or(&JsValue::Undefined))
+            )
+        })
+        .join(", ");
 
-            Ok(())
-        })?;
-    out.push('}');
-
-    Ok(())
+    format!("{{{content}}}")
 }
 
-fn write_value_array_to_string(o: &JsObject, out: &mut String) -> Result<()> {
-    out.push('[');
-    o.borrow()
+fn write_value_array_to_string(o: &JsObject) -> String {
+    let items = o
+        .borrow()
         .properties()
         .index_properties()
         .sorted_by_key(|(i, _)| *i)
-        .try_for_each(|(_, v)| -> Result<()> {
-            let v = v.value().unwrap_or(&JsValue::Null);
-            write_value_to_string(v, out)?;
-            out.push(',');
+        .map(|(_, v)| write_value_to_string(v.value().unwrap_or(&JsValue::Undefined)))
+        .join(", ");
 
-            Ok(())
-        })?;
-
-    out.push(']');
-
-    Ok(())
+    format!("[{items}]")
 }

--- a/server/src/policy/debug.rs
+++ b/server/src/policy/debug.rs
@@ -1,0 +1,82 @@
+use std::fmt::Write as _;
+
+use anyhow::Result;
+use boa_engine::{prelude::JsObject, JsValue};
+use itertools::Itertools;
+
+/// boa host function to debug values in policies
+pub fn debug(
+    _: &JsValue,
+    args: &[JsValue],
+    _ctx: &mut boa_engine::Context,
+) -> std::result::Result<JsValue, JsValue> {
+    let value = &args[0];
+    let mut out = String::new();
+    write_value_to_string(value, &mut out).unwrap();
+
+    println!("{out}");
+    Ok(JsValue::Null)
+}
+
+fn write_value_to_string(value: &JsValue, out: &mut String) -> Result<()> {
+    match value {
+        JsValue::Null => out.push_str("null"),
+        JsValue::Undefined => out.push_str("undefined"),
+        JsValue::Boolean(true) => out.push_str("true"),
+        JsValue::Boolean(false) => out.push_str("false"),
+        JsValue::String(s) => out.push_str(s.as_str()),
+        JsValue::Rational(f) => write!(out, "{f}")?,
+        JsValue::Integer(i) => write!(out, "{i}")?,
+        JsValue::BigInt(bi) => write!(out, "{bi}")?,
+        JsValue::Object(o) => {
+            if o.is_array() {
+                write_value_array_to_string(o, out)?;
+            } else if o.is_function() {
+                out.push_str("<function>");
+            } else {
+                write_obj_value_to_string(o, out)?;
+            }
+        }
+        JsValue::Symbol(s) => write!(out, "<{s}>")?,
+    }
+
+    Ok(())
+}
+
+fn write_obj_value_to_string(o: &JsObject, out: &mut String) -> Result<()> {
+    out.push('{');
+    o.borrow()
+        .properties()
+        .string_properties()
+        .try_for_each(|(k, v)| -> Result<()> {
+            out.push_str(k.as_str());
+            out.push_str(": ");
+            let v = v.value().unwrap_or(&JsValue::Null);
+            write_value_to_string(v, out)?;
+            out.push(',');
+
+            Ok(())
+        })?;
+    out.push('}');
+
+    Ok(())
+}
+
+fn write_value_array_to_string(o: &JsObject, out: &mut String) -> Result<()> {
+    out.push('[');
+    o.borrow()
+        .properties()
+        .index_properties()
+        .sorted_by_key(|(i, _)| *i)
+        .try_for_each(|(_, v)| -> Result<()> {
+            let v = v.value().unwrap_or(&JsValue::Null);
+            write_value_to_string(v, out)?;
+            out.push(',');
+
+            Ok(())
+        })?;
+
+    out.push(']');
+
+    Ok(())
+}

--- a/server/src/policy/engine.rs
+++ b/server/src/policy/engine.rs
@@ -9,6 +9,7 @@ use boa_engine::{JsString, JsValue};
 use chiselc::policies::{Cond, Environment, LogicOp, PolicyName, Predicate, Predicates, Var};
 use serde_json::Value as JsonValue;
 
+use super::debug::debug;
 use super::interpreter::{self, InterpreterContext, JsonResolver};
 use super::store::PolicyStore;
 use super::type_policy::{GeoLocPolicy, ReadPolicy, TransformPolicy, TypePolicy, WritePolicy};
@@ -78,6 +79,7 @@ impl PolicyEngine {
         let mut context = boa_engine::Context::default();
         let action = Action::js_value(&mut context)?;
         context.register_global_property("Action", action, Attribute::all());
+        context.register_global_function("debug", 0, debug);
         Ok(Self {
             boa_ctx: Rc::new(RefCell::new(context)),
             policies: Default::default(),

--- a/server/src/policy/mod.rs
+++ b/server/src/policy/mod.rs
@@ -17,6 +17,7 @@ use crate::types::ObjectType;
 use self::engine::{boa_err_to_anyhow, ChiselRequestContext, PolicyEngine};
 use self::instances::PolicyEvalInstance;
 use self::utils::{entity_map_to_js_value, js_value_to_entity_value};
+mod debug;
 pub mod engine;
 mod instances;
 mod interpreter;


### PR DESCRIPTION
This PR exposes a host function to the policy runtime to debug values.

it is called as follow:

```typescript
(entity, ctx) => {
    debug(entity);
}
```

depends on #1876 