### PR TITLE
Improve test coverage of clients and fix found bugs

### DIFF
--- a/cli/src/cmd/generate_src/client_lib.ts
+++ b/cli/src/cmd/generate_src/client_lib.ts
@@ -350,7 +350,7 @@ export function makeGetAll<Entity>(
     origUrl: URL,
     serverUrl: string,
     entityType: reflect.Entity,
-): (params?: GetParams<Entity>) => Promise<Entity[]> {
+): (params?: GetAllParams<Entity>) => Promise<Entity[]> {
     const makeIter = makeGetManyIter<Entity>(origUrl, serverUrl, entityType);
     return async function (params?: GetAllParams<Entity>): Promise<Entity[]> {
         let iterParams = {};

--- a/cli/tests/integration_tests/framework.rs
+++ b/cli/tests/integration_tests/framework.rs
@@ -939,7 +939,7 @@ impl TypeScriptRunner {
         let src_path = self.tmp_dir.path().join(src_path);
         let src_path = src_path.display().to_string();
 
-        let args = vec!["run", "--allow-net", &src_path];
+        let args = vec!["run", "--allow-net", "--check=all", &src_path];
         run_command(
             &repo_dir().join(".chisel_dev/bin/deno"),
             &args,
@@ -960,7 +960,6 @@ impl TypeScriptRunner {
             &PathBuf::from_str("ts-node").unwrap(),
             &[
                 "--esm",
-                "-T",
                 "--skipProject",
                 "-O",
                 r#"{"lib":["esnext", "webworker"]}"#,


### PR DESCRIPTION
In this PR, I have done the following:

- Enabled type checking for client tests and fixed the corresponding bugs that were found.
- Implemented and activated entityToJson() to perform the inverse operation of jsonToEntity().
- Introduced and used OmitRecursively for the post() function to allow the submission of entities and nested entities without an ID.
- Added tests covering the .post() function with all types that we provide (with the exception of ArrayBuffer, which will require a separate PR).