### PR TITLE
feat(models): make Entity.create() type-safe

### DIFF
--- a/api/src/datastore.ts
+++ b/api/src/datastore.ts
@@ -1079,7 +1079,7 @@ export class ChiselEntity {
      */
     static async create<T extends ChiselEntity>(
         this: { new (): T },
-        ...properties: Record<string, unknown>[]
+        ...properties: Partial<T>[]
     ): Promise<T> {
         const entity = buildEntity(
             this,


### PR DESCRIPTION
## Description

`Entity.create()` wasn't providing type safety for entity creation as `Entity.build()` was doing. So this PR basically changes the properties that can be passed when using `Entity.create()` to be related to the entity