### PR TITLE
policies: fix lookup unexisting value

### DIFF
--- a/chiselc/src/tools/analysis/region.rs
+++ b/chiselc/src/tools/analysis/region.rs
@@ -330,7 +330,6 @@ mod test {
             let from_node = insert_node(&mut graph, from);
             let to_node = insert_node(&mut graph, to);
 
-            dbg!((from_node, to_node, edge));
             graph.add_edge(from_node, to_node, edge);
         }
 

--- a/server/src/policy/interpreter.rs
+++ b/server/src/policy/interpreter.rs
@@ -22,7 +22,9 @@ impl JsonResolver<'_> {
             Var::Member(obj, prop) => {
                 let obj = env.get(*obj);
                 let value = self.get_value(env, obj)?;
-                value.get(prop)
+                // return null so we don't mistake that for an impossiblity to evaluate:
+                // we could go down the property chain, but then found nothing.
+                value.get(prop).or(Some(&JsonValue::Null))
             }
             _ => None,
         }


### PR DESCRIPTION
This pr fixes a bug in the policies variable resolver that would return None on a lookup for an unexisting value in a header.

This is not a _very robust_ fix though. A more robust fix would differentiate between static properties and computed properties. We should aim a better compat with js.
