### PR TITLE
Introduce Nursery

### DIFF
--- a/api/src/kafka.ts
+++ b/api/src/kafka.ts
@@ -16,9 +16,8 @@ export class TopicMap {
         this.topics = {};
     }
 
-    async topic(topic: string, handler: EventHandler) {
+    topic(topic: string, handler: EventHandler) {
         this.topics[topic] = handler;
-        await opAsync("op_chisel_subscribe_topic", topic);
     }
 }
 

--- a/api/src/run.ts
+++ b/api/src/run.ts
@@ -33,10 +33,14 @@ export default async function run(
     specialAfter(routeMap);
     const router = new Router(routeMap);
 
+    // subscribe to all requested Kafka topics
     const topicMap = userTopicMap ?? new TopicMap();
+    for (const topic in topicMap.topics) {
+        opSync("op_chisel_subscribe_topic", topic);
+    }
 
     // signal to Rust that we are ready to handle jobs
-    Deno.core.opSync("op_chisel_ready");
+    opSync("op_chisel_ready");
 
     // register new error class
     // @ts-ignore: Dynamic property

--- a/cli/src/codegen.rs
+++ b/cli/src/codegen.rs
@@ -80,7 +80,7 @@ fn codegen_topic_map(
         // TODO: same quotation issues as above
         lines.push(format!("import eventHandler{} from {:?}", i, import));
         lines.push(format!(
-            "await topicMap.topic({:?}, eventHandler{});",
+            "topicMap.topic({:?}, eventHandler{});",
             topic.topic, i
         ));
     }

--- a/server/src/internal.rs
+++ b/server/src/internal.rs
@@ -18,10 +18,6 @@ pub(crate) fn mark_not_ready() {
     HEALTH_READY.store(400, Ordering::Relaxed);
 }
 
-pub(crate) fn is_stopping() -> bool {
-    HEALTH_READY.load(Ordering::Relaxed) == 400
-}
-
 fn response(body: &str, status: u16) -> Result<Response<Body>> {
     Ok(Response::builder()
         .status(status)

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -33,6 +33,7 @@ pub(crate) mod http;
 pub(crate) mod internal;
 pub(crate) mod kafka;
 pub(crate) mod module_loader;
+mod nursery;
 pub mod ops;
 pub(crate) mod opt;
 pub(crate) mod policies;

--- a/server/src/nursery.rs
+++ b/server/src/nursery.rs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
+
 use futures::stream::{FuturesUnordered, Stream, FusedStream};
 use guard::guard;
 use parking_lot::Mutex;
@@ -5,6 +7,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Weak};
 use std::task::{Context, Poll, Waker};
+use utils::TaskHandle;
 
 #[derive(Debug, Clone)]
 pub struct Nursery<Fut> {
@@ -42,7 +45,6 @@ impl<Fut> Nursery<Fut> {
     }
 }
 
-/*
 impl<T> Nursery<TaskHandle<T>> {
     pub fn spawn<Fut>(&self, fut: Fut)
         where Fut: Future<Output = T> + Send + 'static,
@@ -52,6 +54,7 @@ impl<T> Nursery<TaskHandle<T>> {
     }
 }
 
+/*
 impl<T> Nursery<CancellableTaskHandle<T>> {
     pub fn spawn<Fut>(&self, fut: Fut)
         where Fut: Future<Output = T> + Send + 'static,

--- a/server/src/nursery.rs
+++ b/server/src/nursery.rs
@@ -1,0 +1,91 @@
+use futures::stream::{FuturesUnordered, Stream, FusedStream};
+use guard::guard;
+use parking_lot::Mutex;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Weak};
+use std::task::{Context, Poll, Waker};
+
+#[derive(Debug, Clone)]
+pub struct Nursery<Fut> {
+    state: Arc<Mutex<NurseryState<Fut>>>,
+}
+
+#[derive(Debug)]
+pub struct NurseryStream<Fut> {
+    state: Weak<Mutex<NurseryState<Fut>>>,
+}
+
+#[derive(Debug)]
+struct NurseryState<Fut> {
+    futures: FuturesUnordered<Fut>,
+    waker: Option<Waker>,
+}
+
+impl<Fut> Nursery<Fut> {
+    pub fn new() -> (Nursery<Fut>, NurseryStream<Fut>) {
+        let state = Arc::new(Mutex::new(NurseryState {
+            futures: FuturesUnordered::new(),
+            waker: None,
+        }));
+        let stream = NurseryStream { state: Arc::downgrade(&state) };
+        let nursery = Nursery { state };
+        (nursery, stream)
+    }
+
+    pub fn nurse(&self, fut: Fut) {
+        let mut state = self.state.lock();
+        state.futures.push(fut);
+        if let Some(waker) = state.waker.take() {
+            waker.wake()
+        }
+    }
+}
+
+/*
+impl<T> Nursery<TaskHandle<T>> {
+    pub fn spawn<Fut>(&self, fut: Fut)
+        where Fut: Future<Output = T> + Send + 'static,
+              T: Send + 'static
+    {
+        self.nurse(TaskHandle(tokio::task::spawn(fut)))
+    }
+}
+
+impl<T> Nursery<CancellableTaskHandle<T>> {
+    pub fn spawn<Fut>(&self, fut: Fut)
+        where Fut: Future<Output = T> + Send + 'static,
+              T: Send + 'static
+    {
+        self.nurse(CancellableTaskHandle(tokio::task::spawn(fut)))
+    }
+}
+*/
+
+impl<Fut, T> Stream for NurseryStream<Fut>
+    where Fut: Future<Output = T>
+{
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        let this = self.get_mut();
+        guard!{let Some(state) = Weak::upgrade(&this.state) else {
+            return Poll::Ready(None);
+        }};
+
+        let mut state = state.lock();
+        if let Poll::Ready(Some(x)) = Pin::new(&mut state.futures).poll_next(cx) {
+            return Poll::Ready(Some(x));
+        }
+        state.waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+impl<Fut, T> FusedStream for NurseryStream<Fut>
+    where Fut: Future<Output = T>
+{
+    fn is_terminated(&self) -> bool {
+        self.state.strong_count() == 0
+    }
+}

--- a/server/src/ops/kafka.rs
+++ b/server/src/ops/kafka.rs
@@ -5,15 +5,10 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 #[deno_core::op]
-pub async fn op_chisel_subscribe_topic(state: Rc<RefCell<OpState>>, topic: String) -> Result<()> {
-    let kafka_service = state
-        .borrow()
-        .borrow::<WorkerState>()
-        .server
-        .kafka_service
-        .clone();
-    if let Some(kafka_service) = kafka_service {
-        kafka_service.subscribe_topic(&topic).await;
+pub fn op_chisel_subscribe_topic(op_state: Rc<RefCell<OpState>>, topic: String) -> Result<()> {
+    let server = op_state.borrow().borrow::<WorkerState>().server.clone();
+    if let Some(ref service) = server.kafka_service {
+        service.subscribe_topic(server.clone(), topic);
     }
     Ok(())
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -76,8 +76,8 @@ pub async fn run(opt: Opt) -> Result<()> {
         .await
         .context("Could not start an internal HTTP server")?;
 
-    let kafka_task = match server.opt.kafka_connection.clone() {
-        Some(_) => kafka::spawn(server.clone()).await?.fuse(),
+    let kafka_task = match server.kafka_service.clone() {
+        Some(service) => kafka::spawn(service).await?.fuse(),
         None => Fuse::terminated(),
     };
 

--- a/server/src/trunk.rs
+++ b/server/src/trunk.rs
@@ -29,7 +29,11 @@ pub struct TrunkVersion {
 
 impl Trunk {
     pub fn list_versions(&self) -> Vec<Arc<Version>> {
-        self.versions.read().values().map(|v| v.version.clone()).collect()
+        self.versions
+            .read()
+            .values()
+            .map(|v| v.version.clone())
+            .collect()
     }
 
     pub fn list_trunk_versions(&self) -> Vec<TrunkVersion> {
@@ -41,7 +45,10 @@ impl Trunk {
     }
 
     pub fn get_version(&self, version_id: &str) -> Option<Arc<Version>> {
-        self.versions.read().get(version_id).map(|v| v.version.clone())
+        self.versions
+            .read()
+            .get(version_id)
+            .map(|v| v.version.clone())
     }
 
     // Adds a new version to the trunk.
@@ -54,12 +61,15 @@ impl Trunk {
         task: CancellableTaskHandle<Result<()>>,
     ) {
         let version_id = version.version_id.clone();
-        self.versions.write().insert(version_id, TrunkVersion { version, job_tx });
+        self.versions
+            .write()
+            .insert(version_id, TrunkVersion { version, job_tx });
         self.nursery.nurse(task);
     }
 
     pub fn remove_version(&self, version_id: &str) -> Option<Arc<Version>> {
-        self.versions.write()
+        self.versions
+            .write()
             .remove(version_id)
             .map(|trunk_version| trunk_version.version)
         // if there is still a task in `self.nursery` for this version, we just leave it alone. it
@@ -74,12 +84,12 @@ pub async fn spawn() -> Result<(Trunk, TaskHandle<Result<()>>)> {
         nursery,
     };
 
-    let task = TaskHandle(tokio::task::spawn(async move  {
+    let task = TaskHandle(tokio::task::spawn(async move {
         while let Some(result) = nursery_stream.next().await {
             match result {
-                Some(Ok(_)) => {}, // task terminated successfully
+                Some(Ok(_)) => {} // task terminated successfully
                 Some(Err(err)) => return Err(err),
-                None => {}, // task was cancelled
+                None => {} // task was cancelled
             }
         }
         Ok(())


### PR DESCRIPTION
Introduce the `Nursery` to abstract away the common pattern of awaiting a dynamic set of futures. This unifies the manual polling in `Trunk` and the suboptimal code in `KafkaService`.