### PR TITLE
Generate clients

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-          node-version: 16
+          node-version: 18
 
     - name: Install nightly rust toolchain
       uses: actions-rs/toolchain@v1
@@ -54,6 +54,9 @@ jobs:
       with:
             path: ~/.npm
             key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
+    - name: Install ts-node
+      run: npm install -g ts-node
 
     - name: Cargo config
       run: |
@@ -116,13 +119,16 @@ jobs:
     - name: Install node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Configure Node cache
       uses: actions/cache@v2
       with:
             path: ~/.npm
             key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
+    - name: Install ts-node
+      run: npm install -g ts-node
 
     - name: Cargo config
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -4510,9 +4510,9 @@ checksum = "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157"
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
  "async-compression",
  "base64",
@@ -4528,10 +4528,10 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "native-tls",
+ "once_cell",
  "percent-encoding 2.2.0",
  "pin-project-lite",
  "rustls",
@@ -5076,6 +5076,7 @@ dependencies = [
  "tonic-build",
  "tracing",
  "url 2.3.1",
+ "urlencoding",
  "utils",
  "uuid 0.8.2",
  "vergen",
@@ -7000,6 +7001,12 @@ dependencies = [
  "percent-encoding 2.2.0",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "urlpattern"

--- a/api/src/crud.ts
+++ b/api/src/crud.ts
@@ -63,6 +63,7 @@ export function crud<
 ): RouteMap {
     const createResponse = config?.createResponse ?? responseFromJson;
     const routeMap = new RouteMap();
+    const entityName = entity.name;
 
     // Returns all entities matching the filter in the `filter` URL parameter.
     async function getAll(req: ChiselRequest): Promise<Response> {
@@ -72,7 +73,7 @@ export function crud<
         );
     }
     if (config?.getAll ?? true) {
-        routeMap.get("/", getAll);
+        routeMap.route("GET", "/", getAll, { entityName });
     }
 
     // Returns a specific entity matching :id
@@ -86,7 +87,7 @@ export function crud<
         }
     }
     if (config?.getOne ?? true) {
-        routeMap.get("/:id", getOne);
+        routeMap.route("GET", "/:id", getOne, { entityName });
     }
 
     // Creates and returns a new entity from the `req` payload. Ignores the payload's id property and assigns a fresh one.
@@ -97,7 +98,7 @@ export function crud<
         return createResponse(u, 200);
     }
     if (config?.post ?? config?.write ?? true) {
-        routeMap.post("/", post);
+        routeMap.route("POST", "/", post, { entityName });
     }
 
     // Updates and returns the entity matching :id from the `req` payload.
@@ -108,7 +109,7 @@ export function crud<
         return createResponse(u, 200);
     }
     if (config?.put ?? config?.write ?? true) {
-        routeMap.put("/:id", put);
+        routeMap.route("PUT", "/:id", put, { entityName });
     }
 
     // Modifies an entity matching :id from the `req` payload.
@@ -129,7 +130,7 @@ export function crud<
         return createResponse(orig, 200);
     }
     if (config?.patch ?? config?.write ?? true) {
-        routeMap.patch("/:id", patch);
+        routeMap.route("PATCH", "/:id", patch, { entityName });
     }
 
     // Deletes all entities matching the filter in the `filter` URL parameter.
@@ -141,7 +142,7 @@ export function crud<
         );
     }
     if (config?.deleteAll ?? config?.write ?? true) {
-        routeMap.delete("/", deleteAll);
+        routeMap.route("DELETE", "/", deleteAll, { entityName });
     }
 
     // Deletes the entity matching :id
@@ -151,7 +152,7 @@ export function crud<
         return createResponse(`Deleted ID ${id}`, 200);
     }
     if (config?.deleteOne ?? config?.write ?? true) {
-        routeMap.delete("/:id", deleteOne);
+        routeMap.route("DELETE", "/:id", deleteOne, { entityName });
     }
 
     return routeMap;

--- a/api/src/datastore.ts
+++ b/api/src/datastore.ts
@@ -5,7 +5,7 @@ import { evalFilter } from "./filter.ts";
 import type { FilterExpr } from "./filter.ts";
 import type { RouteMap } from "./routing.ts";
 import { opAsync, opSync } from "./utils.ts";
-import { SimpleTypeSystem, TypeSystem } from "./type_system.ts";
+import { typeSystem } from "./type_system.ts";
 /**
  * Base class for various Operators applicable on `ChiselCursor`. An
  * implementation of Operator<T> processes an AsyncIterable<T> and
@@ -1202,10 +1202,6 @@ export const requestContext: {
     method: "",
     userId: undefined,
 };
-
-const typeSystem: TypeSystem = new TypeSystem(
-    opSync("op_chisel_get_type_system") as SimpleTypeSystem,
-);
 
 function ensureNotGet() {
     if (requestContext.method === "GET") {

--- a/api/src/type_system.ts
+++ b/api/src/type_system.ts
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
+import { opSync } from "./utils.ts";
 
 export type SimpleTypeSystem = {
     entities: Record<string, Entity>;
@@ -33,3 +34,7 @@ export class TypeSystem {
         return this.ts.entities[name];
     }
 }
+
+export const typeSystem: TypeSystem = new TypeSystem(
+    opSync("op_chisel_get_type_system") as SimpleTypeSystem,
+);

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,12 +11,14 @@ clap = { version = "4.0", features = ["derive"] }
 endpoint_tsc = { path = "../endpoint_tsc" }
 futures = "0.3.21"
 guard = "0.5"
-handlebars = "4.2.2"
-nix = "0.22.2"
-notify = "5.0.0-pre.12"
-once_cell = "1.12.0"
+handlebars = "4.3.5"
+itertools = "0.10.5"
+nix = "0.22.3"
+notify = "5.0.0"
+once_cell = "1.16.0"
 prost = "0.8.0"
 regex = "1.5.4"
+reqwest = { version = "0.11.13", features = ["blocking", "json"] }
 serde = "1.0.137"
 serde_derive = "1.0.137"
 serde_json = "1.0.81"
@@ -44,8 +46,7 @@ file-mode = "0.1.2"
 fs_extra = "1.2.0"
 futures = "0.3"
 glob = "0.3.0"
-inventory = "0.3.1"
-itertools = "0.10.3"
+inventory = "0.3.2"
 lazy_static = "1.4"
 lit = { git = "https://github.com/chiselstrike/lit", rev = "607b0b9" }
 num_cpus = "1.13"
@@ -53,7 +54,6 @@ port_scanner = "0.1.5"
 rand = { version = "0.8.5", features = ["alloc"] }
 rayon = "1.5.1"
 regex = "1.6.0"
-reqwest = { version = "0.11.11", features = ["blocking", "json"] }
 rskafka = "0.3.0"
 server = { path = "../server" }
 strip-ansi-escapes = "0.1.1"

--- a/cli/src/cmd/generate.rs
+++ b/cli/src/cmd/generate.rs
@@ -1,53 +1,452 @@
 use crate::proto::chisel_rpc_client::ChiselRpcClient;
 use crate::proto::{type_msg::TypeEnum, DescribeRequest};
-use anyhow::{anyhow, Result};
+use crate::proto::{FieldDefinition, TypeDefinition, TypeMsg, VersionDefinition};
+
+use anyhow::{anyhow, Context, Result};
+use serde::Deserialize;
+use serde_json::json;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
+use tokio::fs::create_dir_all;
 
-pub(crate) async fn cmd_generate(
-    server_url: String,
-    output: PathBuf,
-    version: String,
-) -> Result<()> {
-    let output = File::create(output)?;
-    let mut client = ChiselRpcClient::connect(server_url).await?;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Mode {
+    Node,
+    Deno,
+}
+
+#[derive(Debug)]
+pub struct Opts {
+    pub server_url: String,
+    pub api_addres: String,
+    pub output_dir: PathBuf,
+    pub version: String,
+    pub mode: Mode,
+}
+
+pub(crate) async fn cmd_generate(opts: Opts) -> Result<()> {
+    create_dir_all(&opts.output_dir)
+        .await
+        .context("failed to create directory for generated client files")?;
+
+    let mut client = ChiselRpcClient::connect(opts.server_url.to_owned()).await?;
     let request = tonic::Request::new(DescribeRequest {});
     let response = execute!(client.describe(request).await);
     let version_def = response
         .version_defs
         .iter()
-        .find(|def| def.version_id == version);
-    if let Some(version_def) = version_def {
-        for def in &version_def.type_defs {
-            writeln!(&output, "export type {} = {{", def.name)?;
-            writeln!(&output, "    id: string;")?;
-            for field in &def.field_defs {
-                let field_type = field.field_type()?;
-                writeln!(
-                    &output,
-                    "    {}{}: {}{};",
-                    field.name,
-                    if field.is_optional { "?" } else { "" },
-                    field_type,
-                    field
-                        .default_value
-                        .as_ref()
-                        .map(|d| if matches!(field_type, TypeEnum::String(_)) {
-                            format!(r#" = "{}""#, d)
-                        } else {
-                            format!(" = {}", d)
-                        })
-                        .unwrap_or_else(|| "".into()),
-                )?;
-            }
-            writeln!(&output, "}}")?;
+        .find(|def| def.version_id == opts.version)
+        .context(anyhow!(
+            "can't generate client with an unknown version '{:?}'",
+            opts.version
+        ))?;
+
+    let mut models_file = File::create(opts.output_dir.join("models.ts"))?;
+    write_models(&mut models_file, version_def)?;
+
+    let mut reflection_file = File::create(opts.output_dir.join("reflection.ts"))?;
+    write_reflection(&mut reflection_file, version_def)?;
+
+    let routes = get_routing_info(&opts.api_addres, &opts.version).await?;
+    let mut client_file = File::create(opts.output_dir.join("client.ts"))?;
+    write_routing_client(&mut client_file, &routes, &opts)?;
+
+    let mut client_lib_file = File::create(opts.output_dir.join("client_lib.ts"))?;
+    write_client_lib(&mut client_lib_file, &opts)?;
+
+    let mut filter_file = File::create(opts.output_dir.join("filter.ts"))?;
+    write!(
+        filter_file,
+        "{}",
+        include_str!("../../../api/src/filter.ts")
+    )?;
+
+    Ok(())
+}
+
+fn write_models(output: &mut File, version_def: &VersionDefinition) -> Result<()> {
+    for def in &version_def.type_defs {
+        writeln!(output, "export type {} = {{", def.name)?;
+        writeln!(output, "    id: string;")?;
+        for field in &def.field_defs {
+            let field_type = field.field_type()?;
+            writeln!(
+                output,
+                "    {}{}: {};",
+                field.name,
+                if field.is_optional { "?" } else { "" },
+                field_type
+            )?;
+        }
+        writeln!(output, "}}")?;
+    }
+    Ok(())
+}
+
+fn write_reflection(output: &mut File, version_def: &VersionDefinition) -> Result<()> {
+    write!(output, "{}", include_str!("generate_src/reflection.ts"))?;
+
+    let entites: HashMap<String, TypeDefinition> = HashMap::from_iter(
+        version_def
+            .type_defs
+            .iter()
+            .map(|ty| (ty.name.to_owned(), ty.clone())),
+    );
+
+    for entity_name in entites.keys() {
+        writeln!(
+            output,
+            "export const Ω{}: Entity = {}",
+            entity_name,
+            make_entity_type_obj(&entites, entity_name)?
+        )?;
+    }
+    Ok(())
+}
+
+fn make_entity_type_obj(
+    entities: &HashMap<String, TypeDefinition>,
+    entity_name: &str,
+) -> Result<serde_json::Value> {
+    let entity = entities.get(entity_name).context(anyhow!(
+        "trying to generate entity object from an unknown entity name '{entity_name:?}'"
+    ))?;
+
+    let fields: Vec<_> = entity
+        .field_defs
+        .iter()
+        .map(|field| make_field_obj(entities, field))
+        .collect::<Result<_>>()?;
+
+    Ok(json!({
+        "name": entity_name,
+        "fields": fields
+    }))
+}
+
+fn make_field_obj(
+    entities: &HashMap<String, TypeDefinition>,
+    field: &FieldDefinition,
+) -> Result<serde_json::Value> {
+    let field_type = field
+        .field_type
+        .as_ref()
+        .context("field doesn't have type")?;
+    let type_obj = type_to_obj(entities, field_type)?;
+    Ok(json!({
+        "name": field.name,
+        "type": type_obj,
+        "isOptional": field.is_optional,
+        "isUnique": field.is_unique
+    }))
+}
+
+fn type_to_obj(
+    entities: &HashMap<String, TypeDefinition>,
+    ty: &TypeMsg,
+) -> Result<serde_json::Value> {
+    let type_enum = ty
+        .type_enum
+        .as_ref()
+        .context("field doesn't have type_enum")?;
+    let type_ojbect = match &type_enum {
+        TypeEnum::ArrayBuffer(_) => json!({"name": "arrayBuffer"}),
+        TypeEnum::Bool(_) => json!({"name": "boolean"}),
+        TypeEnum::JsDate(_) => json!({"name": "date"}),
+        TypeEnum::Number(_) => json!({"name": "number"}),
+        TypeEnum::String(_) => json!({"name": "string"}),
+        TypeEnum::EntityId(entity_name) => json!({
+            "name": "entityId",
+            "entityName": entity_name
+        }),
+        TypeEnum::Array(container) => {
+            let element_type = &container
+                .value_type
+                .as_ref()
+                .context("container has no value")?;
+            json!({
+                "name": "array",
+                "elementType": type_to_obj(entities, element_type)?
+            })
+        }
+        TypeEnum::Entity(entity_name) => {
+            json!({
+                "name": "entity",
+                "entityType": make_entity_type_obj(entities, entity_name)?
+            })
+        }
+    };
+    Ok(type_ojbect)
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all(deserialize = "UPPERCASE"))]
+enum HttpMethod {
+    Options,
+    Get,
+    Post,
+    Put,
+    Delete,
+    Head,
+    Trace,
+    Connect,
+    Patch,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClientMetadata {
+    handler: HandlerKind,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RouteInfo {
+    methods: Vec<HttpMethod>,
+    path_pattern: String,
+    client_metadata: Option<ClientMetadata>,
+}
+
+async fn get_routing_info(api_listen_addr: &str, version: &str) -> Result<Vec<RouteInfo>> {
+    let chisel_url = reqwest::Url::parse(&format!("http://{}", api_listen_addr))?;
+    let url = chisel_url.join(&format!("/{version}/__chiselstrike/routes"))?;
+    Ok(reqwest::get(url).await?.json().await?)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", content = "handler")]
+enum HandlerKind {
+    Crud(CrudHandler),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", content = "entityName")]
+enum CrudHandler {
+    GetOne(String),
+    GetMany(String),
+    PutOne(String),
+    PostOne(String),
+    PatchOne(String),
+    DeleteOne(String),
+    DeleteMany(String),
+}
+
+#[derive(Debug)]
+struct RouteHandler {
+    _method: HttpMethod,
+    kind: HandlerKind,
+}
+
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+enum RouteSegment {
+    FixedText(String),
+    Wildcard(String),
+}
+
+#[derive(Debug)]
+struct SubRoute {
+    handlers: Vec<RouteHandler>,
+    children: HashMap<RouteSegment, SubRoute>,
+}
+
+impl SubRoute {
+    fn new() -> Self {
+        Self {
+            handlers: vec![],
+            children: Default::default(),
         }
     }
-    writeln!(&output, "export type Results<T> = {{")?;
-    writeln!(&output, "    next_page: string;")?;
-    writeln!(&output, "    prev_page: string;")?;
-    writeln!(&output, "    results: T[];")?;
-    writeln!(&output, "}}")?;
+    fn add_route(&mut self, route: &str, handler: RouteHandler) {
+        let route_segments: Vec<_> = route
+            .trim()
+            .trim_start_matches('/')
+            .trim_end_matches('/')
+            .split('/')
+            .collect();
+        self.add_route_rec(&route_segments, handler);
+    }
+
+    fn add_route_rec(&mut self, segments: &[&str], handler: RouteHandler) {
+        if segments.is_empty() {
+            self.handlers.push(handler);
+        } else {
+            let segment_str = segments[0];
+            let sub_segments = &segments[1..];
+            let segment = Self::make_segment(segment_str);
+
+            if let Some(child) = self.children.get_mut(&segment) {
+                child.add_route_rec(sub_segments, handler);
+            } else {
+                let mut subroute = SubRoute::new();
+                subroute.add_route_rec(sub_segments, handler);
+                self.children.insert(segment, subroute);
+            }
+        }
+    }
+
+    fn make_segment(segment_str: &str) -> RouteSegment {
+        if segment_str.starts_with(':') {
+            RouteSegment::Wildcard(segment_str.to_owned())
+        } else {
+            RouteSegment::FixedText(segment_str.to_owned())
+        }
+    }
+}
+
+fn path_join(p1: &str, p2: &str) -> String {
+    format!(
+        "{}/{}",
+        p1.trim_end_matches('/'),
+        p2.trim_start_matches('/')
+    )
+}
+
+fn build_routing(routes: &Vec<RouteInfo>) -> Result<SubRoute> {
+    let mut root = SubRoute::new();
+
+    for route in routes {
+        let methods = &route.methods;
+        if let Some(meta) = &route.client_metadata {
+            anyhow::ensure!(
+                methods.len() == 1,
+                "the number of allowed route methods must be one"
+            );
+            root.add_route(
+                &route.path_pattern,
+                RouteHandler {
+                    _method: methods[0].clone(),
+                    kind: meta.handler.clone(),
+                },
+            );
+        }
+    }
+    Ok(root)
+}
+
+fn handler_to_ts(handler: &RouteHandler, url: &str) -> Vec<String> {
+    let HandlerKind::Crud(crud_handler) = &handler.kind;
+    match &crud_handler {
+        CrudHandler::DeleteMany(entity_name) => {
+            vec![format!(
+                "delete: Ωlib.makeDeleteMany<Ωmodels.{entity_name}>(Ωurl(`{url}`))"
+            )]
+        }
+        CrudHandler::DeleteOne(_) => vec![format!("delete: Ωlib.makeDeleteOne(Ωurl(`{url}`))")],
+        CrudHandler::GetMany(entity_name) => {
+            vec![format!(
+                "get: Ωlib.makeGetMany<Ωmodels.{entity_name}>(Ωurl(`{url}`), ΩserverUrl, Ωreflection.Ω{entity_name})"
+            ), format!(
+                "getIter: Ωlib.makeGetManyIter<Ωmodels.{entity_name}>(Ωurl(`{url}`), ΩserverUrl, Ωreflection.Ω{entity_name})"
+            ), format!(
+                "getAll: Ωlib.makeGetAll<Ωmodels.{entity_name}>(Ωurl(`{url}`), ΩserverUrl, Ωreflection.Ω{entity_name})"
+            )]
+        }
+        CrudHandler::GetOne(entity_name) => {
+            vec![format!(
+                "get: Ωlib.makeGetOne<Ωmodels.{entity_name}>(Ωurl(`{url}`), Ωreflection.Ω{entity_name})"
+            )]
+        }
+        CrudHandler::PatchOne(entity_name) => {
+            vec![format!(
+                "patch: Ωlib.makePatchOne<Ωmodels.{entity_name}>(Ωurl(`{url}`), Ωreflection.Ω{entity_name})"
+            )]
+        }
+        CrudHandler::PostOne(entity_name) => {
+            vec![format!(
+                "post: Ωlib.makePostOne<Ωmodels.{entity_name}>(Ωurl(`{url}`), Ωreflection.Ω{entity_name})"
+            )]
+        }
+        CrudHandler::PutOne(entity_name) => {
+            vec![format!(
+                "put: Ωlib.makePutOne<Ωmodels.{entity_name}>(Ωurl(`{url}`), Ωreflection.Ω{entity_name})"
+            )]
+        }
+    }
+}
+
+fn generate_routing_obj(route: &SubRoute, url_prefix: &str) -> Result<String> {
+    let mut handlers: Vec<_> = route
+        .handlers
+        .iter()
+        .flat_map(|h| handler_to_ts(h, url_prefix))
+        .collect();
+
+    for (segment, subroute) in &route.children {
+        let handler = match segment {
+            RouteSegment::FixedText(segment) => format!(
+                "{segment}: {}",
+                generate_routing_obj(subroute, &path_join(url_prefix, segment))?
+            ),
+            RouteSegment::Wildcard(segment) => {
+                let group_name = segment.trim_start_matches(':');
+                let url_path = path_join(url_prefix, &format!("${{{group_name}}}"));
+                format!(
+                    "{group_name}: ({group_name}: string) => {{ return {}; }}",
+                    generate_routing_obj(subroute, &url_path)?
+                )
+            }
+        };
+        handlers.push(handler);
+    }
+    Ok(format!("{{{}}}\n", handlers.join(",\n")))
+}
+
+fn write_routing_client(output: &mut File, routes: &Vec<RouteInfo>, opts: &Opts) -> Result<()> {
+    let imports = match opts.mode {
+        Mode::Deno => {
+            r#"
+                import * as Ωlib from "./client_lib.ts";
+                import * as Ωmodels from "./models.ts";
+                import * as Ωreflection from "./reflection.ts";
+            "#
+        }
+        Mode::Node => {
+            r#"
+                import * as Ωlib from "./client_lib";
+                import * as Ωmodels from "./models";
+                import * as Ωreflection from "./reflection";
+            "#
+        }
+    };
+    write!(output, "{}", &imports)?;
+    write!(output, "{}", include_str!("generate_src/client.ts"))?;
+    let root = build_routing(routes)?;
+
+    writeln!(
+        output,
+        r#"
+            function ΩcreateClient(ΩserverUrl: string, ΩuserVersion?: string) {{
+                const Ωversion = ΩuserVersion ?? '{}';
+                const Ωurl = (url: string) => {{
+                    return Ωlib.urlJoin(ΩserverUrl, Ωversion, url);
+                }};
+                return {};
+            }}
+        "#,
+        opts.version,
+        generate_routing_obj(&root, "")?
+    )?;
+
+    Ok(())
+}
+
+fn write_client_lib(output: &mut File, opts: &Opts) -> Result<()> {
+    let imports = match opts.mode {
+        Mode::Deno => {
+            r#"
+            import { type FilterExpr } from "./filter.ts";
+            import * as reflect from "./reflection.ts";
+        "#
+        }
+        Mode::Node => {
+            r#"
+            import { type FilterExpr } from "./filter";
+            import * as reflect from "./reflection";
+        "#
+        }
+    };
+    write!(output, "{}", &imports)?;
+    write!(output, "{}", include_str!("generate_src/client_lib.ts"))?;
     Ok(())
 }

--- a/cli/src/cmd/generate_src/client.ts
+++ b/cli/src/cmd/generate_src/client.ts
@@ -1,0 +1,3 @@
+export function createChiselClient(serverUrl: string, version?: string) {
+    return ΩcreateClient(serverUrl, version);
+}

--- a/cli/src/cmd/generate_src/client_lib.ts
+++ b/cli/src/cmd/generate_src/client_lib.ts
@@ -1,0 +1,431 @@
+export function urlJoin(...urlParts: string[]): URL {
+    let url = urlParts[0] || "";
+    for (let i = 1; i < urlParts.length; i++) {
+        const part = urlParts[i];
+        if (!url.endsWith("/")) {
+            url += "/";
+        }
+        if (part.startsWith("/")) {
+            url += part.slice(1);
+        } else {
+            url += part;
+        }
+    }
+    return new URL(url);
+}
+
+async function throwOnError(resp: Response) {
+    if (!resp.ok) {
+        // TODO: Improve error handling
+        throw Error(
+            `failed to post an entity. Got error code ${resp.status} (${resp.statusText}) with message: '${await resp
+                .text}'`,
+        );
+    }
+}
+
+async function sendJson(
+    url: URL,
+    method: string,
+    body: unknown,
+): Promise<Response> {
+    const resp = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+    await throwOnError(resp);
+    return resp;
+}
+
+function jsonToEntity<Entity>(
+    entityType: reflect.Entity,
+    inputValue: Record<string, unknown>,
+): Entity {
+    const entityValue: Record<string, unknown> = {};
+    const entityName = entityType.name;
+    for (const field of entityType.fields) {
+        if (!(field.name in inputValue)) {
+            continue;
+        }
+        const fieldName = field.name;
+        const fieldValue = inputValue[fieldName];
+
+        if (fieldValue === null || fieldValue === undefined) {
+            if (field.isOptional) {
+                entityValue[fieldName] = undefined;
+                continue;
+            } else {
+                throw new Error(
+                    `field ${fieldName} of entity ${entityName} is not optional but undefined/null was received for the field`,
+                );
+            }
+        }
+
+        const err = (typeName: string) => {
+            return Error(
+                `field ${field.name} of entity ${entityName} is ${typeName}, but provided value is of type ${typeof fieldValue}`,
+            );
+        };
+        const fieldType = field.type.name;
+        if (fieldType === "string" || fieldType === "entityId") {
+            if (typeof fieldValue !== "string") {
+                throw err("string");
+            }
+            entityValue[fieldName] = fieldValue;
+        } else if (fieldType === "number") {
+            if (typeof fieldValue !== "number") {
+                throw err("number");
+            }
+            entityValue[fieldName] = fieldValue;
+        } else if (fieldType === "boolean") {
+            if (typeof fieldValue !== "boolean") {
+                throw err("boolean");
+            }
+            entityValue[fieldName] = fieldValue;
+        } else if (fieldType === "arrayBuffer") {
+            entityValue[fieldName] = convertArrayBuffer(
+                entityName,
+                fieldName,
+                fieldValue,
+            );
+        } else if (fieldType === "date") {
+            entityValue[fieldName] = convertDate(
+                entityName,
+                fieldName,
+                fieldValue,
+            );
+        } else if (fieldType === "array") {
+            entityValue[fieldName] = convertArray(
+                entityName,
+                fieldName,
+                field.type.elementType,
+                fieldValue,
+            );
+        } else if (fieldType === "entity") {
+            entityValue[fieldName] = convertEntity(
+                entityName,
+                fieldName,
+                field.type.entityType,
+                fieldValue,
+            );
+        } else {
+            assertNever(fieldType);
+            throw new Error(
+                `field '${fieldName}' of entity '${entityName}' has unexpected type '${fieldType}'`,
+            );
+        }
+    }
+    return entityValue as unknown as Entity;
+}
+
+function convertDate(
+    entityName: string,
+    fieldName: string,
+    value: unknown,
+): Date {
+    if (typeof value === "string" || typeof value === "number") {
+        const date = new Date(value);
+        if (Number.isNaN(date.valueOf())) {
+            throw new Error(
+                `failed to convert value to Date for field ${fieldName}`,
+            );
+        }
+        return date;
+    }
+    throw new Error(
+        `field ${fieldName} of entity ${entityName} is Date, but received value is not an instance of string nor number`,
+    );
+}
+
+function convertArrayBuffer(
+    entityName: string,
+    fieldName: string,
+    value: unknown,
+): ArrayBuffer {
+    if (typeof value === "string") {
+        return Uint8Array.from(
+            atob(value),
+            (c) => c.charCodeAt(0),
+        );
+    } else {
+        throw Error(
+            `field ${fieldName} of entity ${entityName} is ArrayBuffer (transported as string), but received value is of type ${typeof value}`,
+        );
+    }
+}
+
+function convertArray(
+    entityName: string,
+    fieldName: string,
+    elementType: reflect.Type,
+    arrayValue: unknown,
+): unknown[] {
+    if (Array.isArray(arrayValue)) {
+        const elementTypeName = elementType.name;
+        switch (elementTypeName) {
+            case "string":
+            case "number":
+            case "boolean":
+            case "entityId":
+                return arrayValue;
+            case "date":
+                return arrayValue.map((e) =>
+                    convertDate(entityName, fieldName, e)
+                );
+            case "arrayBuffer":
+                return arrayValue.map((e) =>
+                    convertArrayBuffer(entityName, fieldName, e)
+                );
+            case "array":
+                return arrayValue.map((e) =>
+                    convertArray(
+                        entityName,
+                        fieldName,
+                        elementType.elementType,
+                        e,
+                    )
+                );
+            case "entity":
+                return arrayValue.map((e) =>
+                    convertEntity(
+                        entityName,
+                        fieldName,
+                        elementType.entityType,
+                        e,
+                    )
+                );
+            default:
+                assertNever(elementTypeName);
+                throw new Error(
+                    `field '${fieldName}' of entity '${entityName}' has unexpected array element type '${elementTypeName}'`,
+                );
+        }
+    } else {
+        throw new Error(
+            `expected Array, but received value is not an instance of Array`,
+        );
+    }
+}
+
+function convertEntity(
+    entityName: string,
+    fieldName: string,
+    entityType: reflect.Entity,
+    entityValue: unknown,
+): unknown {
+    if (typeof entityValue === "object") {
+        type RecordType = Record<string, unknown>;
+        return jsonToEntity<unknown>(
+            entityType,
+            entityValue as RecordType,
+        );
+    } else {
+        throw new Error(
+            `field ${fieldName} of entity ${entityName} is Entity, but received value is not an object`,
+        );
+    }
+}
+
+function assertNever(x: never): never {
+    return x;
+}
+
+export function makeGetOne<Entity>(
+    url: URL,
+    entityType: reflect.Entity,
+): () => Promise<Entity> {
+    return async () => {
+        const resp = await fetch(url, { method: "GET" });
+        await throwOnError(resp);
+        return jsonToEntity<Entity>(entityType, await resp.json());
+    };
+}
+
+export type GetParams<Entity> = {
+    pageSize?: number;
+    offset?: number;
+    filter?: FilterExpr<Entity>;
+};
+
+export type GetResponse<Entity> = {
+    nextPage?: () => Promise<GetResponse<Entity>>;
+    nextPageUrl?: string;
+    prevPage?: () => Promise<GetResponse<Entity>>;
+    prevPageUrl?: string;
+    results: Entity[];
+};
+
+export function makeGetMany<Entity>(
+    origUrl: URL,
+    serverUrl: string,
+    entityType: reflect.Entity,
+): (params: GetParams<Entity>) => Promise<GetResponse<Entity>> {
+    return async function (
+        params: GetParams<Entity>,
+    ): Promise<GetResponse<Entity>> {
+        // We need to make a copy every time so that the original doesn't get
+        // modified when paging.
+        const url = new URL(origUrl);
+        if (params.pageSize !== undefined) {
+            url.searchParams.set("page_size", params.pageSize.toString());
+        }
+        if (params.offset !== undefined) {
+            url.searchParams.set("offset", params.offset.toString());
+        }
+        if (params.filter !== undefined) {
+            const encodedFilter = JSON.stringify(params.filter);
+            url.searchParams.set("filter", encodedFilter);
+        }
+
+        async function makeResponse(url: URL): Promise<GetResponse<Entity>> {
+            const r = await fetch(url, { method: "GET" });
+            await throwOnError(r);
+
+            type PagingResponse = {
+                next_page?: string;
+                prev_page?: string;
+                results: Record<string, unknown>[];
+            };
+            const resp: PagingResponse = await r.json();
+
+            let nextPage = undefined;
+            let prevPage = undefined;
+            if (resp.next_page !== undefined) {
+                nextPage = () => {
+                    return makeResponse(new URL(resp.next_page!, serverUrl));
+                };
+            }
+            if (resp.prev_page !== undefined) {
+                prevPage = () => {
+                    return makeResponse(new URL(resp.prev_page!, serverUrl));
+                };
+            }
+            return {
+                nextPage,
+                nextPageUrl: resp.next_page,
+                prevPage,
+                prevPageUrl: resp.prev_page,
+                results: resp.results.map((e) =>
+                    jsonToEntity<Entity>(entityType, e)
+                ),
+            };
+        }
+        return await makeResponse(url);
+    };
+}
+
+export function makeGetManyIter<Entity>(
+    origUrl: URL,
+    serverUrl: string,
+    entityType: reflect.Entity,
+): (params?: GetParams<Entity>) => AsyncIterable<Entity> {
+    const getPage = makeGetMany<Entity>(origUrl, serverUrl, entityType);
+    return function (params?: GetParams<Entity>): AsyncIterable<Entity> {
+        return {
+            [Symbol.asyncIterator]: async function* () {
+                let page = await getPage(params ?? {});
+                while (true) {
+                    for (const e of page.results) {
+                        yield e;
+                    }
+                    if (page.nextPage !== undefined) {
+                        page = await page.nextPage();
+                    } else {
+                        break;
+                    }
+                }
+            },
+        };
+    };
+}
+
+export type GetAllParams<Entity> = {
+    limit?: number;
+    offset?: number;
+    filter?: FilterExpr<Entity>;
+};
+
+export function makeGetAll<Entity>(
+    origUrl: URL,
+    serverUrl: string,
+    entityType: reflect.Entity,
+): (params?: GetParams<Entity>) => Promise<Entity[]> {
+    const makeIter = makeGetManyIter<Entity>(origUrl, serverUrl, entityType);
+    return async function (params?: GetAllParams<Entity>): Promise<Entity[]> {
+        let iterParams = {};
+        let limit;
+        if (params !== undefined) {
+            iterParams = {
+                offset: params.offset,
+                filter: params.filter,
+            };
+            limit = params.limit;
+        }
+        const iter = makeIter(iterParams);
+        const arr = [];
+        for await (const e of iter) {
+            if (limit !== undefined && limit <= arr.length) {
+                break;
+            }
+            if (arr.length === 100000) {
+                console.warn(
+                    `Retrieving more than 100k elements using getAll endpoint (url '${origUrl}'). For performance reasons, please consider using '.getIter' or stricter FilterExpr object.`,
+                );
+            }
+            arr.push(e);
+        }
+        return arr;
+    };
+}
+
+export function makePostOne<Entity>(
+    url: URL,
+    entityType: reflect.Entity,
+): (entity: Omit<Entity, "id">) => Promise<Entity> {
+    return async (entity: Omit<Entity, "id">) => {
+        // TODO: We should probably do the inverse of jsonToEntity.
+        const resp = await sendJson(url, "POST", entity);
+        await throwOnError(resp);
+        return jsonToEntity<Entity>(entityType, await resp.json());
+    };
+}
+
+export function makePutOne<Entity>(
+    url: URL,
+    entityType: reflect.Entity,
+): (entity: Entity) => Promise<Entity> {
+    return async (entity: Entity) => {
+        const resp = await sendJson(url, "PUT", entity);
+        await throwOnError(resp);
+        return jsonToEntity<Entity>(entityType, await resp.json());
+    };
+}
+
+export function makePatchOne<Entity>(
+    url: URL,
+    entityType: reflect.Entity,
+): (entity: Partial<Entity>) => Promise<Entity> {
+    return async (entity: Partial<Entity>) => {
+        const resp = await sendJson(url, "PATCH", entity);
+        await throwOnError(resp);
+        return jsonToEntity<Entity>(entityType, await resp.json());
+    };
+}
+
+export function makeDeleteOne(url: URL): () => Promise<void> {
+    return async () => {
+        const resp = await fetch(url, { method: "DELETE" });
+        await throwOnError(resp);
+    };
+}
+
+export function makeDeleteMany<Entity>(
+    url: URL,
+): (filter: FilterExpr<Entity>) => Promise<void> {
+    return async (filter: FilterExpr<Entity>) => {
+        url.searchParams.set("filter", JSON.stringify(filter));
+        const resp = await fetch(url, { method: "DELETE" });
+        await throwOnError(resp);
+    };
+}

--- a/cli/src/cmd/generate_src/reflection.ts
+++ b/cli/src/cmd/generate_src/reflection.ts
@@ -1,0 +1,21 @@
+export type Type =
+    | { name: "string" }
+    | { name: "number" }
+    | { name: "boolean" }
+    | { name: "date" }
+    | { name: "arrayBuffer" }
+    | { name: "array"; elementType: Type }
+    | { name: "entity"; entityType: Entity }
+    | { name: "entityId"; entityName: string };
+
+export type Field = {
+    name: string;
+    type: Type;
+    isOptional: boolean;
+    isUnique: boolean;
+};
+
+export type Entity = {
+    name: string;
+    fields: Field[];
+};

--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -1,13 +1,17 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
+use once_cell::sync::Lazy;
+use regex::Regex;
 use std::env;
 use std::ffi::OsString;
+use std::fs::create_dir_all;
+use std::fs::File;
+use std::io::Read;
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use std::process;
 use std::sync::atomic::{AtomicU16, Ordering};
-
-use once_cell::sync::Lazy;
+use toml::Value;
 
 pub static CHISEL_BIN_DIR: Lazy<PathBuf> = Lazy::new(|| repo_dir().join(".chisel_dev"));
 pub static CHISEL_LOCAL_PATH: Lazy<OsString> = Lazy::new(|| {
@@ -110,4 +114,60 @@ pub fn get_free_port(ports_counter: &AtomicU16) -> u16 {
         }
     }
     panic!("failed to find free port in 10000 iterations");
+}
+
+#[allow(dead_code)]
+pub fn cargo<'a, T: IntoIterator<Item = &'a str>>(args: T) -> Command {
+    run("cargo", args)
+}
+
+#[allow(dead_code)]
+pub fn nightly<'a, T: IntoIterator<Item = &'a str>>(args: T) -> Command {
+    let mut ret = cargo(itertools::chain(["+nightly-2022-08-29"], args));
+    ret.env("CARGO_TARGET_DIR", "./target/nightly");
+    ret
+}
+
+#[allow(dead_code)]
+pub fn cargo_install(version: &str, pkg: &str, bin: &str) {
+    ensure_correct_version(pkg, version);
+    create_dir_all(&*CHISEL_BIN_DIR).unwrap();
+    cargo([
+        "install",
+        "--version",
+        version,
+        pkg,
+        "--bin",
+        bin,
+        "--locked",
+        "--root",
+        &CHISEL_BIN_DIR.display().to_string(),
+    ]);
+}
+
+#[allow(dead_code)]
+pub fn ensure_correct_version(pkg: &str, version: &str) {
+    let re = Regex::new(&format!(r"{pkg} v{version}:")).unwrap();
+    let mut cmd = cargo(["install", "--list"]);
+    let out = cmd.inner.output().unwrap();
+
+    let stdout = std::str::from_utf8(&out.stdout).unwrap();
+
+    // only accept global package if it's the correct version.
+    assert!(
+        re.is_match(stdout) || !stdout.contains(pkg),
+        "An incorrect version of {pkg} is present in the global environment. Please uninstall it."
+    );
+}
+
+#[allow(dead_code)]
+pub fn get_deno_version() -> String {
+    let mut f = File::open(repo_dir().join("third_party/deno/cli/Cargo.toml")).unwrap();
+    let mut s = String::new();
+    f.read_to_string(&mut s).unwrap();
+    let doc = s.parse::<Value>().unwrap();
+    if let Value::String(v) = &doc["package"]["version"] {
+        return v.clone();
+    }
+    panic!("Could not find the deno version");
 }

--- a/cli/tests/integration_tests/rust_tests/crud.rs
+++ b/cli/tests/integration_tests/rust_tests/crud.rs
@@ -97,7 +97,6 @@ pub async fn basic(c: TestContext) {
     c.chisel.write("models/person.ts", PERSON_MODEL);
     c.chisel.write("routes/people.ts", PEOPLE_CRUD);
     c.chisel.apply_ok().await;
-
     assert_eq!(
         c.chisel.get_json("/dev/people").await,
         json!({"results": []})

--- a/cli/tests/integration_tests/rust_tests/generate_client.rs
+++ b/cli/tests/integration_tests/rust_tests/generate_client.rs
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
+
+use std::collections::HashMap;
+
+use crate::framework::prelude::*;
+use crate::framework::Chisel;
+
+static PERSON_MODEL: &str = r#"
+    import { ChiselEntity } from "@chiselstrike/api";
+
+    export class Person extends ChiselEntity {
+        firstName: string = "";
+        lastName: string = "";
+        age: number = 0;
+        human: boolean = false;
+        height: number = 1;
+    }
+"#;
+
+static PEOPLE_CRUD: &str = r#"
+    import { Person } from "../models/person.ts";
+    export default Person.crud();
+"#;
+
+async fn store_person(chisel: &Chisel, p: serde_json::Value) -> String {
+    let r = chisel.post("dev/people").json(p).send().await.json();
+    let id = r["id"].as_str().unwrap();
+    id.to_owned()
+}
+
+async fn store_people(chisel: &Chisel) -> HashMap<String, String> {
+    let glauber_id = store_person(
+        chisel,
+        json!({
+            "firstName":"Glauber",
+            "lastName":"Costa",
+            "age": 666,
+            "human": true,
+            "height": 10.01
+        }),
+    )
+    .await;
+    let jan_id = store_person(
+        chisel,
+        json!({
+            "firstName":"Jan",
+            "lastName":"Plhak",
+            "age": -666,
+            "human": true,
+            "height": 10.02
+        }),
+    )
+    .await;
+    let pekka_id = store_person(
+        chisel,
+        json!({
+            "firstName":"Pekka",
+            "lastName":"Enberg",
+            "age": 888,
+            "human": false,
+            "height": 12.2
+        }),
+    )
+    .await;
+    HashMap::from([
+        ("glauber".to_owned(), glauber_id),
+        ("jan".to_owned(), jan_id),
+        ("pekka".to_owned(), pekka_id),
+    ])
+}
+
+fn with_client(c: &TestContext, src: &str) -> String {
+    let common_funs = r#"
+        async function iterToArray<T>(iterable: AsyncIterable<T>): Promise<T[]> {{
+            const arr = [];
+            for await (const e of iterable) {{
+                arr.push(e)
+            }}
+            return arr;
+        }}
+    "#;
+    match c.client_mode {
+        ClientMode::Deno => {
+            let imports = r#"
+                import { createChiselClient } from "./client.ts";
+                import { type GetParams } from "./client_lib.ts";
+                import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
+            "#;
+            format!(
+                r#"
+                {imports}
+                {common_funs}
+
+                const cli = createChiselClient('http://{}');
+                {src}
+            "#,
+                c.chisel.api_address
+            )
+        }
+        ClientMode::Node => {
+            let imports = r#"
+                import { createChiselClient } from "./client";
+                import { type GetParams } from "./client_lib";
+
+                function assertEquals<T>(actual: T, expected: T, msg?: string) {
+                    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+                        throw new Error(msg ?? `actual (${actual}) != expected (${expected})`);
+                    }
+                }
+            "#;
+            format!(
+                r#"
+                {imports}
+                {common_funs}
+                async function main() {{
+                    const cli = createChiselClient('http://{}');
+                    {src}
+                }}
+                main();
+            "#,
+                c.chisel.api_address
+            )
+        }
+    }
+}
+
+#[chisel_macros::test(modules = Deno, client_modes = Both)]
+pub async fn get_simple(c: TestContext) {
+    c.chisel.write("models/person.ts", PERSON_MODEL);
+    c.chisel.write("routes/people.ts", PEOPLE_CRUD);
+
+    c.chisel.apply_ok().await;
+    store_people(&c.chisel).await;
+
+    c.chisel.generate_ok("generated").await;
+    let src = with_client(
+        &c,
+        r#"
+        const ppl = (await cli.people.get({pageSize: 3})).results;
+        const names = ppl.map(p => p.firstName);
+        names.sort();
+        assertEquals(names, ["Glauber", "Jan", "Pekka"]);
+        "#,
+    );
+    c.ts_runner.run_ok("generated/test.ts", &src).await;
+}
+
+#[chisel_macros::test(modules = Deno, client_modes = Both)]
+pub async fn get_all(c: TestContext) {
+    c.chisel.write("models/person.ts", PERSON_MODEL);
+    c.chisel.write("routes/people.ts", PEOPLE_CRUD);
+
+    c.chisel.apply_ok().await;
+    store_people(&c.chisel).await;
+
+    c.chisel.generate_ok("generated").await;
+    let src = with_client(
+        &c,
+        r#"
+        const ppl = await cli.people.getAll({limit: 1});
+        assertEquals(ppl.length, 1);
+        "#,
+    );
+    c.ts_runner.run_ok("generated/test.ts", &src).await;
+}
+
+#[chisel_macros::test(modules = Deno, client_modes = Both)]
+pub async fn get_by_id(c: TestContext) {
+    c.chisel.write("models/person.ts", PERSON_MODEL);
+    c.chisel.write("routes/people.ts", PEOPLE_CRUD);
+
+    c.chisel.apply_ok().await;
+    let ids = store_people(&c.chisel).await;
+    let jan_id = ids.get("jan").unwrap();
+
+    c.chisel.generate_ok("generated").await;
+    let src = with_client(
+        &c,
+        &format!(
+            "
+            const person = await cli.people.id('{jan_id}').get();
+            assertEquals(person.firstName, 'Jan')
+            ",
+        ),
+    );
+    c.ts_runner.run_ok("generated/test.ts", &src).await;
+}
+
+#[chisel_macros::test(modules = Deno, client_modes = Both)]
+pub async fn get_iterable_simple(c: TestContext) {
+    c.chisel.write("models/person.ts", PERSON_MODEL);
+    c.chisel.write("routes/people.ts", PEOPLE_CRUD);
+
+    c.chisel.apply_ok().await;
+    store_people(&c.chisel).await;
+
+    c.chisel.generate_ok("generated").await;
+    let src = with_client(
+        &c,
+        r#"
+        const ppl = cli.people.getIter();
+        const names = (await iterToArray(ppl)).map(p => p.firstName);
+        names.sort();
+        assertEquals(names, ["Glauber", "Jan", "Pekka"]);
+        "#,
+    );
+    c.ts_runner.run_ok("generated/test.ts", &src).await;
+}
+
+#[chisel_macros::test(modules = Deno, client_modes = Both)]
+pub async fn get_iterable_repeated(c: TestContext) {
+    c.chisel.write("models/person.ts", PERSON_MODEL);
+    c.chisel.write("routes/people.ts", PEOPLE_CRUD);
+
+    c.chisel.apply_ok().await;
+    store_people(&c.chisel).await;
+
+    c.chisel.generate_ok("generated").await;
+    let src = with_client(
+        &c,
+        r#"
+        async function runTest() {
+            const ppl = cli.people.getIter({pageSize: 1});
+            const names = (await iterToArray(ppl)).map(p => p.firstName);
+            names.sort();
+            assertEquals(names, ["Glauber", "Jan", "Pekka"]);
+        }
+        await runTest();
+        await runTest();
+        await runTest();
+        "#,
+    );
+    c.ts_runner.run_ok("generated/test.ts", &src).await;
+}

--- a/cli/tests/linters.rs
+++ b/cli/tests/linters.rs
@@ -3,65 +3,12 @@
 mod common;
 
 mod linters {
-    use crate::common::{repo_dir, run, Command, CHISEL_BIN_DIR};
-    use regex::Regex;
-    use std::fs::{create_dir_all, File};
-    use std::io::Read;
-    use toml::Value;
-
-    fn cargo<'a, T: IntoIterator<Item = &'a str>>(args: T) -> Command {
-        run("cargo", args)
-    }
-
-    fn nightly<'a, T: IntoIterator<Item = &'a str>>(args: T) -> Command {
-        let mut ret = cargo(itertools::chain(["+nightly-2022-08-29"], args));
-        ret.env("CARGO_TARGET_DIR", "./target/nightly");
-        ret
-    }
-
-    fn cargo_install(version: &str, pkg: &str, bin: &str) {
-        ensure_correct_version(pkg, version);
-        create_dir_all(&*CHISEL_BIN_DIR).unwrap();
-        cargo([
-            "install",
-            "--version",
-            version,
-            pkg,
-            "--bin",
-            bin,
-            "--locked",
-            "--root",
-            &CHISEL_BIN_DIR.display().to_string(),
-        ]);
-    }
-
-    fn ensure_correct_version(pkg: &str, version: &str) {
-        let re = Regex::new(&format!(r"{pkg} v{version}:")).unwrap();
-        let mut cmd = cargo(["install", "--list"]);
-        let out = cmd.inner.output().unwrap();
-
-        let stdout = std::str::from_utf8(&out.stdout).unwrap();
-
-        // only accept global package if it's the correct version.
-        assert!(re.is_match(stdout) || !stdout.contains(pkg),
-            "An incorrect version of {pkg} is present in the global environment. Please uninstall it.");
-    }
+    use crate::common::{cargo, cargo_install, get_deno_version, nightly, run};
 
     #[test]
     fn eslint() {
         run("npm", ["install"]);
         run("npx", ["eslint", ".", "--ext", ".ts"]);
-    }
-
-    fn get_deno_version() -> String {
-        let mut f = File::open(repo_dir().join("third_party/deno/cli/Cargo.toml")).unwrap();
-        let mut s = String::new();
-        f.read_to_string(&mut s).unwrap();
-        let doc = s.parse::<Value>().unwrap();
-        if let Value::String(v) = &doc["package"]["version"] {
-            return v.clone();
-        }
-        panic!("Could not find the deno version");
     }
 
     #[test]

--- a/deno.json
+++ b/deno.json
@@ -3,6 +3,7 @@
         "files": {
             "include": [
                 "api",
+                "cli/src/cmd/generate_src",
                 "server",
                 "packages",
                 "deno.json",
@@ -31,12 +32,14 @@
         "files": {
             "include": [
                 "api",
+                "cli/src/cmd/generate_src",
                 "server",
                 "packages",
                 "tsc_compile",
                 "tsc_compile_build"
             ],
             "exclude": [
+                "cli/src/cmd/generate_src/client.ts",
                 "tsc_compile/tests/",
                 "third_party",
                 "packages/create-chiselstrike-app/node_modules/",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -67,7 +67,7 @@ time = "0.3.16"
 tokio = { version = "1.11.0", features = ["net", "rt", "time"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.5.2"
-url = "2.2"
+url = "2.3"
 utils = { path = "../utils" }
 uuid = { version = "0.8.2", features = ["v4"] }
 
@@ -75,6 +75,7 @@ uuid = { version = "0.8.2", features = ["v4"] }
 proptest = "1.0.0"
 tempdir = "0.3.7"
 tempfile = "3.2.0"
+urlencoding = "2.1.2"
 
 [build-dependencies]
 # FIXME: We have additional dependencies here to work around

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0.56"
 async-channel = "1.6.1"
 futures-core = "0.3"
 nix = "0.22.2"
-reqwest = { version = "=0.11.11", features = ["rustls-tls"], default-features = false } # strict = because of https://github.com/seanmonstar/reqwest/issues/1403
+reqwest = { version = "0.11.13", features = ["rustls-tls"], default-features = false }
 tokio = { version = "1.11", features = ["rt"] }
 
 [lib]


### PR DESCRIPTION
This PR brings support for client generation.
The main changes include

- New build container to include `ts-node`. 
- `chisel generate` generates TS client that can be used against our CRUD endpoints
- `/__chiselstrike/routes` internal reflection endpoint returning information about routing
- Added support for testing of generated clients to our rust integration tests.