### PR TITLE
Drop udeps and sorted deps cargo linters to speed up test suite.

### DIFF
--- a/cli/tests/linters.rs
+++ b/cli/tests/linters.rs
@@ -3,7 +3,7 @@
 mod common;
 
 mod linters {
-    use crate::common::{cargo, cargo_install, nightly, run};
+    use crate::common::{cargo, run};
 
     #[test]
     fn eslint() {
@@ -15,18 +15,6 @@ mod linters {
     fn deno_checks() {
         run("deno", ["lint", "--config", "deno.json"]);
         run("deno", ["fmt", "--config", "deno.json", "--check"]);
-    }
-
-    #[test]
-    fn sorted_dependencies() {
-        cargo_install("1.0.5", "cargo-sort", "cargo-sort");
-        cargo(["sort", "-w", "-c"]);
-    }
-
-    #[test]
-    fn unused_dependencies() {
-        cargo_install("0.1.29", "cargo-udeps", "cargo-udeps");
-        nightly(["udeps"]);
     }
 
     #[test]


### PR DESCRIPTION
As previously discussed, we can probably drop these linters as they are slow and not as important.
It's quite sufficient to run them just once in a while.