### PR TITLE
improve Dockerfile for project template

### DIFF
--- a/packages/create-chiselstrike-app/template/Dockerfile
+++ b/packages/create-chiselstrike-app/template/Dockerfile
@@ -10,4 +10,7 @@ RUN npm i
 
 EXPOSE 8080/tcp
 
-CMD npm run dev -- -- --api-listen-addr 0.0.0.0:8080
+# replace this with your own connection string if deploying into postgres!
+ARG DBURI="sqlite://.chiseld.db?mode=rwc"
+
+CMD npm run dev -- -- --db-uri ${DBURI} --api-listen-addr 0.0.0.0:8080


### PR DESCRIPTION
There are many platforms around where you may want to deploy ChiselStrike where there is no local volume (one real example: digital ocean). For those, we have to pass an environment variable with a connection string for an external database.

The ARG statement for Dockerfile allows us to have a default, so we can default to a local image, meaning it will still work when no arguments are passed. But this opens the door for users to use external databases more easily.