### PR TITLE
Improve ControlFlow analysis

### DIFF
--- a/chiselc/src/tools/analysis/region.rs
+++ b/chiselc/src/tools/analysis/region.rs
@@ -235,6 +235,8 @@ impl RegionBuilder<'_> {
         (Some(region.into()), cons_end)
     }
 
+    /// In control flow analysis, leader nodes mark the boundaries of basic blocks.
+    /// see: https://en.wikipedia.org/wiki/Basic_block
     fn is_leader(&self, idx: Idx) -> bool {
         let graph = self.cfg.graph();
         // is this the first statement?
@@ -281,7 +283,7 @@ impl RegionBuilder<'_> {
 mod test {
     use std::collections::{hash_map::Entry, HashMap};
 
-    use petgraph::{dot::Dot, Graph};
+    use petgraph::Graph;
 
     use super::*;
 

--- a/chiselc/src/tools/analysis/region.rs
+++ b/chiselc/src/tools/analysis/region.rs
@@ -667,8 +667,6 @@ mod test {
 
         let cfg = parse_graph(description);
 
-        println!("{}", Dot::new(cfg.graph()));
-
         let region = Region::from_cfg(&cfg, &|idx| match idx.index() {
             0 | 1 | 2 | 3 | 5 => StmtKind::Conditional,
             _ => StmtKind::BBComponent,

--- a/chiselc/src/tools/functions.rs
+++ b/chiselc/src/tools/functions.rs
@@ -1,7 +1,12 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
 use anyhow::Result;
-use swc_ecmascript::ast::{ArrowExpr, BlockStmtOrExpr, Ident, Pat, TsEntityName, TsType};
+use petgraph::dot::Dot;
+use swc_ecmascript::ast::{
+    ArrowExpr, BlockStmtOrExpr, Decl, Ident, Pat, Stmt, TsEntityName, TsType,
+};
+
+use crate::tools::analysis::region::StmtKind;
 
 use super::analysis::control_flow::ControlFlow;
 use super::analysis::region::Region;
@@ -19,7 +24,16 @@ impl<'a> ArrowFunction<'a> {
         match &arrow.body {
             BlockStmtOrExpr::BlockStmt(block) => {
                 let (cfg, stmt_map) = ControlFlow::build(&block.stmts)?;
-                let regions = Region::from_cfg(&cfg, &stmt_map);
+                println!("{}", Dot::new(&cfg.inner));
+                let regions = Region::from_cfg(&cfg, &|idx| match stmt_map[idx].stmt {
+                    Stmt::If(_) => StmtKind::Conditional,
+                    Stmt::Block(_) => StmtKind::Ignore,
+                    Stmt::Empty(_) => StmtKind::Ignore,
+                    Stmt::Decl(Decl::Var(_)) | Stmt::Expr(_) | Stmt::Return(_) => {
+                        StmtKind::BBComponent
+                    }
+                    _ => unimplemented!(),
+                });
                 Ok(Self {
                     orig: arrow,
                     stmt_map,

--- a/chiselc/src/tools/functions.rs
+++ b/chiselc/src/tools/functions.rs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
 use anyhow::Result;
-use petgraph::dot::Dot;
 use swc_ecmascript::ast::{
     ArrowExpr, BlockStmtOrExpr, Decl, Ident, Pat, Stmt, TsEntityName, TsType,
 };
@@ -24,7 +23,6 @@ impl<'a> ArrowFunction<'a> {
         match &arrow.body {
             BlockStmtOrExpr::BlockStmt(block) => {
                 let (cfg, stmt_map) = ControlFlow::build(&block.stmts)?;
-                println!("{}", Dot::new(&cfg.inner));
                 let regions = Region::from_cfg(&cfg, &|idx| match stmt_map[idx].stmt {
                     Stmt::If(_) => StmtKind::Conditional,
                     Stmt::Block(_) => StmtKind::Ignore,


### PR DESCRIPTION
This PR makes improvements to the controlflow analysis, and particularly to the Region analysis:

- Fix a couple of bugs
- Add documentation
- Add tests
- make region building more generic for testing
- add invariant assertions
- disable loop support (it was not supported anyways, and need additional work to work properly)
