### PR TITLE
Use deno from docker instead of installing it.

### DIFF
--- a/.github/build.Dockerfile
+++ b/.github/build.Dockerfile
@@ -4,7 +4,12 @@ FROM ubuntu:22.04
 # in .github/workflows/rust.yml
 RUN apt-get update &&\
     apt-get upgrade -y &&\
-    apt-get install -y lld git curl jq build-essential pkg-config libssl-dev postgresql-client uuid-runtime zstd sudo &&\
+    apt-get install -y lld git curl unzip jq build-essential pkg-config libssl-dev \
+        postgresql-client uuid-runtime zstd sudo &&\
     apt-get clean -y
+
+# Install deno
+RUN curl -fsSL https://deno.land/x/install/install.sh | sh &&\
+    mv /root/.deno/bin/deno /usr/bin/
 
 RUN useradd -u 1000 ubuntu && echo "ubuntu ALL=NOPASSWD: ALL" > /etc/sudoers.d/sudo

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: self-hosted
     container:
-      image: ghcr.io/chiselstrike/rust-build-image:v1.0
+      image: ghcr.io/chiselstrike/rust-build-image:v1.2
       options: --user 1000
     steps:
     - name: checkout repo
@@ -90,7 +90,7 @@ jobs:
   postgres-test:
     runs-on: self-hosted
     container:
-      image: ghcr.io/chiselstrike/rust-build-image:v1.0
+      image: ghcr.io/chiselstrike/rust-build-image:v1.2
       options: --user 1000
     services:
       postgres:

--- a/cli/tests/integration_tests/framework.rs
+++ b/cli/tests/integration_tests/framework.rs
@@ -21,7 +21,6 @@ use serde::Serialize;
 use tempdir::TempDir;
 use tokio::io::{duplex, AsyncRead, AsyncReadExt, AsyncWriteExt, DuplexStream};
 
-use crate::common::repo_dir;
 use crate::database::Database;
 use crate::suite::ClientMode;
 
@@ -941,7 +940,7 @@ impl TypeScriptRunner {
 
         let args = vec!["run", "--allow-net", "--check=all", &src_path];
         run_command(
-            &repo_dir().join(".chisel_dev/bin/deno"),
+            &PathBuf::from_str("deno").unwrap(),
             &args,
             self.tmp_dir.path(),
             self.capture,

--- a/cli/tests/integration_tests/rust.rs
+++ b/cli/tests/integration_tests/rust.rs
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: © 2022 ChiselStrike <info@chiselstrike.com>
 
-use crate::common::{bin_dir, cargo_install, get_deno_version, get_free_port, repo_dir};
+use crate::common::{bin_dir, get_free_port, repo_dir};
 use crate::database::{Database, DatabaseConfig, PostgresDb, SqliteDb};
 use crate::framework::{
     execute_async, wait_for_chiseld_startup, Chisel, GuardedChild, TestContext, TypeScriptRunner,
@@ -240,14 +240,8 @@ fn format_test_instance(instance: &TestInstance) -> String {
     )
 }
 
-fn ensure_dependencies() {
-    let version = get_deno_version();
-    cargo_install(&version, "deno", "deno");
-}
-
 #[tokio::main]
 pub(crate) async fn run_tests(opt: Arc<Opt>) -> bool {
-    ensure_dependencies();
     let suite = TestSuite::from_inventory();
     let ports_counter = Arc::new(AtomicU16::new(30000));
     let parallel = opt.parallel.unwrap_or_else(num_cpus::get);

--- a/cli/tests/linters.rs
+++ b/cli/tests/linters.rs
@@ -3,7 +3,7 @@
 mod common;
 
 mod linters {
-    use crate::common::{cargo, cargo_install, get_deno_version, nightly, run};
+    use crate::common::{cargo, cargo_install, nightly, run};
 
     #[test]
     fn eslint() {
@@ -13,10 +13,6 @@ mod linters {
 
     #[test]
     fn deno_checks() {
-        // Find our deno version and install that. We don't use --path
-        // because that always reinstall the binary.
-        let version = get_deno_version();
-        cargo_install(&version, "deno", "deno");
         run("deno", ["lint", "--config", "deno.json"]);
         run("deno", ["fmt", "--config", "deno.json", "--check"]);
     }


### PR DESCRIPTION
Gets rid of cargo_install for deno in our tests in favor of deno preinstalled in a docker. 
This makes test execution faster. Rough estimate: general build plus tests 18 -> 14 minutes, postgres tests 9 -> 7 minutes