### PR TITLE
feat(api): expose EventHandler, ResponseLike and ChiselEntityClass

### DIFF
--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
 export { crud } from "./crud.ts";
+export type { ChiselEntityClass } from "./crud.ts";
 export {
     AuthUser,
     ChiselCursor,
@@ -11,11 +12,16 @@ export {
     unique,
 } from "./datastore.ts";
 export type { Id } from "./datastore.ts";
-export type { ChiselEvent } from "./kafka.ts";
+export type { ChiselEvent, EventHandler } from "./kafka.ts";
 export { publishEvent } from "./kafka.ts";
 export { ChiselRequest, Params, Query } from "./request.ts";
 export { RouteMap } from "./routing.ts";
-export type { Handler, MiddlewareHandler, MiddlewareNext } from "./routing.ts";
+export type {
+    Handler,
+    MiddlewareHandler,
+    MiddlewareNext,
+    ResponseLike,
+} from "./routing.ts";
 export { getSecret, responseFromJson } from "./utils.ts";
 export type { JSONValue } from "./utils.ts";
 export type { Action, ReqContext } from "./policies.ts";

--- a/api/src/crud.ts
+++ b/api/src/crud.ts
@@ -4,7 +4,7 @@ import { ChiselEntity, mergeIntoEntity, requestContext } from "./datastore.ts";
 import { ChiselRequest } from "./request.ts";
 import { RouteMap } from "./routing.ts";
 
-type ChiselEntityClass<T extends ChiselEntity> = {
+export type ChiselEntityClass<T extends ChiselEntity> = {
     new (): T;
     findOne: (_: { id: string }) => Promise<T | undefined>;
     findMany: (_: Partial<T>) => Promise<T[]>;


### PR DESCRIPTION
## Description

To import these files you needed to import from the file. Example:

```ts
import type { EventHandler } from '@chiselstrike/api/lib/kafka.ts';
```

Now allow to import it from `@/chiselstrike/api`