### PR TITLE
Upgrade CI actions.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
         submodules: recursive
 
     - name: Install rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
           components: rustfmt, clippy
 
@@ -41,7 +41,7 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: set up node cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
             path: ~/.npm
             key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -100,12 +100,12 @@ jobs:
         submodules: recursive
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
           components: rustfmt, clippy
 
     - name: Configure Rust cache
-      uses: Swatinem/rust-cache@v1
+      uses: Swatinem/rust-cache@v2
 
     - name: Install node
       uses: actions/setup-node@v3
@@ -113,7 +113,7 @@ jobs:
         node-version: 18
 
     - name: Configure Node cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
             path: ~/.npm
             key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -145,12 +145,12 @@ jobs:
         submodules: recursive
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
           components: rustfmt, clippy
 
     - name: Configure Rust cache
-      uses: Swatinem/rust-cache@v1
+      uses: Swatinem/rust-cache@v2
 
     - name: Install node
       uses: actions/setup-node@v3
@@ -158,7 +158,7 @@ jobs:
         node-version: 16
 
     - name: Configure Node cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
             path: ~/.npm
             key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
```
Swatinem/rust-cache@v1 -> Swatinem/rust-cache@v2
actions/cache@v2 -> actions/cache@v3
actions-rs/toolchain@v1 -> dtolnay/rust-toolchain
```

Apart from general upgrade goodness, this should rid us of the deprecation warnings 
```
kafka-test
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, Swatinem/rust-cache@v1, actions/cache@v2
```

Unfortunately, `actions-rs/toolchain@v1` had top be ditched for it seems to be unmaintained (https://github.com/actions-rs/toolchain/issues/221) 