### PR TITLE
fix convert cond to bool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
  "clap 4.0.29",
  "indexmap",
  "petgraph 0.6.2",
+ "proptest",
  "quine-mc_cluskey",
  "serde",
  "serde_json",

--- a/chiselc/Cargo.toml
+++ b/chiselc/Cargo.toml
@@ -17,3 +17,6 @@ swc_atoms = "0.3.0"
 swc_common = "0.25.0"
 swc_ecmascript = { version = "0.185.0", features = ["visit", "parser", "transforms", "codegen", "typescript"] }
 vec_map = "0.8.2"
+
+[dev-dependencies]
+proptest = "1.0.0"

--- a/chiselc/src/policies.rs
+++ b/chiselc/src/policies.rs
@@ -253,7 +253,7 @@ pub enum LogicOp {
     Or,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Cond {
     And(Box<Self>, Box<Self>),
     Or(Box<Self>, Box<Self>),
@@ -520,6 +520,16 @@ impl Predicates {
     pub fn map(&self, f: impl FnMut(&Predicate) -> Predicate) -> Self {
         Self(self.0.iter().map(f).collect())
     }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 impl Deref for Actions {
@@ -717,4 +727,50 @@ fn emit_arrow_js_code(arrow: &ArrowExpr, sm: Lrc<SourceMap>) -> Result<Box<[u8]>
     emit(module, Target::JavaScript, sm, &mut js_code)?;
 
     Ok(js_code.into_boxed_slice())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use proptest::{collection, prelude::*, sample::Index};
+
+    fn arb_predicates() -> impl Strategy<Value = Predicates> {
+        collection::vec(any::<usize>().prop_map(Predicate::Var), 1..50).prop_map(Predicates)
+    }
+
+    fn arb_cond(preds: Predicates) -> impl Strategy<Value = (Cond, Predicates)> {
+        let preds_len = preds.len();
+        let leaf = prop_oneof![
+            Just(Cond::True),
+            Just(Cond::False),
+            // don't really care about what predicate
+            any::<Index>().prop_map(move |index| Cond::Predicate(index.index(preds_len))),
+        ];
+        let cond_strat = leaf.prop_recursive(
+            8,   // 8 levels deep
+            256, // Shoot for maximum size of 256 nodes
+            10,  // We put up to 10 items per collection
+            |inner| {
+                prop_oneof![
+                    // Take the inner strategy and make the two recursive cases.
+                    (inner.clone(), inner.clone()).prop_map(|(l, r)| Cond::Or(l.into(), r.into())),
+                    (inner.clone(), inner.clone()).prop_map(|(l, r)| Cond::And(l.into(), r.into())),
+                    inner.prop_map(|c| Cond::Not(c.into()))
+                ]
+            },
+        );
+
+        (cond_strat, Just(preds))
+    }
+
+    proptest! {
+        #[test]
+        fn roundtrip_convert((cond, preds) in arb_predicates().prop_flat_map(arb_cond)) {
+            let mut mapping = Vec::new();
+            let bool = cond.to_bool(&preds, &mut mapping);
+            let ret = Cond::from_bool(&bool, &mapping);
+
+            assert_eq!(ret, cond);
+        }
+    }
 }

--- a/chiselc/src/tools/functions.rs
+++ b/chiselc/src/tools/functions.rs
@@ -23,7 +23,6 @@ impl<'a> ArrowFunction<'a> {
         match &arrow.body {
             BlockStmtOrExpr::BlockStmt(block) => {
                 let (cfg, stmt_map) = ControlFlow::build(&block.stmts)?;
-                println!("{}", cfg.dot());
                 let regions = Region::from_cfg(&cfg, &|idx| match stmt_map[idx].stmt {
                     Stmt::If(_) => StmtKind::Conditional,
                     Stmt::Block(_) => StmtKind::Ignore,

--- a/chiselc/src/tools/functions.rs
+++ b/chiselc/src/tools/functions.rs
@@ -23,6 +23,7 @@ impl<'a> ArrowFunction<'a> {
         match &arrow.body {
             BlockStmtOrExpr::BlockStmt(block) => {
                 let (cfg, stmt_map) = ControlFlow::build(&block.stmts)?;
+                println!("{}", cfg.dot());
                 let regions = Region::from_cfg(&cfg, &|idx| match stmt_map[idx].stmt {
                     Stmt::If(_) => StmtKind::Conditional,
                     Stmt::Block(_) => StmtKind::Ignore,

--- a/server/src/policy/engine.rs
+++ b/server/src/policy/engine.rs
@@ -270,7 +270,7 @@ fn predicate_to_expr(pred: &Predicate, entity_param_name: &str, env: &Environmen
                 right,
             })
         }
-        Predicate::Not(_) => todo!(),
+        Predicate::Not(pred) => Expr::Not(predicate_to_expr(pred, entity_param_name, env)?.into()),
         Predicate::Lit(val) => Expr::Value {
             value: Value::from(val),
         },


### PR DESCRIPTION
This pr fixes a bug when converting from a `Cond` to a `Bool`. I was ignoring that And and Or bool can have more than 2 predicates.

I have added property testing to ensure this doesn't regress
