### PR TITLE
Cli generation: Add dedicated models without ID field.

### DIFF
--- a/cli/src/cmd/generate_src/client.ts
+++ b/cli/src/cmd/generate_src/client.ts
@@ -2,6 +2,11 @@
  * Container for extra configuration information for client API requests.
  */
 export type ClientConfig = Ωlib.ClientConfig;
+/**
+ * This generic turns given `Entity` type into a type without id fields
+ * (it removes id fields for nested entities as well)
+ */
+export type WithoutId<Entity> = ΩWithoutId<Entity>;
 
 /**
  * Creates an object that exposes an API to make requests of a ChiselStrike

--- a/cli/src/cmd/generate_src/client_lib.ts
+++ b/cli/src/cmd/generate_src/client_lib.ts
@@ -644,27 +644,16 @@ export function makeGetAll<Entity>(
     };
 }
 
-// This magic is necessary to allow passing of nested objects without ID. However, once we allow plain objects
-// we will have to generate the ID-less entities explictly because otherwise we might accidentaly
-// remove 'id' fields from plain objects.
-type OmitDistributive<T, K extends PropertyKey> = T extends
-    Record<string, unknown> ? OmitRecursively<T, K> : T;
-type OmitRecursively<T extends Record<string, unknown>, K extends PropertyKey> =
-    Omit<
-        { [P in keyof T]: OmitDistributive<T[P], K> },
-        K
-    >;
-
 export function makePostOne<Entity extends Record<string, unknown>>(
     url: URL,
     entityType: reflect.Entity,
     cliConfig: InternalClientConfig,
 ): (
-    entity: OmitRecursively<Entity, "id">,
+    entity: WithoutId<Entity>,
     headers?: Headers | Record<string, string>,
 ) => Promise<Entity> {
     return async (
-        entity: OmitRecursively<Entity, "id">,
+        entity: WithoutId<Entity>,
         headers?: Headers | Record<string, string>,
     ) => {
         const entityJson = entityToJson(entityType, entity);
@@ -684,11 +673,11 @@ export function makePutOne<Entity extends Record<string, unknown>>(
     entityType: reflect.Entity,
     cliConfig: InternalClientConfig,
 ): (
-    entity: OmitRecursively<Entity, "id">,
+    entity: WithoutId<Entity>,
     headers?: Headers | Record<string, string>,
 ) => Promise<Entity> {
     return async (
-        entity: OmitRecursively<Entity, "id">,
+        entity: WithoutId<Entity>,
         headers?: Headers | Record<string, string>,
     ) => {
         const entityJson = entityToJson(entityType, entity);

--- a/cli/src/cmd/generate_src/models_without_id.ts
+++ b/cli/src/cmd/generate_src/models_without_id.ts
@@ -1,0 +1,3 @@
+type ΩIfEquals<T, U, Y = unknown, N = never> =
+    (<G>() => G extends T ? 1 : 2) extends (<G>() => G extends U ? 1 : 2) ? Y
+        : N;


### PR DESCRIPTION
+ It fixes a bug in client's PUT where the function would throw an error if an ID wasn't provided.

Example generated `models_without_id.ts`:
```
import * as Ωmodels from "./models";

type ΩIfEquals<T, U, Y = unknown, N = never> = (<G>() => G extends T ? 1 : 2) extends (<G>() => G extends U ? 1 : 2) ? Y
    : N;

export type Animal = {
    kind: string;
};
export type Person = {
    name: string;
};

export type ΩWithoutId<ΩEntityType> = ΩIfEquals<
    ΩEntityType,
    Ωmodels.Person,
    Person,
    ΩIfEquals<ΩEntityType, Ωmodels.Animal, Animal, never>
>;
```