### PR TITLE
Fix `npx create-chiselstrike-app` command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ streaming platforms.
 To get a CRUD API working in 30 seconds or less, first create a new project:
 
 ```console
-npx -y create-chiselstrike-app my-app
+npx -y create-chiselstrike-app@latest my-app
 cd my-app
 ```
 


### PR DESCRIPTION
We need to specify a version; otherwise a random version cached on someones machine could be picked up.