### PR TITLE
fix(create-chiselstrike-app): ignote generated events folder

### DIFF
--- a/packages/create-chiselstrike-app/template/gitignore
+++ b/packages/create-chiselstrike-app/template/gitignore
@@ -3,3 +3,4 @@
 /.vscode
 /node_modules
 /.routegen
+/.eventgen


### PR DESCRIPTION
## Description

Ignore the `.eventgen` folder when running `create-chiselstrike-app`